### PR TITLE
docs: replace unrealistic write: examples with practical patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,9 +443,8 @@ ash_grant do
   scope :own_draft, [:own], expr(status == :draft)
   # Result: author_id == actor.id AND status == :draft
 
-  # Dual read/write scope - separate expression for write actions
-  scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id))),
-    write: expr(team_id in ^actor(:team_ids))
+  # Relational scope - works for both reads and writes automatically
+  scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id)))
 end
 ```
 
@@ -620,13 +619,13 @@ query to verify the record matches the scope.
 
 ```elixir
 ash_grant do
-  # Explicit in-memory expression for writes (avoids DB query)
-  scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id))),
-    write: expr(team_id in ^actor(:team_ids))
-
   # Explicitly deny writes with this scope
   scope :org_member, expr(exists(org.users, id == ^actor(:id))),
     write: false
+
+  # Explicit in-memory expression (avoids DB round-trip)
+  scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+    write: expr(org_id == ^actor(:org_id))
 end
 ```
 
@@ -1030,15 +1029,17 @@ Scope Filter: true (no filtering)
 
 ### Dual Read/Write Scope (`write:` Option)
 
-Scopes using `exists()` or dot-path references cannot be evaluated in-memory for write
-actions. The `write:` option provides a separate expression for write action evaluation:
+Scopes with `exists()` or dot-paths work automatically for both reads and writes via
+[DB query fallback](#relational-scopes-exists-and-dot-paths). The `write:` option
+is an optional override for explicit control:
 
-| `write:` value | Behavior |
-|----------------|----------|
-| `write: expr(...)` | Use this direct-field expression for write actions |
-| `write: false` | Explicitly deny all writes with this scope |
-| `write: true` | Allow all writes with this scope (no filtering) |
-| _(omitted)_ | Fall back to `filter` (default, backward compatible) |
+| `write:` value | Strategy | Behavior |
+|----------------|----------|----------|
+| _(omitted, no relationships)_ | In-memory | Evaluates filter in-memory (default) |
+| _(omitted, has relationships)_ | DB query | Queries DB with read scope (automatic) |
+| `write: expr(...)` | In-memory | Use this expression for writes (overrides DB query) |
+| `write: false` | Deny | Explicitly deny all writes with this scope |
+| `write: true` | Allow | Allow all writes with this scope (no filtering) |
 
 ```elixir
 ash_grant do
@@ -1046,15 +1047,18 @@ ash_grant do
 
   scope :all, true
 
-  # Read uses SQL EXISTS; write checks team_id directly
-  scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id))),
-    write: expr(team_id in ^actor(:team_ids))
+  # Relational scope — DB query fallback handles writes automatically
+  scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id)))
 
-  # Read uses SQL; write is denied entirely
+  # Explicitly deny writes
   scope :org_member, expr(exists(org.users, id == ^actor(:id))),
     write: false
 
