### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-01-21
+
+### Added
+
+- **Policy Configuration Testing**: DSL-based testing framework for verifying policy configurations without a database
+  - `AshGrant.PolicyTest` - Main module with `use` macro for defining policy tests
+  - `assert_can/2,3` and `assert_cannot/2,3` assertion macros
+  - `resource/1`, `actor/2`, `describe/2`, `test/2` DSL macros
+  - `AshGrant.PolicyTest.Runner` - Test execution with summary statistics
+  - `AshGrant.PolicyTest.Result` - Result struct with timing information
+
+- **YAML Policy Tests**: Alternative format for non-Elixir developers
+  - `AshGrant.PolicyTest.YamlParser` - Parse and run YAML test files
+  - `AshGrant.PolicyTest.YamlExporter` - Export DSL tests to YAML
+  - `AshGrant.PolicyTest.DslGenerator` - Generate DSL code from YAML
+
+- **Policy Export**: Export policy configurations to documentation formats
+  - `AshGrant.PolicyExport.Mermaid` - Generate Mermaid flowchart diagrams
+  - `AshGrant.PolicyExport.Markdown` - Generate Markdown documentation
+
+- **Mix Tasks**: CLI tools for policy testing and export
+  - `mix ash_grant.verify` - Run policy configuration tests
+  - `mix ash_grant.export` - Export policies to YAML/Mermaid/Markdown
+  - `mix ash_grant.import` - Convert YAML to Elixir DSL
+
+### Dependencies
+
+- Added `yaml_elixir ~> 2.9` as optional dependency for YAML support
+
 ## [0.4.1] - 2026-01-21
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.5.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary

Release v0.5.0 with policy configuration testing framework.

## Changes

- Version bump: 0.4.1 → 0.5.0
- CHANGELOG.md updated

## New in v0.5.0

### Policy Configuration Testing
- DSL-based testing with `assert_can`/`assert_cannot`
- YAML interchange format for non-Elixir developers
- Export to Mermaid diagrams and Markdown documentation
- Mix tasks: `ash_grant.verify`, `ash_grant.export`, `ash_grant.import`

### New Modules
- `AshGrant.PolicyTest` - Main testing DSL
- `AshGrant.PolicyTest.Runner` - Test execution
- `AshGrant.PolicyExport` - Documentation export

### Dependencies
- `yaml_elixir ~> 2.9` (optional)

## After Merge

```bash
git checkout main && git pull
git tag v0.5.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.ai/code)