### PR TITLE
feat: add Permission struct with metadata and Permissionable protocol

### DIFF
--- a/lib/ash_grant/permission_input.ex
+++ b/lib/ash_grant/permission_input.ex
@@ -1,0 +1,116 @@
+defmodule AshGrant.PermissionInput do
+  @moduledoc """
+  Permission input struct with optional metadata for debugging and explain functionality.
+
+  This struct allows users to provide permissions with additional context
+  like descriptions and source information, which can be used for:
+
+  - Better debugging with `AshGrant.explain/4`
+  - Understanding permission origins (role-based, direct grants, etc.)
+  - Human-readable permission explanations
+
+  ## Fields
+
+  - `:string` - Required. The permission string (e.g., "post:*:update:own")
+  - `:description` - Optional. Human-readable description (e.g., "Edit own posts")
+  - `:source` - Optional. Where the permission came from (e.g., "editor_role", "direct_grant")
+  - `:metadata` - Optional. Additional arbitrary metadata as a map
+
+  ## Examples
+
+      # Simple permission with just the string
+      %AshGrant.PermissionInput{string: "post:*:read:all"}
+
+      # Permission with metadata
+      %AshGrant.PermissionInput{
+        string: "post:*:update:own",
+        description: "Edit own posts",
+        source: "editor_role"
+      }
+
+      # Permission with extra metadata
+      %AshGrant.PermissionInput{
+        string: "post:*:delete:all",
+        description: "Delete any post",
+        source: "admin_role",
+        metadata: %{granted_at: ~U[2024-01-15 10:00:00Z], granted_by: "system"}
+      }
+
+  ## Usage with PermissionResolver
+
+  Return `PermissionInput` structs from your resolver for enhanced debugging:
+
+      defmodule MyApp.PermissionResolver do
+        @behaviour AshGrant.PermissionResolver
+
+        @impl true
+        def resolve(actor, _context) do
+          actor
+          |> get_role_permissions()
+          |> Enum.map(fn role_perm ->
+            %AshGrant.PermissionInput{
+              string: role_perm.permission,
+              description: role_perm.label,
+              source: "role:\#{role_perm.role_name}"
+            }
+          end)
+        end
+      end
+
+  ## Protocol Integration
+
+  This struct implements `AshGrant.Permissionable`, so it can be used
+  directly in permission lists without manual conversion.
+  """
+
+  @type t :: %__MODULE__{
+          string: String.t(),
+          description: String.t() | nil,
+          source: String.t() | nil,
+          metadata: map() | nil
+        }
+
+  @enforce_keys [:string]
+  defstruct [:string, :description, :source, :metadata]
+
+  @doc """
+  Creates a new PermissionInput from a permission string.
+
+  ## Examples
+
+      iex> AshGrant.PermissionInput.new("post:*:read:all")
+      %AshGrant.PermissionInput{string: "post:*:read:all"}
+
+      iex> AshGrant.PermissionInput.new("post:*:update:own", description: "Edit own posts")
+      %AshGrant.PermissionInput{string: "post:*:update:own", description: "Edit own posts"}
+
+  """
+  @spec new(String.t(), keyword()) :: t()
+  def new(string, opts \\ []) when is_binary(string) do
+    %__MODULE__{
+      string: string,
+      description: Keyword.get(opts, :description),
+      source: Keyword.get(opts, :source),
+      metadata: Keyword.get(opts, :metadata)
+    }
+  end
+
+  @doc """
+  Returns the permission string from a PermissionInput.
+
+  ## Examples
+
+      iex> input = %AshGrant.PermissionInput{string: "post:*:read:all", description: "Read posts"}
+      iex> AshGrant.PermissionInput.to_string(input)
+      "post:*:read:all"
+
+  """
+  @spec to_string(t()) :: String.t()
+  def to_string(%__MODULE__{string: string}), do: string
+end
+
+defimpl String.Chars, for: AshGrant.PermissionInput do
+  def to_string(input) do
+    AshGrant.PermissionInput.to_string(input)
+  end
+end

