### PR TITLE
test: add business hours fragment and timezone scope tests

### DIFF
--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -47,6 +47,37 @@ defmodule AshGrant.Test.Post do
       :business_hours_injectable,
       expr(fragment("EXTRACT(HOUR FROM ?::timestamp) BETWEEN 9 AND 17", ^context(:current_time)))
     )
+
+    # ============================================================
+    # Local Timezone Business Hours Scopes
+    # ============================================================
+    # Real-world patterns for timezone-aware business hours
+
+    # Option 1: Context-provided timezone (e.g., from request headers)
+    # Use case: Multi-timezone application where timezone comes per-request
+    scope(
+      :business_hours_local,
+      expr(
+        fragment(
+          "EXTRACT(HOUR FROM ?::timestamptz AT TIME ZONE ?) BETWEEN 9 AND 17",
+          ^context(:current_time),
+          ^context(:timezone)
+        )
+      )
+    )
+
+    # Option 2: Actor's timezone (stored on user profile)
+    # Use case: Each user has their preferred timezone in their profile
+    scope(
+      :business_hours_actor_tz,
+      expr(
+        fragment(
+          "EXTRACT(HOUR FROM ?::timestamptz AT TIME ZONE ?) BETWEEN 9 AND 17",
+          ^context(:current_time),
+          ^actor(:timezone)
+        )
+      )
+    )
   end
 
   policies do


### PR DESCRIPTION
## Summary
- Add tests for business hours temporal scopes using SQL fragments
- Add timezone-aware business hours scope tests (Asia/Seoul, America/New_York)
- Add actor timezone scope tests

These tests cover the documented but untested fragment patterns in the temporal scope examples.

## Test plan
- [x] `mix test test/ash_grant/temporal_scope_test.exs` passes
- [x] `mix test test/ash_grant/db_integration_test.exs` passes