### PR TITLE
feat: redesign field_group DSL to fix positional arg ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **`field_group` DSL redesign** (#40): Removed positional argument ambiguity between `inherits` and `fields`
+  - **BREAKING: `inherits` is now keyword-only**: `field_group :name, [:parents], [:fields]` no longer works. Use `field_group :name, [:fields], inherits: [:parents]` instead.
+  - **BREAKING: `[:*]` replaced by `:all`**: Use `field_group :name, :all` instead of `field_group :name, [:*]` (deprecated `[:*]` still works with a warning, will be removed in v1.0.0)
+  - **New `:all` syntax**: `field_group :admin, :all` — all resource attributes
+  - **Blacklist mode**: `field_group :public, :all, except: [:salary, :ssn]`
+  - **Combined**: `field_group :editor, :all, except: [:admin_notes], inherits: [:base]`
+  - **Most common pattern unchanged**: `field_group :public, [:name, :department]` works as before
+
+#### Migration Guide
+
+```elixir
+# Before (v0.9.0)
+field_group :public, [], [:*], except: [:salary, :ssn]
+field_group :sensitive, [:public], [:phone, :address]
+field_group :confidential, [:sensitive], [:salary, :email]
+
+# After (v0.10.0)
+field_group :public, :all, except: [:salary, :ssn]
+field_group :sensitive, [:phone, :address], inherits: [:public]
+field_group :confidential, [:salary, :email], inherits: [:sensitive]
+```
+
+### Deprecated
+
+- **`[:*]` wildcard syntax**: Use `:all` instead. `[:*]` still works but emits a compile-time deprecation warning. Will be removed in v1.0.0.
+
 ## [0.9.0] - 2026-03-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -728,16 +728,16 @@ ash_grant do
   field_group :public, [:name, :department, :position]
 
   # Inherits all fields from :public, adds phone and address
-  field_group :sensitive, [:public], [:phone, :address]
+  field_group :sensitive, [:phone, :address], inherits: [:public]
 
   # Inherits all fields from :sensitive (which includes :public)
-  field_group :confidential, [:sensitive], [:salary, :email]
+  field_group :confidential, [:salary, :email], inherits: [:sensitive]
 end
 ```
 
 #### Blacklist Mode (`except`)
 
-When a resource has many attributes, use `[:*]` with `except` to exclude specific fields instead of listing all visible ones:
+When a resource has many attributes, use `:all` with `except` to exclude specific fields instead of listing all visible ones:
 
 ```elixir
 ash_grant do
@@ -745,14 +745,14 @@ ash_grant do
   scope :all, true
 
   # All attributes except salary and ssn
-  field_group :public, [], [:*], except: [:salary, :ssn]
+  field_group :public, :all, except: [:salary, :ssn]
 
   # Child group adds back the excluded fields
-  field_group :full, [:public], [:salary, :ssn]
+  field_group :full, [:salary, :ssn], inherits: [:public]
 end
 ```
 
-`[:*]` expands to all resource attributes at compile time. `except` removes fields from that list. `[:*]` without `except` is also valid (expands to all attributes).
+`:all` expands to all resource attributes at compile time. `except` removes fields from that list. `:all` without `except` is also valid (expands to all attributes).
 
 ### Permission Strings with Field Groups
 
@@ -800,16 +800,16 @@ ash_grant do
   scope :all, true
 
   field_group :public, [:name, :department, :position]
-  field_group :sensitive, [:public], [:phone, :address]
-  field_group :confidential, [:sensitive], [:salary, :email]
+  field_group :sensitive, [:phone, :address], inherits: [:public]
+  field_group :confidential, [:salary, :email], inherits: [:sensitive]
 end
 ```
 
 This also works with blacklist mode:
 
 ```elixir
-field_group :public, [], [:*], except: [:salary, :ssn]
-field_group :full, [:public], [:salary, :ssn]
+field_group :public, :all, except: [:salary, :ssn]
+field_group :full, [:salary, :ssn], inherits: [:public]
 ```
 
 Auto-generates equivalent field policies with a catch-all `field_policy :*` that allows non-grouped fields.
@@ -831,7 +831,8 @@ An actor with `confidential` permission can see everything that `sensitive` and 
 Instead of hiding fields entirely, you can show masked values:
 
 ```elixir
-field_group :sensitive, [:public], [:phone, :address],
+field_group :sensitive, [:phone, :address],
+  inherits: [:public],
   mask: [:phone, :address],
   mask_with: fn value, _field ->
     if is_binary(value), do: String.replace(value, ~r/./, "*"), else: "***"

--- a/lib/ash_grant.ex
+++ b/lib/ash_grant.ex
@@ -271,10 +271,10 @@ defmodule AshGrant do
 
         # Field groups (whitelist)
         field_group :public, [:name, :department]
-        field_group :sensitive, [:public], [:phone, :address]
+        field_group :sensitive, [:phone, :address], inherits: [:public]
 
         # Field groups (blacklist with except)
-        # field_group :public, [], [:*], except: [:salary, :ssn]
+        # field_group :public, :all, except: [:salary, :ssn]
       end
 
   | Option | Type | Description |
@@ -303,7 +303,7 @@ defmodule AshGrant do
     sections: AshGrant.Dsl.sections(),
     transformers: [
       AshGrant.Transformers.ValidateScopes,
-      AshGrant.Transformers.ResolveFieldGroupExcept,
+      AshGrant.Transformers.ResolveFieldGroupFields,
       AshGrant.Transformers.ValidateFieldGroups,
       AshGrant.Transformers.AddDefaultPolicies,
       AshGrant.Transformers.AddFieldPolicies,

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -225,30 +225,31 @@ defmodule AshGrant.Dsl do
         # Root group — no inheritance
         field_group :public, [:name, :department, :position]
 
+        # All fields
+        field_group :admin, :all
+
+        # All fields except (blacklist)
+        field_group :internal, :all, except: [:ssn, :tax_code]
+
         # Inherits from :public, adds more fields
-        field_group :sensitive, [:public], [:phone, :address]
+        field_group :sensitive, [:phone, :address], inherits: [:public]
 
         # With masking
-        field_group :sensitive, [:public], [:phone, :address] do
+        field_group :sensitive, [:phone, :address], inherits: [:public] do
           mask [:phone, :address], with: &MyApp.Masker.mask/2
         end
 
-        # Wildcard — all resource attributes
-        field_group :everything, [:*]
-
-        # Blacklist — all attributes except specified ones
-        field_group :public, [:*], except: [:salary, :ssn]
-
-        # Blacklist with inheritance
-        field_group :sensitive, [:public], [:*], except: [:salary]
+        # Inherits + all except
+        field_group :editor, :all, except: [:admin_notes], inherits: [:public]
     """,
     examples: [
       "field_group :public, [:name, :department]",
-      "field_group :sensitive, [:public], [:phone, :address]",
-      "field_group :public, [:*], except: [:salary, :ssn]"
+      "field_group :sensitive, [:phone, :address], inherits: [:public]",
+      "field_group :admin, :all",
+      "field_group :public, :all, except: [:salary, :ssn]"
     ],
     target: AshGrant.Dsl.FieldGroup,
-    args: [:name, {:optional, :inherits}, :fields],
+    args: [:name, :fields],
     schema: [
       name: [
         type: :atom,
@@ -260,9 +261,9 @@ defmodule AshGrant.Dsl do
         doc: "List of parent field groups to inherit from"
       ],
       fields: [
-        type: {:list, :atom},
+        type: {:or, [{:in, [:all]}, {:list, :atom}]},
         required: true,
-        doc: "List of field atoms accessible at this level"
+        doc: "List of field atoms accessible at this level, or `:all` for all resource attributes"
       ],
       mask: [
         type: {:list, :atom},
@@ -275,9 +276,9 @@ defmodule AshGrant.Dsl do
       except: [
         type: {:list, :atom},
         doc:
-          "Fields to exclude when using `[:*]` wildcard. " <>
-            "Only valid when `fields` is `[:*]`. " <>
-            "The transformer resolves `[:*]` minus `except` to concrete field names."
+          "Fields to exclude when `fields` is `:all`. " <>
+            "Only valid when `fields` is `:all`. " <>
+            "The transformer resolves `:all` minus `except` to concrete field names."
       ],
       description: [
         type: :string,
@@ -443,9 +444,9 @@ defmodule AshGrant.Dsl.FieldGroup do
   ## Fields
 
   - `:name` - The atom name of the field group (e.g., `:public`, `:sensitive`)
-  - `:fields` - List of field atoms included in this group (or `[:*]` for all attributes)
+  - `:fields` - `:all` or list of field atoms included in this group (resolved to `[atom()]` by transformer)
   - `:inherits` - Optional list of parent field group names to inherit fields from
-  - `:except` - Optional list of fields to exclude when using `[:*]` wildcard
+  - `:except` - Optional list of fields to exclude when `fields` is `:all`
   - `:mask` - Optional list of fields to mask (return masked values instead of hiding)
   - `:mask_with` - Optional 2-arity function `(value, field_name) -> masked_value`
   - `:description` - Optional human-readable description
@@ -464,7 +465,7 @@ defmodule AshGrant.Dsl.FieldGroup do
 
   @type t :: %__MODULE__{
           name: atom(),
-          fields: [atom()],
+          fields: :all | [atom()],
           inherits: [atom()] | nil,
           except: [atom()] | nil,
           mask: [atom()] | nil,

--- a/lib/ash_grant/transformers/add_field_policies.ex
+++ b/lib/ash_grant/transformers/add_field_policies.ex
@@ -14,8 +14,8 @@ defmodule AshGrant.Transformers.AddFieldPolicies do
   For field groups:
 
       field_group :public, [:name, :department]
-      field_group :sensitive, [:public], [:phone, :address]
-      field_group :confidential, [:sensitive], [:salary, :email]
+      field_group :sensitive, [:phone, :address], inherits: [:public]
+      field_group :confidential, [:salary, :email], inherits: [:sensitive]
 
   Generates:
 

--- a/lib/ash_grant/transformers/resolve_field_group_fields.ex
+++ b/lib/ash_grant/transformers/resolve_field_group_fields.ex
@@ -1,22 +1,27 @@
-defmodule AshGrant.Transformers.ResolveFieldGroupExcept do
+defmodule AshGrant.Transformers.ResolveFieldGroupFields do
   @moduledoc """
-  Resolves `[:*]` wildcard in field group `fields` to concrete attribute names.
+  Resolves `:all` and deprecated `[:*]` wildcard in field group `fields` to concrete attribute names.
 
-  When a field group uses `[:*]` as its fields list, this transformer expands it
+  When a field group uses `:all` as its fields value, this transformer expands it
   to all public resource attributes, then removes any fields listed in the `except`
   option.
 
   ## Examples
 
       # Resolves to all attributes
-      field_group :everything, [:*]
+      field_group :everything, :all
 
       # Resolves to all attributes except :salary and :ssn
-      field_group :public, [:*], except: [:salary, :ssn]
+      field_group :public, :all, except: [:salary, :ssn]
+
+  ## Deprecation
+
+  The `[:*]` syntax is deprecated in favor of `:all` and will be removed in v1.0.0.
+  Using `[:*]` emits a compile-time warning and is treated as `:all` internally.
 
   ## Validations
 
-  - `except` without `[:*]` raises a compile error
+  - `except` without `:all` (or deprecated `[:*]`) raises a compile error
   - Fields in `except` that don't exist as resource attributes raise a compile error
   - Masked fields that appear in `except` raise a compile error
 
@@ -65,7 +70,8 @@ defmodule AshGrant.Transformers.ResolveFieldGroupExcept do
     end
   end
 
-  defp resolve_field_group(%{fields: [:*], except: except} = fg, all_attr_names, resource)
+  # New syntax: fields: :all, except: [...]
+  defp resolve_field_group(%{fields: :all, except: except} = fg, all_attr_names, resource)
        when is_list(except) and except != [] do
     validate_except_fields_exist!(except, all_attr_names, fg.name, resource)
     validate_mask_not_in_except!(fg, resource)
@@ -73,18 +79,50 @@ defmodule AshGrant.Transformers.ResolveFieldGroupExcept do
     {:ok, %{fg | fields: resolved_fields, except: except}}
   end
 
-  defp resolve_field_group(%{fields: [:*]} = fg, all_attr_names, _resource) do
+  # New syntax: fields: :all (no except)
+  defp resolve_field_group(%{fields: :all} = fg, all_attr_names, _resource) do
     {:ok, %{fg | fields: all_attr_names}}
   end
 
+  # Deprecated syntax: fields: [:*], except: [...]
+  defp resolve_field_group(%{fields: [:*], except: except} = fg, all_attr_names, resource)
+       when is_list(except) and except != [] do
+    emit_deprecation_warning(fg.name, resource)
+    validate_except_fields_exist!(except, all_attr_names, fg.name, resource)
+    validate_mask_not_in_except!(fg, resource)
+    resolved_fields = all_attr_names -- except
+    {:ok, %{fg | fields: resolved_fields, except: except}}
+  end
+
+  # Deprecated syntax: fields: [:*] (no except)
+  defp resolve_field_group(%{fields: [:*]} = fg, all_attr_names, resource) do
+    emit_deprecation_warning(fg.name, resource)
+    {:ok, %{fg | fields: all_attr_names}}
+  end
+
+  # except with non-wildcard fields is an error
   defp resolve_field_group(%{except: except}, _all_attr_names, _resource)
        when is_list(except) and except != [] do
     {:error,
-     "The `except` option is only valid when `fields` is `[:*]`. Use `[:*]` as the fields list or remove the `except` option."}
+     "The `except` option is only valid when `fields` is `:all`. " <>
+       "Use `:all` as the fields value or remove the `except` option."}
   end
 
+  # No resolution needed
   defp resolve_field_group(_fg, _all_attr_names, _resource) do
     {:ok, nil}
+  end
+
+  defp emit_deprecation_warning(group_name, resource) do
+    IO.warn("""
+    AshGrant: field_group #{inspect(group_name)} uses deprecated [:*] syntax in #{inspect(resource)}.
+
+    Replace [:*] with :all:
+        field_group #{inspect(group_name)}, :all
+        field_group #{inspect(group_name)}, :all, except: [:field1, :field2]
+
+    The [:*] syntax will be removed in v1.0.0.
+    """)
   end
 
   defp validate_except_fields_exist!(except, all_attr_names, group_name, _resource) do

--- a/test/ash_grant/field_group_except_test.exs
+++ b/test/ash_grant/field_group_except_test.exs
@@ -3,10 +3,10 @@ defmodule AshGrant.FieldGroupExceptTest do
   Tests for the field_group `except` (blacklist) option.
 
   Covers:
-  - [:*] resolves to all resource attributes
-  - [:*] with except excludes specified fields
+  - :all resolves to all resource attributes
+  - :all with except excludes specified fields
   - Child group inheriting from except parent and adding back excluded fields
-  - except without [:*] raises compile error
+  - except without :all raises compile error
   - mask field in except raises compile error
   - except field not in resource attributes raises compile error
   - Integration: actor with public permission can't see excepted fields
@@ -15,12 +15,12 @@ defmodule AshGrant.FieldGroupExceptTest do
 
   alias AshGrant.Test.ExceptRecord
 
-  describe "[:*] wildcard resolution" do
-    test "ExceptRecord compiles with [:*] and except option" do
+  describe ":all wildcard resolution" do
+    test "ExceptRecord compiles with :all and except option" do
       assert Code.ensure_loaded?(ExceptRecord)
     end
 
-    test "[:*] with except resolves to all attributes minus excepted fields" do
+    test ":all with except resolves to all attributes minus excepted fields" do
       fg = AshGrant.Info.get_field_group(ExceptRecord, :public)
 
       assert fg != nil
@@ -59,14 +59,14 @@ defmodule AshGrant.FieldGroupExceptTest do
       assert :ssn in resolved_fields
     end
 
-    test "id attribute is included in [:*] resolution" do
+    test "id attribute is included in :all resolution" do
       fg = AshGrant.Info.get_field_group(ExceptRecord, :public)
       assert :id in fg.fields
     end
   end
 
   describe "compile-time validation errors" do
-    test "except without [:*] raises compile error" do
+    test "except without :all raises compile error" do
       assert_raise Spark.Error.DslError, ~r/only valid when/, fn ->
         defmodule ExceptWithoutWildcard do
           use Ash.Resource,
@@ -82,7 +82,7 @@ defmodule AshGrant.FieldGroupExceptTest do
             resource_name("exc_no_wildcard")
             scope(:all, true)
 
-            field_group(:bad, [], [:name, :email], except: [:salary])
+            field_group(:bad, [:name, :email], except: [:salary])
           end
 
           attributes do
@@ -115,7 +115,7 @@ defmodule AshGrant.FieldGroupExceptTest do
             resource_name("exc_bad_field")
             scope(:all, true)
 
-            field_group(:bad, [], [:*], except: [:nonexistent_field])
+            field_group(:bad, :all, except: [:nonexistent_field])
           end
 
           attributes do
@@ -146,7 +146,7 @@ defmodule AshGrant.FieldGroupExceptTest do
             resource_name("exc_mask_conflict")
             scope(:all, true)
 
-            field_group(:bad, [], [:*],
+            field_group(:bad, :all,
               except: [:salary],
               mask: [:salary],
               mask_with: &AshGrant.Test.MaskHelpers.mask_string/2
@@ -167,9 +167,9 @@ defmodule AshGrant.FieldGroupExceptTest do
     end
   end
 
-  describe "[:*] without except" do
-    test "[:*] without except resolves to all attributes" do
-      defmodule WildcardAll do
+  describe ":all without except" do
+    test ":all without except resolves to all attributes" do
+      defmodule AllNoExcept do
         use Ash.Resource,
           domain: AshGrant.Test.Domain,
           data_layer: Ash.DataLayer.Ets,
@@ -181,10 +181,10 @@ defmodule AshGrant.FieldGroupExceptTest do
           resolver(fn _, _ -> [] end)
           default_policies(true)
           default_field_policies(true)
-          resource_name("wildcard_all")
+          resource_name("all_no_except")
           scope(:all, true)
 
-          field_group(:everything, [], [:*])
+          field_group(:everything, :all)
         end
 
         attributes do
@@ -199,7 +199,7 @@ defmodule AshGrant.FieldGroupExceptTest do
         end
       end
 
-      fg = AshGrant.Info.get_field_group(WildcardAll, :everything)
+      fg = AshGrant.Info.get_field_group(AllNoExcept, :everything)
       assert :id in fg.fields
       assert :name in fg.fields
       assert :email in fg.fields

--- a/test/ash_grant/field_group_new_dsl_test.exs
+++ b/test/ash_grant/field_group_new_dsl_test.exs
@@ -1,0 +1,346 @@
+defmodule AshGrant.FieldGroupNewDslTest do
+  @moduledoc """
+  TDD tests for the redesigned field_group DSL (issue #40).
+
+  New syntax:
+  - `field_group :name, :all` — all fields (replaces `[:*]`)
+  - `field_group :name, :all, except: [...]` — blacklist
+  - `field_group :name, [:fields], inherits: [:parents]` — keyword-only inherits
+  - Deprecated: `[:*]` still works but emits IO.warn
+
+  These tests are written BEFORE implementation changes (TDD).
+  """
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO, only: [with_io: 2]
+
+  # ============================================
+  # New :all syntax
+  # ============================================
+
+  describe "field_group :name, :all (new syntax)" do
+    test ":all resolves to all resource attributes" do
+      defmodule AllFieldsResource do
+        use Ash.Resource,
+          domain: AshGrant.Test.Domain,
+          data_layer: Ash.DataLayer.Ets,
+          authorizers: [Ash.Policy.Authorizer],
+          extensions: [AshGrant],
+          validate_domain_inclusion?: false
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          default_policies(true)
+          default_field_policies(true)
+          resource_name("all_fields_res")
+          scope(:all, true)
+
+          field_group(:everything, :all)
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+          attribute(:email, :string, public?: true)
+          attribute(:salary, :integer, public?: true)
+        end
+
+        actions do
+          defaults([:read, create: :*])
+        end
+      end
+
+      fg = AshGrant.Info.get_field_group(AllFieldsResource, :everything)
+      assert :id in fg.fields
+      assert :name in fg.fields
+      assert :email in fg.fields
+      assert :salary in fg.fields
+    end
+
+    test ":all with except resolves to all attributes minus excepted fields" do
+      defmodule AllExceptResource do
+        use Ash.Resource,
+          domain: AshGrant.Test.Domain,
+          data_layer: Ash.DataLayer.Ets,
+          authorizers: [Ash.Policy.Authorizer],
+          extensions: [AshGrant],
+          validate_domain_inclusion?: false
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          default_policies(true)
+          default_field_policies(true)
+          resource_name("all_except_res")
+          scope(:all, true)
+
+          field_group(:public, :all, except: [:salary, :ssn])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+          attribute(:email, :string, public?: true)
+          attribute(:salary, :integer, public?: true)
+          attribute(:ssn, :string, public?: true)
+        end
+
+        actions do
+          defaults([:read, create: :*])
+        end
+      end
+
+      fg = AshGrant.Info.get_field_group(AllExceptResource, :public)
+      assert :id in fg.fields
+      assert :name in fg.fields
+      assert :email in fg.fields
+      refute :salary in fg.fields
+      refute :ssn in fg.fields
+      assert fg.except == [:salary, :ssn]
+    end
+
+    test "except without :all raises compile error" do
+      assert_raise Spark.Error.DslError, ~r/only valid when/, fn ->
+        defmodule ExceptWithoutAll do
+          use Ash.Resource,
+            domain: AshGrant.Test.Domain,
+            data_layer: Ash.DataLayer.Ets,
+            authorizers: [Ash.Policy.Authorizer],
+            extensions: [AshGrant],
+            validate_domain_inclusion?: false
+
+          ash_grant do
+            resolver(fn _, _ -> [] end)
+            default_policies(true)
+            default_field_policies(true)
+            resource_name("except_no_all")
+            scope(:all, true)
+
+            field_group(:bad, [:name, :email], except: [:salary])
+          end
+
+          attributes do
+            uuid_primary_key(:id)
+            attribute(:name, :string, public?: true)
+            attribute(:email, :string, public?: true)
+            attribute(:salary, :integer, public?: true)
+          end
+
+          actions do
+            defaults([:read, create: :*])
+          end
+        end
+      end
+    end
+  end
+
+  # ============================================
+  # New inherits: keyword syntax
+  # ============================================
+
+  describe "inherits: keyword option (new syntax)" do
+    test "field_group with inherits: keyword sets inherits correctly" do
+      defmodule InheritsKeywordResource do
+        use Ash.Resource,
+          domain: AshGrant.Test.Domain,
+          data_layer: Ash.DataLayer.Ets,
+          authorizers: [Ash.Policy.Authorizer],
+          extensions: [AshGrant],
+          validate_domain_inclusion?: false
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          default_policies(true)
+          default_field_policies(true)
+          resource_name("inherits_kw_res")
+          scope(:all, true)
+
+          field_group(:public, [:name, :department])
+          field_group(:sensitive, [:phone, :address], inherits: [:public])
+          field_group(:confidential, [:salary, :email], inherits: [:sensitive])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+          attribute(:department, :string, public?: true)
+          attribute(:phone, :string, public?: true)
+          attribute(:address, :string, public?: true)
+          attribute(:salary, :integer, public?: true)
+          attribute(:email, :string, public?: true)
+        end
+
+        actions do
+          defaults([:read, create: :*])
+        end
+      end
+
+      public = AshGrant.Info.get_field_group(InheritsKeywordResource, :public)
+      assert public.inherits == nil
+      assert public.fields == [:name, :department]
+
+      sensitive = AshGrant.Info.get_field_group(InheritsKeywordResource, :sensitive)
+      assert sensitive.inherits == [:public]
+      assert sensitive.fields == [:phone, :address]
+
+      confidential = AshGrant.Info.get_field_group(InheritsKeywordResource, :confidential)
+      assert confidential.inherits == [:sensitive]
+      assert confidential.fields == [:salary, :email]
+
+      # Verify inheritance resolution
+      resolved = AshGrant.Info.resolve_field_group(InheritsKeywordResource, :confidential)
+      assert :name in resolved.fields
+      assert :department in resolved.fields
+      assert :phone in resolved.fields
+      assert :address in resolved.fields
+      assert :salary in resolved.fields
+      assert :email in resolved.fields
+    end
+
+    test "inherits: with :all and except works" do
+      defmodule InheritsAllExceptResource do
+        use Ash.Resource,
+          domain: AshGrant.Test.Domain,
+          data_layer: Ash.DataLayer.Ets,
+          authorizers: [Ash.Policy.Authorizer],
+          extensions: [AshGrant],
+          validate_domain_inclusion?: false
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          default_policies(true)
+          default_field_policies(true)
+          resource_name("inherits_all_except_res")
+          scope(:all, true)
+
+          field_group(:base, [:name])
+          field_group(:editor, :all, except: [:admin_notes], inherits: [:base])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:name, :string, public?: true)
+          attribute(:email, :string, public?: true)
+          attribute(:admin_notes, :string, public?: true)
+        end
+
+        actions do
+          defaults([:read, create: :*])
+        end
+      end
+
+      fg = AshGrant.Info.get_field_group(InheritsAllExceptResource, :editor)
+      assert fg.inherits == [:base]
+      assert :id in fg.fields
+      assert :name in fg.fields
+      assert :email in fg.fields
+      refute :admin_notes in fg.fields
+    end
+  end
+
+  # ============================================
+  # Deprecation: [:*] still works with warning
+  # ============================================
+
+  describe "[:*] deprecation" do
+    test "[:*] still works but emits deprecation warning" do
+      {result, warning} =
+        with_io(:stderr, fn ->
+          defmodule DeprecatedWildcardResource do
+            use Ash.Resource,
+              domain: AshGrant.Test.Domain,
+              data_layer: Ash.DataLayer.Ets,
+              authorizers: [Ash.Policy.Authorizer],
+              extensions: [AshGrant],
+              validate_domain_inclusion?: false
+
+            ash_grant do
+              resolver(fn _, _ -> [] end)
+              default_policies(true)
+              default_field_policies(true)
+              resource_name("deprecated_wildcard_res")
+              scope(:all, true)
+
+              field_group(:everything, [:*])
+            end
+
+            attributes do
+              uuid_primary_key(:id)
+              attribute(:name, :string, public?: true)
+              attribute(:email, :string, public?: true)
+            end
+
+            actions do
+              defaults([:read, create: :*])
+            end
+          end
+
+          AshGrant.Info.get_field_group(DeprecatedWildcardResource, :everything)
+        end)
+
+      assert warning =~ "deprecated"
+      assert warning =~ ":all"
+
+      # Still resolves correctly
+      assert :id in result.fields
+      assert :name in result.fields
+      assert :email in result.fields
+    end
+
+    test "[:*] with except still works but emits deprecation warning" do
+      {result, warning} =
+        with_io(:stderr, fn ->
+          defmodule DeprecatedWildcardExceptResource do
+            use Ash.Resource,
+              domain: AshGrant.Test.Domain,
+              data_layer: Ash.DataLayer.Ets,
+              authorizers: [Ash.Policy.Authorizer],
+              extensions: [AshGrant],
+              validate_domain_inclusion?: false
+
+            ash_grant do
+              resolver(fn _, _ -> [] end)
+              default_policies(true)
+              default_field_policies(true)
+              resource_name("deprecated_wc_except_res")
+              scope(:all, true)
+
+              field_group(:public, [:*], except: [:salary])
+            end
+
+            attributes do
+              uuid_primary_key(:id)
+              attribute(:name, :string, public?: true)
+              attribute(:salary, :integer, public?: true)
+            end
+
+            actions do
+              defaults([:read, create: :*])
+            end
+          end
+
+          AshGrant.Info.get_field_group(DeprecatedWildcardExceptResource, :public)
+        end)
+
+      assert warning =~ "deprecated"
+      assert warning =~ ":all"
+
+      assert :name in result.fields
+      refute :salary in result.fields
+    end
+  end
+
+  # ============================================
+  # FieldGroup struct type
+  # ============================================
+
+  describe "FieldGroup struct with :all" do
+    test "fields can be :all atom before transformer resolution" do
+      fg = %AshGrant.Dsl.FieldGroup{
+        name: :everything,
+        fields: :all
+      }
+
+      assert fg.fields == :all
+    end
+  end
+end

--- a/test/support/policy_test_fixtures.ex
+++ b/test/support/policy_test_fixtures.ex
@@ -248,7 +248,7 @@ defmodule AshGrant.PolicyTest.Fixtures.FieldVisibilityTest do
 
   resource(AshGrant.Test.ExceptRecord)
 
-  # Actor with :public field_group ([:*] except [:salary, :ssn])
+  # Actor with :public field_group (:all except [:salary, :ssn])
   actor(:public_viewer, %{permissions: ["exceptrecord:*:read:all:public"]})
   # Actor with :full field_group (inherits :public, adds [:salary, :ssn])
   actor(:full_viewer, %{permissions: ["exceptrecord:*:read:all:full"]})
@@ -285,7 +285,7 @@ defmodule AshGrant.PolicyTest.Fixtures.ExceptFieldGroupTest do
 
   resource(AshGrant.Test.ExceptRecord)
 
-  # Actor with :public field_group ([:*] except [:salary, :ssn])
+  # Actor with :public field_group (:all except [:salary, :ssn])
   actor(:public_viewer, %{permissions: ["exceptrecord:*:read:all:public"]})
   # Actor with :full field_group (inherits :public, adds [:salary, :ssn])
   actor(:full_viewer, %{permissions: ["exceptrecord:*:read:all:full"]})

--- a/test/support/resources/except_record.ex
+++ b/test/support/resources/except_record.ex
@@ -2,14 +2,14 @@ defmodule AshGrant.Test.ExceptRecord do
   @moduledoc """
   Test resource for field_group `except` (blacklist) option.
 
-  Uses ETS data layer and defines field groups using the `[:*]` wildcard
+  Uses ETS data layer and defines field groups using `:all`
   with `except` to test the blacklist mode.
 
   ## Field Groups
 
   | Group | Definition | Resolved Fields |
   |-------|-----------|-----------------|
-  | :public | `[:*], except: [:salary, :ssn]` | id, name, department, position, email, phone, address |
+  | :public | `:all, except: [:salary, :ssn]` | id, name, department, position, email, phone, address |
   | :full | inherits :public, adds [:salary, :ssn] | all fields |
   """
   use Ash.Resource,
@@ -32,8 +32,8 @@ defmodule AshGrant.Test.ExceptRecord do
 
     scope(:all, true)
 
-    field_group(:public, [], [:*], except: [:salary, :ssn])
-    field_group(:full, [:public], [:salary, :ssn])
+    field_group(:public, :all, except: [:salary, :ssn])
+    field_group(:full, [:salary, :ssn], inherits: [:public])
   end
 
   attributes do

--- a/test/support/resources/masked_record.ex
+++ b/test/support/resources/masked_record.ex
@@ -46,12 +46,13 @@ defmodule AshGrant.Test.MaskedRecord do
 
     field_group(:public, [:name, :department])
 
-    field_group(:sensitive, [:public], [:phone, :address],
+    field_group(:sensitive, [:phone, :address],
+      inherits: [:public],
       mask: [:phone, :address],
       mask_with: &AshGrant.Test.MaskHelpers.mask_string/2
     )
 
-    field_group(:confidential, [:sensitive], [:salary, :email])
+    field_group(:confidential, [:salary, :email], inherits: [:sensitive])
   end
 
   attributes do

--- a/test/support/resources/sensitive_record.ex
+++ b/test/support/resources/sensitive_record.ex
@@ -34,8 +34,8 @@ defmodule AshGrant.Test.SensitiveRecord do
     scope(:all, true)
 
     field_group(:public, [:name, :department, :position])
-    field_group(:sensitive, [:public], [:phone, :address])
-    field_group(:confidential, [:sensitive], [:salary, :email])
+    field_group(:sensitive, [:phone, :address], inherits: [:public])
+    field_group(:confidential, [:salary, :email], inherits: [:sensitive])
   end
 
   attributes do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -213,7 +213,7 @@ returns `false`, the child is also denied.
 
 ```elixir
 field_group :name, [:field1, :field2]
-field_group :name, [:parent_groups], [:field1, :field2]
+field_group :name, [:field1, :field2], inherits: [:parent_groups]
 ```
 
 Field groups define sets of fields for column-level read authorization.
@@ -223,8 +223,8 @@ ash_grant do
   resolver MyApp.PermissionResolver
 
   field_group :public, [:name, :department, :position]
-  field_group :sensitive, [:public], [:phone, :address]        # Inherits public
-  field_group :confidential, [:sensitive], [:salary, :ssn]     # Inherits sensitive
+  field_group :sensitive, [:phone, :address], inherits: [:public]          # Inherits public
+  field_group :confidential, [:salary, :ssn], inherits: [:sensitive]      # Inherits sensitive
 end
 ```
 
@@ -509,8 +509,8 @@ ash_grant do
   resolver MyApp.PermissionResolver
 
   field_group :public, [:name, :department]
-  field_group :sensitive, [:public], [:phone, :address]
-  field_group :confidential, [:sensitive], [:salary, :ssn]
+  field_group :sensitive, [:phone, :address], inherits: [:public]
+  field_group :confidential, [:salary, :ssn], inherits: [:sensitive]
 end
 
 field_policies do
@@ -538,8 +538,8 @@ ash_grant do
   default_field_policies true
 
   field_group :public, [:name, :department]
-  field_group :sensitive, [:public], [:phone, :address]
-  field_group :confidential, [:sensitive], [:salary, :ssn]
+  field_group :sensitive, [:phone, :address], inherits: [:public]
+  field_group :confidential, [:salary, :ssn], inherits: [:sensitive]
 end
 # field_policies block is generated automatically
 ```


### PR DESCRIPTION
## Summary

- Replace `[:*]` wildcard with `:all` atom to eliminate positional argument ambiguity in `field_group` DSL
- Move `inherits` from positional arg to keyword-only option
- Deprecate old `[:*]` syntax with compile-time warning (removal in v1.0.0)

Closes #40

## BREAKING CHANGES

- `field_group` no longer accepts `inherits` as a positional argument — use `inherits:` keyword
- `[:*]` wildcard replaced by `:all` atom (deprecated with warning)

### Migration

```elixir
# Before
field_group :sensitive, [:public], [:phone, :address]
field_group :admin, [], [:*]
field_group :internal, [], [:*], except: [:ssn]

# After
field_group :sensitive, [:phone, :address], inherits: [:public]
field_group :admin, :all
field_group :internal, :all, except: [:ssn]
```

## Test plan

- [x] TDD: tests written first, all pass
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 741 tests, 0 failures
- [x] `mix format --check-formatted` passes
- [x] `mix credo` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)