--- a/lib/ash_grant/permissionable.ex
+++ b/lib/ash_grant/permissionable.ex
@@ -1,0 +1,120 @@
+defprotocol AshGrant.Permissionable do
+  @moduledoc """
+  Protocol for converting values to `AshGrant.PermissionInput` structs.
+
+  This protocol enables AshGrant to accept permissions from various sources
+  without requiring manual conversion in your `PermissionResolver`.
+
+  ## Why Use This Protocol?
+
+  - **Zero boilerplate**: Return your existing structs directly from the resolver
+  - **Separation of concerns**: Conversion logic lives near your struct definition
+  - **Extensible**: Implement for any struct, including third-party ones
+  - **Backward compatible**: Plain strings continue to work without changes
+
+  ## Default Implementations
+
+  AshGrant provides implementations for:
+
+  - `BitString` (plain strings) - Converts to `PermissionInput` with just the string
+  - `AshGrant.PermissionInput` - Pass-through, returns as-is
+  - `AshGrant.Permission` - Converts parsed permission back to input format
+
+  ## Implementing for Custom Structs
+
+  If you have your own permission struct, implement the protocol:
+
+      defmodule MyApp.RolePermission do
+        defstruct [:permission_string, :label, :role_name]
+      end
+
+      defimpl AshGrant.Permissionable, for: MyApp.RolePermission do
+        def to_permission_input(%MyApp.RolePermission{} = rp) do
+          %AshGrant.PermissionInput{
+            string: rp.permission_string,
+            description: rp.label,
+            source: "role:\#{rp.role_name}"
+          }
+        end
+      end
+
+  Then your resolver can simply return these structs:
+
+      defmodule MyApp.PermissionResolver do
+        @behaviour AshGrant.PermissionResolver
+
+        @impl true
+        def resolve(actor, _context) do
+          # Just return your structs - AshGrant handles conversion
+          MyApp.Accounts.get_role_permissions(actor)
+        end
+      end
+
+  ## Usage Examples
+
+  ### Plain strings (backward compatible)
+
+      def resolve(actor, _context) do
+        ["post:*:read:all", "post:*:update:own"]
+      end
+
+  ### Mixed strings and PermissionInput
+
+      def resolve(actor, _context) do
+        [
+          "post:*:read:all",
+          %AshGrant.PermissionInput{
+            string: "post:*:update:own",
+            description: "Edit own posts",
+            source: "editor_role"
+          }
+        ]
+      end
+
+  ### Custom structs via Protocol
+
+      def resolve(actor, _context) do
+        # Returns [%MyApp.RolePermission{}, ...]
+        # Protocol handles conversion automatically
+        MyApp.Accounts.get_role_permissions(actor)
+      end
+
+  """
+
+  @doc """
+  Converts a value to `AshGrant.PermissionInput` struct.
+
+  ## Examples
+
+      iex> AshGrant.Permissionable.to_permission_input("post:*:read:all")
+      %AshGrant.PermissionInput{string: "post:*:read:all"}
+
+      iex> input = %AshGrant.PermissionInput{string: "post:*:read:all", description: "Read posts"}
+      iex> AshGrant.Permissionable.to_permission_input(input)
+      %AshGrant.PermissionInput{string: "post:*:read:all", description: "Read posts"}
+
+  """
+  @spec to_permission_input(t) :: AshGrant.PermissionInput.t()
+  def to_permission_input(value)
+end
+
+# Default implementation for strings (backward compatibility)
+defimpl AshGrant.Permissionable, for: BitString do
+  def to_permission_input(string) do
+    %AshGrant.PermissionInput{string: string}
+  end
+end
+
+# Pass-through for PermissionInput struct
+defimpl AshGrant.Permissionable, for: AshGrant.PermissionInput do
+  def to_permission_input(input), do: input
+end
+
+# Convert parsed Permission back to PermissionInput
+defimpl AshGrant.Permissionable, for: AshGrant.Permission do
+  def to_permission_input(permission) do
+    %AshGrant.PermissionInput{
+      string: AshGrant.Permission.to_string(permission)
+    }
+  end
+end

