### PR TITLE
feat: add instance permission read support for filter_check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Instance Permission Read Support**: Instance permissions now work with read actions (`filter_check/1`)
+  - `AshGrant.Evaluator.get_matching_instance_ids/3` extracts instance IDs from permissions
+  - `FilterCheck` combines RBAC scopes with instance ID filters using OR logic
+  - Enables Google Docs-style sharing where specific resources are shared with specific users
+  - Example: `"doc:doc_abc123:read:"` allows reading the specific document
+
 ## [0.3.1] - 2025-01-05
 
 ### Added

--- a/priv/test_repo/migrations/20250105100000_add_shared_docs_table.exs
+++ b/priv/test_repo/migrations/20250105100000_add_shared_docs_table.exs
@@ -1,0 +1,14 @@
+defmodule AshGrant.TestRepo.Migrations.AddSharedDocsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:shared_docs, primary_key: false) do
+      add :id, :uuid, null: false, primary_key: true
+      add :title, :string, null: false
+      add :owner_id, :string
+
+      add :inserted_at, :utc_datetime_usec, null: false, default: fragment("now()")
+      add :updated_at, :utc_datetime_usec, null: false, default: fragment("now()")
+    end
+  end
+end

--- a/test/ash_grant/db_integration_test.exs
+++ b/test/ash_grant/db_integration_test.exs
@@ -291,9 +291,6 @@ defmodule AshGrant.DbIntegrationTest do
   end
 
   describe "instance permissions" do
-    @tag :skip
-    # Skipped: Instance permissions in FilterCheck need to generate
-    # id == specific_id filters - not yet implemented
     test "instance permission grants access to specific record" do
       author = Ash.UUID.generate()
       actor_id = Ash.UUID.generate()