-  # No write: option — filter is used for both read and write
+  # Explicit in-memory override (avoids DB round-trip)
+  scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+    write: expr(org_id == ^actor(:org_id))
+
+  # Simple scopes — in-memory evaluation, no write: needed
   scope :own, expr(author_id == ^actor(:id))
 end
 ```

--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -79,8 +79,9 @@ defmodule AshGrant.Check do
   The `write:` option is an explicit override. When omitted, the check automatically
   chooses the best strategy for the scope expression (see "DB Query Fallback" below).
 
-      scope :team_member, expr(exists(team.members, user_id == ^actor(:id))),
-        write: expr(team_id in ^actor(:team_ids))
+      # Explicit in-memory override (avoids DB round-trip)
+      scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+        write: expr(org_id == ^actor(:org_id))
 
   Set `write: false` to explicitly deny writes with a scope:
 

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -34,23 +34,22 @@ defmodule AshGrant.Dsl do
   ### Dual Read/Write Scope
 
   The `filter` expression is used for read actions (converted to SQL via `FilterCheck`).
-  For write actions, `Check` evaluates the scope in-memory using `Ash.Expr.eval/2`.
+  For write actions, `Check` evaluates the scope — simple scopes use in-memory
+  evaluation, while scopes with relationship references (`exists()` or dot-paths)
+  automatically use a DB query to verify the scope.
 
-  Relationship traversal (`exists()` or dot-paths like `order.center_id`) cannot
-  be evaluated in-memory. Use the `write:` option to provide a direct-field expression
-  for write actions:
+  The `write:` option is an optional override for explicit control:
 
-      scope :team_member, expr(exists(team.members, user_id == ^actor(:id))),
-        write: expr(team_id in ^actor(:team_ids))
-
-  Set `write: false` to explicitly deny writes with a scope:
-
+      # Explicitly deny writes
       scope :readonly, expr(exists(org.users, id == ^actor(:id))),
         write: false
 
-  When `write:` is omitted, the `filter` expression is used for both reads and writes
-  (backward compatible). A compile-time warning is emitted if relationship traversal
-  is detected without a `write:` option.
+      # Explicit in-memory expression (avoids DB round-trip)
+      scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+        write: expr(org_id == ^actor(:org_id))
+
+  When `write:` is omitted, scopes with relationship references use a DB query
+  fallback; simple scopes use in-memory evaluation.
 
   ## Example
 
@@ -67,9 +66,8 @@ defmodule AshGrant.Dsl do
           scope :published, expr(status == :published)
           scope :own_draft, [:own], expr(status == :draft)
 
-          # Dual scope: read uses exists(), write uses direct field
-          scope :team_visible, expr(exists(team.members, user_id == ^actor(:id))),
-            write: expr(team_id in ^actor(:team_ids))
+          # Relational scope — works for reads and writes automatically
+          scope :team_visible, expr(exists(team.members, user_id == ^actor(:id)))
         end
       end
 
@@ -148,9 +146,8 @@ defmodule AshGrant.Dsl do
         scope :today, expr(fragment("DATE(inserted_at) = ?", ^context(:reference_date))),
           description: "Records created today"
 
-        # Dual read/write scope: read uses exists(), write uses direct field
-        scope :team_member, expr(exists(team.members, user_id == ^actor(:id))),
-          write: expr(team_id in ^actor(:team_ids))
+        # Relational scope — DB query fallback handles writes automatically
+        scope :team_member, expr(exists(team.members, user_id == ^actor(:id)))
 
         # Explicitly deny writes with this scope
         scope :readonly, expr(exists(org.users, id == ^actor(:id))),
@@ -166,7 +163,7 @@ defmodule AshGrant.Dsl do
       "scope :own_draft, [:own], expr(status == :draft)",
       ~s|scope :today, expr(fragment("DATE(inserted_at) = ?", ^context(:reference_date)))|,
       ~s|scope :own, expr(author_id == ^actor(:id)), description: "Records owned by the current user"|,
-      "scope :team_member, expr(exists(team.members, user_id == ^actor(:id))), write: expr(team_id in ^actor(:team_ids))",
+      "scope :team_member, expr(exists(team.members, user_id == ^actor(:id)))",
       "scope :readonly, expr(exists(org.users, id == ^actor(:id))), write: false"
     ],
     target: AshGrant.Dsl.Scope,
@@ -195,19 +192,20 @@ defmodule AshGrant.Dsl do
         type: {:or, [:boolean, :any]},
         required: false,
         doc: """
-        Expression for write action evaluation. Falls back to `filter` if omitted.
-        Set to `false` to explicitly deny writes with this scope.
+        Optional override for write action evaluation. When omitted, scopes with
+        relationship references use a DB query fallback; simple scopes use in-memory
+        evaluation.
 
-        Use this when the read filter uses relationship traversal (exists() or dot-paths)
-        that cannot be evaluated in-memory for write actions.
+        Set to `false` to explicitly deny writes, or to an expression for explicit
+        in-memory evaluation (avoids DB round-trip).
 
         ## Example
 
-            scope :own, expr(exists(team.members, user_id == ^actor(:id))),
-              write: expr(team_id in ^actor(:team_ids))
-
             scope :readonly, expr(exists(org.users, id == ^actor(:id))),
               write: false
+
+            scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+              write: expr(org_id == ^actor(:org_id))
         """
       ]
     ]

--- a/lib/ash_grant/info.ex
+++ b/lib/ash_grant/info.ex
@@ -226,8 +226,8 @@ defmodule AshGrant.Info do
   ## Examples
 
       # Scope with write: expr(...) → returns the write expression
-      resolve_write_scope_filter(Resource, :team_member, context)
-      # => expr(team_id in ^actor(:team_ids))
+      resolve_write_scope_filter(Resource, :same_org, context)
+      # => expr(org_id == ^actor(:org_id))
 
       # Scope with write: false → returns false
       resolve_write_scope_filter(Resource, :readonly, context)

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -184,9 +184,9 @@ ash_grant do
   # No write: needed — DB query fallback handles it automatically
   scope :team_member, expr(exists(team.members, user_id == ^actor(:id)))
 
-  # Explicit override: use in-memory expression for writes (avoids DB query)
-  scope :team_visible, expr(exists(team.members, user_id == ^actor(:id))),
-    write: expr(team_id in ^actor(:team_ids))
+  # Explicit override: in-memory expression (avoids DB round-trip)
+  scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+    write: expr(org_id == ^actor(:org_id))
 
   # Explicitly deny writes with this scope
   scope :readonly, expr(exists(org.users, id == ^actor(:id))),
@@ -357,8 +357,8 @@ Use `write:` to override the automatic DB query strategy:
 
 ```elixir
 # Explicit in-memory expression (avoids DB query overhead)
-scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id))),
-  write: expr(team_id in ^actor(:team_ids))
+scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+  write: expr(org_id == ^actor(:org_id))
 
 # Explicitly deny writes
 scope :readonly, expr(exists(org.users, id == ^actor(:id))),
@@ -679,8 +679,8 @@ in-memory evaluation. Use `write:` to provide a direct-field expression:
 
 ```elixir
 # For resources WITHOUT a data layer, use write: to provide an alternative
-scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id))),
-  write: expr(team_id in ^actor(:team_ids))
+scope :same_org, expr(exists(org.users, id == ^actor(:id))),
+  write: expr(org_id == ^actor(:org_id))
 ```
 
 ### Forgetting that deny-wins means no order dependency


### PR DESCRIPTION
## Summary
- Replace `write: expr(team_id in ^actor(:team_ids))` with `write: expr(org_id == ^actor(:org_id))` across all docs
- The old pattern required maintaining a `team_ids` list on the actor, which is impractical
- Since v0.8.0 DB query fallback handles `exists()` scopes automatically, `write:` is now optional

## Files updated
- README.md
- lib/ash_grant/dsl.ex
- lib/ash_grant/checks/check.ex
- lib/ash_grant/info.ex
- usage-rules.md

## Test plan
- [ ] Documentation-only change, no code behavior affected
- [ ] Test files intentionally kept as-is (they test the `write:` feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)