--- a/test/ash_grant/permissionable_test.exs
+++ b/test/ash_grant/permissionable_test.exs
@@ -1,0 +1,299 @@
+defmodule AshGrant.PermissionableTest do
+  use ExUnit.Case, async: true
+
+  alias AshGrant.{Permission, PermissionInput, Permissionable}
+  alias AshGrant.Evaluator
+
+  describe "Permissionable protocol for BitString" do
+    test "converts string to PermissionInput" do
+      input = Permissionable.to_permission_input("post:*:read:all")
+
+      assert %PermissionInput{} = input
+      assert input.string == "post:*:read:all"
+      assert input.description == nil
+      assert input.source == nil
+      assert input.metadata == nil
+    end
+  end
+
+  describe "Permissionable protocol for PermissionInput" do
+    test "returns PermissionInput as-is" do
+      original = %PermissionInput{
+        string: "post:*:read:all",
+        description: "Read all posts",
+        source: "admin_role"
+      }
+
+      result = Permissionable.to_permission_input(original)
+      assert result == original
+    end
+  end
+
+  describe "Permissionable protocol for Permission" do
+    test "converts Permission to PermissionInput" do
+      permission = Permission.parse!("post:*:read:all")
+      input = Permissionable.to_permission_input(permission)
+
+      assert %PermissionInput{} = input
+      assert input.string == "post:*:read:all"
+    end
+
+    test "preserves deny prefix in conversion" do
+      permission = Permission.parse!("!post:*:delete:all")
+      input = Permissionable.to_permission_input(permission)
+
+      assert input.string == "!post:*:delete:all"
+    end
+  end
+
+  describe "PermissionInput struct" do
+    test "new/1 creates with just string" do
+      input = PermissionInput.new("post:*:read:all")
+
+      assert input.string == "post:*:read:all"
+      assert input.description == nil
+      assert input.source == nil
+    end
+
+    test "new/2 creates with options" do
+      input =
+        PermissionInput.new("post:*:read:all",
+          description: "Read posts",
+          source: "editor_role",
+          metadata: %{granted_at: ~U[2024-01-15 10:00:00Z]}
+        )
+
+      assert input.string == "post:*:read:all"
+      assert input.description == "Read posts"
+      assert input.source == "editor_role"
+      assert input.metadata == %{granted_at: ~U[2024-01-15 10:00:00Z]}
+    end
+
+    test "to_string returns the permission string" do
+      input = %PermissionInput{
+        string: "post:*:read:all",
+        description: "Read posts"
+      }
+
+      assert PermissionInput.to_string(input) == "post:*:read:all"
+      assert to_string(input) == "post:*:read:all"
+    end
+  end
+
+  describe "Permission.from_input/1" do
+    test "creates Permission from PermissionInput preserving metadata" do
+      input = %PermissionInput{
+        string: "blog:*:read:all",
+        description: "Read all blogs",
+        source: "editor_role",
+        metadata: %{key: "value"}
+      }
+
+      permission = Permission.from_input(input)
+
+      assert %Permission{} = permission
+      assert permission.resource == "blog"
+      assert permission.instance_id == "*"
+      assert permission.action == "read"
+      assert permission.scope == "all"
+      assert permission.deny == false
+      assert permission.description == "Read all blogs"
+      assert permission.source == "editor_role"
+      assert permission.metadata == %{key: "value"}
+    end
+
+    test "handles deny prefix" do
+      input = %PermissionInput{
+        string: "!blog:*:delete:all",
+        description: "Cannot delete blogs"
+      }
+
+      permission = Permission.from_input(input)
+
+      assert permission.deny == true
+      assert permission.description == "Cannot delete blogs"
+    end
+
+    test "handles instance permissions" do
+      input = %PermissionInput{
+        string: "blog:post_abc123:read:",
+        source: "direct_grant"
+      }
+
+      permission = Permission.from_input(input)
+
+      assert permission.instance_id == "post_abc123"
+      assert permission.scope == nil
+      assert permission.source == "direct_grant"
+    end
+  end
+
+  describe "Evaluator with PermissionInput" do
+    test "has_access? works with PermissionInput" do
+      permissions = [
+        %PermissionInput{
+          string: "blog:*:read:all",
+          description: "Read blogs"
+        }
+      ]
+
+      assert Evaluator.has_access?(permissions, "blog", "read")
+      refute Evaluator.has_access?(permissions, "blog", "write")
+    end
+
+    test "has_access? works with mixed strings and PermissionInput" do
+      permissions = [
+        "post:*:read:all",
+        %PermissionInput{
+          string: "post:*:update:own",
+          description: "Edit own posts",
+          source: "editor_role"
+        }
+      ]
+
+      assert Evaluator.has_access?(permissions, "post", "read")
+      assert Evaluator.has_access?(permissions, "post", "update")
+      refute Evaluator.has_access?(permissions, "post", "delete")
+    end
+
+    test "get_scope works with PermissionInput" do
+      permissions = [
+        %PermissionInput{string: "blog:*:read:all"},
+        %PermissionInput{string: "blog:*:update:own"}
+      ]
+
+      assert Evaluator.get_scope(permissions, "blog", "read") == "all"
+      assert Evaluator.get_scope(permissions, "blog", "update") == "own"
+    end
+
+    test "deny-wins with PermissionInput" do
+      permissions = [
+        %PermissionInput{string: "blog:*:*:all", description: "All access"},
+        %PermissionInput{string: "!blog:*:delete:all", description: "Cannot delete"}
+      ]
+
+      assert Evaluator.has_access?(permissions, "blog", "read")
+      refute Evaluator.has_access?(permissions, "blog", "delete")
+    end
+
+    test "has_instance_access? works with PermissionInput" do
+      permissions = [
+        %PermissionInput{
+          string: "blog:post_abc123xyz789ab:read:",
+          source: "direct_share"
+        }
+      ]
+
+      assert Evaluator.has_instance_access?(permissions, "post_abc123xyz789ab", "read")
+      refute Evaluator.has_instance_access?(permissions, "post_xyz789abc123xy", "read")
+    end
+  end
+
+  describe "Custom struct with Permissionable protocol" do
+    defmodule RolePermission do
+      defstruct [:permission_string, :label, :role_name]
+    end
+
+    defimpl Permissionable, for: RolePermission do
+      def to_permission_input(%RolePermission{} = rp) do
+        %PermissionInput{
+          string: rp.permission_string,
+          description: rp.label,
+          source: "role:#{rp.role_name}"
+        }
+      end
+    end
+
+    test "custom struct works with Evaluator" do
+      permissions = [
+        %RolePermission{
+          permission_string: "blog:*:read:all",
+          label: "Read all blogs",
+          role_name: "editor"
+        },
+        %RolePermission{
+          permission_string: "blog:*:update:own",
+          label: "Edit own blogs",
+          role_name: "editor"
+        }
+      ]
+
+      assert Evaluator.has_access?(permissions, "blog", "read")
+      assert Evaluator.has_access?(permissions, "blog", "update")
+      refute Evaluator.has_access?(permissions, "blog", "delete")
+    end
+
+    test "custom struct metadata is preserved through normalization" do
+      role_perm = %RolePermission{
+        permission_string: "blog:*:read:all",
+        label: "Read all blogs",
+        role_name: "editor"
+      }
+
+      # Convert through the protocol
+      input = Permissionable.to_permission_input(role_perm)
+      permission = Permission.from_input(input)
+
+      assert permission.description == "Read all blogs"
+      assert permission.source == "role:editor"
+    end
+
+    test "mixed custom structs and strings work together" do
+      permissions = [
+        "post:*:read:all",
+        %RolePermission{
+          permission_string: "post:*:update:own",
+          label: "Edit own posts",
+          role_name: "author"
+        },
+        %PermissionInput{
+          string: "post:*:create:all",
+          description: "Create posts"
+        }
+      ]
+
+      assert Evaluator.has_access?(permissions, "post", "read")
+      assert Evaluator.has_access?(permissions, "post", "update")
+      assert Evaluator.has_access?(permissions, "post", "create")
+    end
+  end
+
+  describe "Permission struct with metadata" do
+    test "Permission struct includes metadata fields" do
+      permission = %Permission{
+        resource: "blog",
+        instance_id: "*",
+        action: "read",
+        scope: "all",
+        deny: false,
+        description: "Read all blogs",
+        source: "admin_role",
+        metadata: %{priority: 1}
+      }
+
+      assert permission.description == "Read all blogs"
+      assert permission.source == "admin_role"
+      assert permission.metadata == %{priority: 1}
+    end
+
+    test "Permission.parse! sets metadata to nil by default" do
+      permission = Permission.parse!("blog:*:read:all")
+
+      assert permission.description == nil
+      assert permission.source == nil
+      assert permission.metadata == nil
+    end
+
+    test "Permission matching ignores metadata" do
+      permission = %Permission{
+        resource: "blog",
+        instance_id: "*",
+        action: "read",
+        scope: "all",
+        description: "Has metadata"
+      }
+
+      assert Permission.matches?(permission, "blog", "read")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `AshGrant.PermissionInput` struct with optional metadata fields (`description`, `source`, `metadata`) for better debugging
- Add `AshGrant.Permissionable` protocol for converting custom structs to permissions
- Default implementations for `BitString`, `PermissionInput`, and `Permission`
- Update `Permission` struct to include metadata fields that are preserved through evaluation
- Update `Evaluator` to use Protocol for normalization
- Maintain full backward compatibility with plain strings

