### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-03-12
+
 ### Added
 
 - **`field_group` `except` option (blacklist mode)**: Use `[:*]` wildcard with `except` to exclude specific fields instead of listing all visible ones. Useful for resources with many attributes where only a few are sensitive. (#36)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.9.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary

- Bump version to 0.9.0
- Move Unreleased changelog entries to v0.9.0

### What's new in v0.9.0

- **`field_group` `except` option (blacklist mode)** (#36): `[:*]` wildcard with `except` for excluding fields instead of whitelisting

🤖 Generated with [Claude Code](https://claude.com/claude-code)