### PR TITLE
fix: handle Ash.Query.Call in DB query fallback

### DIFF
--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -391,6 +391,10 @@ defmodule AshGrant.Check do
   defp contains_relationship_reference?(%Ash.Query.Not{expression: e}),
     do: contains_relationship_reference?(e)
 
+  defp contains_relationship_reference?(%Ash.Query.Call{args: args}) do
+    Enum.any?(args, &contains_relationship_reference?/1)
+  end
+
   defp contains_relationship_reference?(%{__struct__: _, left: l, right: r}) do
     contains_relationship_reference?(l) or contains_relationship_reference?(r)
   end
@@ -442,7 +446,7 @@ defmodule AshGrant.Check do
     |> Ash.Query.for_read(:read, %{})
     |> Ash.Query.filter(^resolved_filter)
     |> Ash.Query.filter(^pk_filter)
-    |> Ash.exists?(authorize?: false)
+    |> Ash.exists?(exists_opts(context))
   rescue
     _ -> false
   end
@@ -541,10 +545,16 @@ defmodule AshGrant.Check do
       |> Ash.Query.for_read(:read, %{})
       |> Ash.Query.filter(^[{relationship.destination_attribute, fk_value}])
       |> Ash.Query.filter(^resolved)
-      |> Ash.exists?(authorize?: false)
+      |> Ash.exists?(exists_opts(context))
     else
       _ -> false
     end
+  end
+
+  # Build opts for Ash.exists? — always skip authorization, pass tenant if present
+  defp exists_opts(context) do
+    opts = [authorize?: false]
+    if context[:tenant], do: Keyword.put(opts, :tenant, context[:tenant]), else: opts
   end
 
   # Resolve actor/tenant/context templates in an expression
@@ -566,6 +576,10 @@ defmodule AshGrant.Check do
 
   defp extract_first_relationship(%Ash.Query.BooleanExpression{left: l, right: r}) do
     extract_first_relationship(l) || extract_first_relationship(r)
+  end
+
+  defp extract_first_relationship(%Ash.Query.Call{args: args}) do
+    Enum.find_value(args, &extract_first_relationship/1)
   end
 
   defp extract_first_relationship(%{__struct__: _, left: l, right: r}) do

--- a/test/ash_grant/db_query_write_test.exs
+++ b/test/ash_grant/db_query_write_test.exs
@@ -375,4 +375,108 @@ defmodule AshGrant.DbQueryWriteTest do
       assert updated.title == "Updated"
     end
   end
+
+  # ============================================================
+  # DB query fallback for dot-path expressions (Ash.Query.Call)
+  # ============================================================
+
+  describe "DB query fallback for dot-path expressions" do
+    test "update with dot-path scope and matching team name succeeds" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with_perms(["item:*:update:named_team", "item:*:read:all"], actor_id)
+        |> Map.put(:team_name, "Alpha")
+
+      team = create_team!("Alpha")
+      item = create_item!(%{title: "Dot Path Item", author_id: actor_id, team_id: team.id})
+
+      result =
+        item
+        |> Ash.Changeset.for_update(:update, %{title: "Updated"})
+        |> Ash.update(actor: actor)
+
+      assert {:ok, updated} = result
+      assert updated.title == "Updated"
+    end
+
+    test "update with dot-path scope and non-matching team name is forbidden" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with_perms(["item:*:update:named_team", "item:*:read:all"], actor_id)
+        |> Map.put(:team_name, "Beta")
+
+      team = create_team!("Alpha")
+      item = create_item!(%{title: "Dot Path Item", author_id: actor_id, team_id: team.id})
+
+      result =
+        item
+        |> Ash.Changeset.for_update(:update, %{title: "Should Fail"})
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "create with dot-path scope and matching team name succeeds" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with_perms(["item:*:create:named_team"], actor_id)
+        |> Map.put(:team_name, "Gamma")
+
+      team = create_team!("Gamma")
+
+      result =
+        BulkItem
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Dot Path Create",
+          author_id: actor_id,
+          team_id: team.id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:ok, item} = result
+      assert item.title == "Dot Path Create"
+    end
+
+    test "create with dot-path scope and non-matching team name is forbidden" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with_perms(["item:*:create:named_team"], actor_id)
+        |> Map.put(:team_name, "Delta")
+
+      team = create_team!("Epsilon")
+
+      result =
+        BulkItem
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Should Fail",
+          author_id: actor_id,
+          team_id: team.id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "destroy with dot-path scope and matching team name succeeds" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with_perms(["item:*:destroy:named_team", "item:*:read:all"], actor_id)
+        |> Map.put(:team_name, "Zeta")
+
+      team = create_team!("Zeta")
+      item = create_item!(%{title: "Delete Me", author_id: actor_id, team_id: team.id})
+
+      result =
+        item
+        |> Ash.Changeset.for_destroy(:destroy)
+        |> Ash.destroy(actor: actor)
+
+      assert :ok = result
+    end
+  end
 end

--- a/test/support/resources/bulk_item.ex
+++ b/test/support/resources/bulk_item.ex
@@ -14,6 +14,7 @@ defmodule AshGrant.Test.BulkItem do
   | :own | author_id == ^actor(:id) |
   | :team_member | exists(team.memberships, user_id == ^actor(:id)) |
   | :own_in_team | author_id == ^actor(:id) AND exists(team.memberships, ...) |
+  | :named_team | team.name == ^actor(:team_name) (dot-path) |
   """
   use Ash.Resource,
     domain: AshGrant.Test.Domain,
@@ -47,6 +48,8 @@ defmodule AshGrant.Test.BulkItem do
       [],
       expr(author_id == ^actor(:id) and exists(team.memberships, user_id == ^actor(:id)))
     )
+
+    scope(:named_team, [], expr(team.name == ^actor(:team_name)))
   end
 
   attributes do


### PR DESCRIPTION
## Summary
- Add `Ash.Query.Call` clause to `contains_relationship_reference?/1` so dot-path expressions (e.g., `order.center_id in ^actor(:ids)`) trigger the DB query fallback
- Add `Ash.Query.Call` clause to `extract_first_relationship/1` for create action filter splitting
- Pass `tenant:` from context to all `Ash.exists?/2` calls to support multitenanted resources

Closes #33

## Test plan
- [x] 5 new dot-path scope tests (update match/mismatch, create match/mismatch, destroy)
- [x] All 707 existing tests pass
- [x] `mix compile --warnings-as-errors` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)