--- a/test/ash_grant/instance_permission_read_test.exs
+++ b/test/ash_grant/instance_permission_read_test.exs
@@ -1,0 +1,177 @@
+defmodule AshGrant.InstancePermissionReadTest do
+  @moduledoc """
+  TDD tests for instance permission read support.
+
+  Instance permissions should work with read actions (filter_check),
+  allowing users to read specific shared resources.
+
+  Example use case: Google Docs-style sharing where specific documents
+  are shared with specific users.
+  """
+  use AshGrant.DataCase, async: true
+
+  alias AshGrant.Test.SharedDoc
+
+  describe "instance permission read with filter_check" do
+    test "user can read a specific shared document" do
+      # Create documents
+      doc1 = create_shared_doc("Doc 1", "owner-1")
+      doc2 = create_shared_doc("Doc 2", "owner-2")
+      _doc3 = create_shared_doc("Doc 3", "owner-3")
+
+      # Actor has instance permission to read doc1 and doc2
+      actor = %{
+        id: "reader-1",
+        role: :guest,
+        shared_doc_ids: [doc1.id, doc2.id]
+      }
+
+      # Should only see doc1 and doc2
+      docs = SharedDoc |> Ash.read!(actor: actor)
+      ids = Enum.map(docs, & &1.id)
+
+      assert length(docs) == 2
+      assert doc1.id in ids
+      assert doc2.id in ids
+    end
+
+    test "user with no instance permissions is forbidden" do
+      _doc1 = create_shared_doc("Doc 1", "owner-1")
+
+      actor = %{id: "reader-1", role: :guest, shared_doc_ids: []}
+
+      # When FilterCheck returns false (no permissions at all),
+      # Ash raises Forbidden at strict_check stage
+      assert_raise Ash.Error.Forbidden, fn ->
+        SharedDoc |> Ash.read!(actor: actor)
+      end
+    end
+
+    test "instance permission combined with RBAC permission" do
+      doc1 = create_shared_doc("Doc 1", "owner-1")
+      doc2 = create_shared_doc("Doc 2", "owner-1")
+      doc3 = create_shared_doc("Doc 3", "owner-2")
+
+      # Actor owns doc1 and doc2 (RBAC), and has instance permission for doc3
+      actor = %{
+        id: "owner-1",
+        role: :user,
+        shared_doc_ids: [doc3.id]
+      }
+
+      docs = SharedDoc |> Ash.read!(actor: actor)
+      ids = Enum.map(docs, & &1.id)
+
+      assert length(docs) == 3
+      assert doc1.id in ids
+      assert doc2.id in ids
+      assert doc3.id in ids
+    end
+
+    test "deny instance permission blocks read" do
+      doc1 = create_shared_doc("Doc 1", "owner-1")
+
+      # Actor has instance permission but also deny - deny wins
+      actor = %{
+        id: "reader-1",
+        role: :guest,
+        shared_doc_ids: [doc1.id],
+        denied_doc_ids: [doc1.id]
+      }
+
+      # When all instance permissions are denied, FilterCheck returns false
+      # and Ash raises Forbidden
+      assert_raise Ash.Error.Forbidden, fn ->
+        SharedDoc |> Ash.read!(actor: actor)
+      end
+    end
+
+    test "Ash.get! returns document when instance permission exists" do
+      doc1 = create_shared_doc("Doc 1", "owner-1")
+
+      actor = %{
+        id: "reader-1",
+        role: :guest,
+        shared_doc_ids: [doc1.id]
+      }
+
+      result = Ash.get(SharedDoc, doc1.id, actor: actor)
+
+      assert {:ok, doc} = result
+      assert doc.id == doc1.id
+    end
+
+    test "Ash.get returns Forbidden when no instance permission" do
+      doc1 = create_shared_doc("Doc 1", "owner-1")
+
+      actor = %{
+        id: "reader-1",
+        role: :guest,
+        shared_doc_ids: []
+      }
+
+      # When FilterCheck returns false, Ash.get returns Forbidden
+      # (not NotFound, because the filter is rejected at strict_check stage)
+      result = Ash.get(SharedDoc, doc1.id, actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
+
+  describe "Evaluator.get_matching_instance_ids/3" do
+    test "returns instance IDs for matching permissions" do
+      permissions = [
+        "shareddoc:doc_abc:read:",
+        "shareddoc:doc_xyz:read:",
+        "shareddoc:doc_123:write:"
+      ]
+
+      ids = AshGrant.Evaluator.get_matching_instance_ids(permissions, "shareddoc", "read")
+
+      assert length(ids) == 2
+      assert "doc_abc" in ids
+      assert "doc_xyz" in ids
+    end
+
+    test "returns empty list when no matching instance permissions" do
+      permissions = [
+        "shareddoc:*:read:all",
+        "otherdoc:doc_abc:read:"
+      ]
+
+      ids = AshGrant.Evaluator.get_matching_instance_ids(permissions, "shareddoc", "read")
+
+      assert ids == []
+    end
+
+    test "excludes denied instance permissions" do
+      permissions = [
+        "shareddoc:doc_abc:read:",
+        "shareddoc:doc_xyz:read:",
+        "!shareddoc:doc_xyz:read:"
+      ]
+
+      ids = AshGrant.Evaluator.get_matching_instance_ids(permissions, "shareddoc", "read")
+
+      assert ids == ["doc_abc"]
+    end
+
+    test "handles wildcard action matching" do
+      permissions = [
+        "shareddoc:doc_abc:*:"
+      ]
+
+      ids = AshGrant.Evaluator.get_matching_instance_ids(permissions, "shareddoc", "read")
+
+      assert ids == ["doc_abc"]
+    end
+  end
+
+  # Helper functions
+
+  defp create_shared_doc(title, owner_id) do
+    SharedDoc
+    |> Ash.Changeset.for_create(:create, %{title: title, owner_id: owner_id})
+    |> Ash.create!(authorize?: false)
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -31,5 +31,8 @@ defmodule AshGrant.Test.Domain do
     # Multi-tenancy test resource
     # Uses ^tenant() scope expression
     resource(AshGrant.Test.TenantPost)
+
+    # Instance permission read test resource
+    resource(AshGrant.Test.SharedDoc)
   end
 end

--- a/test/support/resources/shared_doc.ex
+++ b/test/support/resources/shared_doc.ex
@@ -1,0 +1,120 @@
+defmodule AshGrant.Test.SharedDoc do
+  @moduledoc """
+  SharedDoc resource for testing instance permission read support.
+
+  Demonstrates:
+  - Instance-level permissions for specific document access
+  - Combined RBAC + instance permissions
+  - Deny instance permissions
+  """
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: AshPostgres.DataLayer,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  postgres do
+    table("shared_docs")
+    repo(AshGrant.TestRepo)
+  end
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil ->
+          []
+
+        %{role: :admin} ->
+          ["shareddoc:*:*:all"]
+
+        %{role: :user, id: id, shared_doc_ids: shared_ids} ->
+          # RBAC: own documents
+          rbac_perms = ["shareddoc:*:read:own", "shareddoc:*:update:own"]
+
+          # Instance permissions for shared documents
+          instance_perms =
+            Enum.map(shared_ids || [], fn doc_id ->
+              "shareddoc:#{doc_id}:read:"
+            end)
+
+          # Deny permissions if specified
+          deny_perms =
+            case actor do
+              %{denied_doc_ids: denied_ids} ->
+                Enum.map(denied_ids || [], fn doc_id ->
+                  "!shareddoc:#{doc_id}:read:"
+                end)
+
+              _ ->
+                []
+            end
+
+          rbac_perms ++ instance_perms ++ deny_perms
+
+        %{role: :guest, shared_doc_ids: shared_ids} ->
+          # Guest only has instance permissions, no RBAC
+          instance_perms =
+            Enum.map(shared_ids || [], fn doc_id ->
+              "shareddoc:#{doc_id}:read:"
+            end)
+
+          # Deny permissions if specified
+          deny_perms =
+            case actor do
+              %{denied_doc_ids: denied_ids} ->
+                Enum.map(denied_ids || [], fn doc_id ->
+                  "!shareddoc:#{doc_id}:read:"
+                end)
+
+              _ ->
+                []
+            end
+
+          instance_perms ++ deny_perms
+
+        _ ->
+          []
+      end
+    end)
+
+    resource_name("shareddoc")
+
+    scope(:all, true)
+    scope(:own, expr(owner_id == ^actor(:id)))
+  end
+
+  policies do
+    bypass actor_attribute_equals(:role, :admin) do
+      authorize_if(always())
+    end
+
+    policy action_type(:read) do
+      authorize_if(AshGrant.filter_check())
+    end
+
+    policy action_type([:create, :update, :destroy]) do
+      authorize_if(AshGrant.check())
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, allow_nil?: false, public?: true)
+    attribute(:owner_id, :string, public?: true)
+
+    create_timestamp(:inserted_at)
+    update_timestamp(:updated_at)
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:title, :owner_id])
+    end
+
+    update :update do
+      accept([:title])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add instance permission support for read actions (`filter_check/1`)
- Enable Google Docs-style sharing where specific resources are shared with specific users
- Instance permissions now generate `WHERE id IN (instance_ids)` filters for read queries

## Changes

- **Evaluator**: Add `get_matching_instance_ids/3` to extract instance IDs from permissions
- **FilterCheck**: Extend to build instance ID filters and combine with RBAC scopes using OR logic
- **Permission**: Make `matches_resource?/2` and `matches_action?/2` public for reuse
- **Tests**: Add comprehensive tests for instance permission read scenarios
- **Docs**: Update README with instance permission read examples

## Example Usage

```elixir
# Resolver returns instance permissions for shared documents
def resolve(%{shared_doc_ids: doc_ids}, _context) do
  Enum.map(doc_ids, fn doc_id -> "document:#{doc_id}:read:" end)
end

# User can only read documents shared with them
actor = %{shared_doc_ids: ["doc_abc", "doc_xyz"]}
Document |> Ash.read!(actor: actor)
# => Returns only doc_abc and doc_xyz

# When combined with RBAC (e.g., :own scope)
# Filter: owner_id == actor.id OR id IN ['doc_abc', 'doc_xyz']
```

## Test plan

- [x] Instance permission read returns only shared documents
- [x] No permissions returns Forbidden
- [x] RBAC + instance permissions combined with OR
- [x] Deny instance permission blocks read
- [x] `Ash.get/3` works with instance permissions
- [x] All 308 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)