## Benefits

- **Better explain/4 output**: Permission origins and descriptions can be traced
- **Zero boilerplate in resolvers**: Just return custom structs, protocol handles conversion
- **Elixir-standard pattern**: Familiar protocol pattern for extensibility
- **Backward compatible**: Existing code returning `[String.t()]` works without changes

## Usage Examples

### Plain strings (backward compatible)
```elixir
def resolve(actor, _context) do
  ["post:*:read:all", "post:*:update:own"]
end
```

### PermissionInput with metadata
```elixir
def resolve(actor, _context) do
  [
    "post:*:read:all",
    %AshGrant.PermissionInput{
      string: "post:*:update:own",
      description: "Edit own posts",
      source: "editor_role"
    }
  ]
end
```

### Custom structs with Permissionable protocol
```elixir
defimpl AshGrant.Permissionable, for: MyApp.RolePermission do
  def to_permission_input(%MyApp.RolePermission{} = rp) do
    %AshGrant.PermissionInput{
      string: rp.permission_string,
      description: rp.label,
      source: "role:#{rp.role_name}"
    }
  end
end

# Resolver just returns custom structs
def resolve(actor, _context) do
  MyApp.Accounts.get_role_permissions(actor)
end
```

## Test plan

- [x] All existing tests pass (282 tests, 0 failures)
- [x] New tests for PermissionInput struct
- [x] New tests for Permissionable protocol with default implementations
- [x] New tests for custom struct via protocol
- [x] New tests for mixed strings and structs
- [x] New tests for metadata preservation through normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)