### PR TITLE
fix: match action prefix patterns by Ash action type

### DIFF
--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -250,7 +250,12 @@ defmodule AshGrant.Check do
         _module -> configured_name
       end
 
-    action_name = Keyword.get(opts, :action) || to_string(action.name)
+    # When action is overridden via opts, don't infer action_type
+    {action_name, action_type} =
+      case Keyword.get(opts, :action) do
+        nil -> {to_string(action.name), action_type_from(action)}
+        override -> {override, nil}
+      end
 
     # Build context
     context = build_context(actor, resource_module, action, authorizer)
@@ -259,16 +264,21 @@ defmodule AshGrant.Check do
     permissions = resolve_permissions(resolver, actor, context)
 
     # Check access using evaluator
-    case AshGrant.Evaluator.has_access?(permissions, resource_name, action_name) do
+    case AshGrant.Evaluator.has_access?(permissions, resource_name, action_name, action_type) do
       false ->
         false
 
       true ->
         # Has permission, now check scope
-        scope = AshGrant.Evaluator.get_scope(permissions, resource_name, action_name)
+        scope =
+          AshGrant.Evaluator.get_scope(permissions, resource_name, action_name, action_type)
+
         check_scope_access(scope, scope_resolver, context, authorizer, opts)
     end
   end
+
+  defp action_type_from(%{type: type}), do: type
+  defp action_type_from(_), do: nil
 
   defp build_context(actor, resource, action, authorizer) do
     %{

--- a/lib/ash_grant/checks/field_check.ex
+++ b/lib/ash_grant/checks/field_check.ex
@@ -58,6 +58,7 @@ defmodule AshGrant.FieldCheck do
     resource_name = AshGrant.Info.resource_name(resource_module)
     action = authorizer.action
     action_name = to_string(action.name)
+    action_type = action_type_from(action)
 
     context = %{
       actor: actor,
@@ -69,16 +70,24 @@ defmodule AshGrant.FieldCheck do
     permissions = resolve_permissions(resolver, actor, context)
 
     actor_field_groups =
-      AshGrant.Evaluator.get_all_field_groups(permissions, resource_name, action_name)
+      AshGrant.Evaluator.get_all_field_groups(
+        permissions,
+        resource_name,
+        action_name,
+        action_type
+      )
 
     # If no field groups specified in permissions, actor has unrestricted field access
     if actor_field_groups == [] do
       # Check if the actor has any matching permissions at all (for read access)
-      AshGrant.Evaluator.has_access?(permissions, resource_name, action_name)
+      AshGrant.Evaluator.has_access?(permissions, resource_name, action_name, action_type)
     else
       field_group_grants_access?(resource_module, actor_field_groups, required_group)
     end
   end
+
+  defp action_type_from(%{type: type}), do: type
+  defp action_type_from(_), do: nil
 
   # Check if any of the actor's field groups equals or inherits from the required group
   defp field_group_grants_access?(_resource, [], _required), do: false

--- a/lib/ash_grant/checks/filter_check.ex
+++ b/lib/ash_grant/checks/filter_check.ex
@@ -210,7 +210,12 @@ defmodule AshGrant.FilterCheck do
         _module -> configured_name
       end
 
-    action_name = Keyword.get(opts, :action) || to_string(action.name)
+    # When action is overridden via opts, don't infer action_type
+    {action_name, action_type} =
+      case Keyword.get(opts, :action) do
+        nil -> {to_string(action.name), action_type_from(action)}
+        override -> {override, nil}
+      end
 
     # Build context
     context = %{
@@ -224,15 +229,24 @@ defmodule AshGrant.FilterCheck do
     permissions = resolve_permissions(resolver, actor, context)
 
     # Get RBAC scopes (instance_id = "*")
-    scopes = AshGrant.Evaluator.get_all_scopes(permissions, resource_name, action_name)
+    scopes =
+      AshGrant.Evaluator.get_all_scopes(permissions, resource_name, action_name, action_type)
 
     # Get instance permission IDs
     instance_ids =
-      AshGrant.Evaluator.get_matching_instance_ids(permissions, resource_name, action_name)
+      AshGrant.Evaluator.get_matching_instance_ids(
+        permissions,
+        resource_name,
+        action_name,
+        action_type
+      )
 
     # Build combined filter from RBAC scopes + instance IDs
     build_filter_with_instances(scopes, instance_ids, scope_resolver, context)
   end
+
+  defp action_type_from(%{type: type}), do: type
+  defp action_type_from(_), do: nil
 
   defp build_filter_with_instances(scopes, instance_ids, scope_resolver, context) do
     # Check for global access from RBAC

--- a/lib/ash_grant/evaluator.ex
+++ b/lib/ash_grant/evaluator.ex
@@ -137,14 +137,14 @@ defmodule AshGrant.Evaluator do
       false
 
   """
-  @spec has_access?(permissions(), String.t(), String.t()) :: boolean()
-  def has_access?(permissions, resource, action) do
+  @spec has_access?(permissions(), String.t(), String.t(), atom() | nil) :: boolean()
+  def has_access?(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
 
     # Check for deny rules first (deny wins)
     has_deny =
       Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
 
     if has_deny do
@@ -152,7 +152,7 @@ defmodule AshGrant.Evaluator do
     else
       # Check for allow rules
       Enum.any?(permissions, fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
     end
   end
@@ -300,14 +300,14 @@ defmodule AshGrant.Evaluator do
       nil
 
   """
-  @spec get_scope(permissions(), String.t(), String.t()) :: String.t() | nil
-  def get_scope(permissions, resource, action) do
+  @spec get_scope(permissions(), String.t(), String.t(), atom() | nil) :: String.t() | nil
+  def get_scope(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
 
     # First check if denied
     has_deny =
       Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
 
     if has_deny do
@@ -316,7 +316,7 @@ defmodule AshGrant.Evaluator do
       # Find first matching allow permission and return its scope
       permissions
       |> Enum.find(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
       |> case do
         nil -> nil
@@ -338,14 +338,14 @@ defmodule AshGrant.Evaluator do
       ["own", "published", "all"]
 
   """
-  @spec get_all_scopes(permissions(), String.t(), String.t()) :: [String.t()]
-  def get_all_scopes(permissions, resource, action) do
+  @spec get_all_scopes(permissions(), String.t(), String.t(), atom() | nil) :: [String.t()]
+  def get_all_scopes(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
 
     # Check for deny first
     has_deny =
       Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
 
     if has_deny do
@@ -353,7 +353,7 @@ defmodule AshGrant.Evaluator do
     else
       permissions
       |> Enum.filter(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
       |> Enum.map(& &1.scope)
       |> Enum.reject(&is_nil/1)
@@ -378,13 +378,13 @@ defmodule AshGrant.Evaluator do
       nil
 
   """
-  @spec get_field_group(permissions(), String.t(), String.t()) :: String.t() | nil
-  def get_field_group(permissions, resource, action) do
+  @spec get_field_group(permissions(), String.t(), String.t(), atom() | nil) :: String.t() | nil
+  def get_field_group(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
 
     has_deny =
       Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
 
     if has_deny do
@@ -392,7 +392,7 @@ defmodule AshGrant.Evaluator do
     else
       permissions
       |> Enum.find(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
       |> case do
         nil -> nil
@@ -419,13 +419,13 @@ defmodule AshGrant.Evaluator do
       []
 
   """
-  @spec get_all_field_groups(permissions(), String.t(), String.t()) :: [String.t()]
-  def get_all_field_groups(permissions, resource, action) do
+  @spec get_all_field_groups(permissions(), String.t(), String.t(), atom() | nil) :: [String.t()]
+  def get_all_field_groups(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
 
     has_deny =
       Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
 
     if has_deny do
@@ -433,7 +433,7 @@ defmodule AshGrant.Evaluator do
     else
       permissions
       |> Enum.filter(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action)
+        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
       end)
       |> Enum.map(& &1.field_group)
       |> Enum.reject(&is_nil/1)
@@ -452,11 +452,11 @@ defmodule AshGrant.Evaluator do
       2
 
   """
-  @spec find_matching(permissions(), String.t(), String.t()) :: [Permission.t()]
-  def find_matching(permissions, resource, action) do
+  @spec find_matching(permissions(), String.t(), String.t(), atom() | nil) :: [Permission.t()]
+  def find_matching(permissions, resource, action, action_type \\ nil) do
     permissions
     |> normalize_permissions()
-    |> Enum.filter(&Permission.matches?(&1, resource, action))
+    |> Enum.filter(&Permission.matches?(&1, resource, action, action_type))
   end
 
   @doc """
@@ -483,8 +483,9 @@ defmodule AshGrant.Evaluator do
       []
 
   """
-  @spec get_matching_instance_ids(permissions(), String.t(), String.t()) :: [String.t()]
-  def get_matching_instance_ids(permissions, resource, action) do
+  @spec get_matching_instance_ids(permissions(), String.t(), String.t(), atom() | nil) ::
+          [String.t()]
+  def get_matching_instance_ids(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
 
     # Find all instance permissions that match resource and action
@@ -493,7 +494,7 @@ defmodule AshGrant.Evaluator do
       |> Enum.filter(fn perm ->
         Permission.instance_permission?(perm) and
           Permission.matches_resource?(perm.resource, resource) and
-          Permission.matches_action?(perm.action, action)
+          Permission.matches_action?(perm.action, action, action_type)
       end)
 
     # Get denied instance IDs

--- a/lib/ash_grant/explainer.ex
+++ b/lib/ash_grant/explainer.ex
@@ -33,6 +33,13 @@ defmodule AshGrant.Explainer do
     resource_name = Info.resource_name(resource)
     action_str = to_string(action)
 
+    # Resolve action type from Ash resource info
+    action_type =
+      case Ash.Resource.Info.action(resource, action) do
+        %{type: type} -> type
+        _ -> nil
+      end
+
     # Get permissions from resolver
     raw_permissions = get_permissions(resource, actor, context)
 
@@ -43,16 +50,25 @@ defmodule AshGrant.Explainer do
     evaluated =
       Enum.map(permission_inputs, fn input ->
         perm = Permission.from_input(input)
-        matched = Permission.matches?(perm, resource_name, action_str)
+        matched = Permission.matches?(perm, resource_name, action_str, action_type)
         is_deny = Permission.deny?(perm)
 
         reason =
           cond do
-            matched && is_deny -> "Denied by explicit deny rule"
-            matched -> nil
-            !matches_resource?(perm, resource_name) -> "Resource mismatch"
-            !matches_action?(perm, action_str) -> "Action mismatch"
-            true -> "No match"
+            matched && is_deny ->
+              "Denied by explicit deny rule"
+
+            matched ->
+              nil
+
+            !matches_resource?(perm, resource_name) ->
+              "Resource mismatch"
+
+            !Permission.matches_action?(perm.action, action_str, action_type) ->
+              "Action mismatch"
+
+            true ->
+              "No match"
           end
 
         # Get scope info from DSL
@@ -156,9 +172,5 @@ defmodule AshGrant.Explainer do
 
   defp matches_resource?(%Permission{resource: perm_resource}, resource_name) do
     perm_resource == "*" || perm_resource == resource_name
-  end
-
-  defp matches_action?(%Permission{action: perm_action}, action_str) do
-    perm_action == "*" || perm_action == action_str
   end
 end

--- a/lib/ash_grant/introspect.ex
+++ b/lib/ash_grant/introspect.ex
@@ -86,18 +86,21 @@ defmodule AshGrant.Introspect do
 
     Enum.map(actions, fn action ->
       action_name = to_string(action.name)
+      action_type = action.type
 
       # Check RBAC permissions
-      scopes = Evaluator.get_all_scopes(permissions, resource_name, action_name)
+      scopes = Evaluator.get_all_scopes(permissions, resource_name, action_name, action_type)
 
       # Check for deny
-      has_deny = has_deny_permission?(permissions, resource_name, action_name)
+      has_deny = has_deny_permission?(permissions, resource_name, action_name, action_type)
 
       # Check instance permissions
-      instance_ids = Evaluator.get_matching_instance_ids(permissions, resource_name, action_name)
+      instance_ids =
+        Evaluator.get_matching_instance_ids(permissions, resource_name, action_name, action_type)
 
       # Check field groups
-      field_groups = Evaluator.get_all_field_groups(permissions, resource_name, action_name)
+      field_groups =
+        Evaluator.get_all_field_groups(permissions, resource_name, action_name, action_type)
 
       # Determine status
       allowed = (scopes != [] or instance_ids != []) and not has_deny
@@ -207,21 +210,34 @@ defmodule AshGrant.Introspect do
       action_name = to_string(action)
       permissions = permissions_for(resource, actor, context: context)
 
+      # Resolve action type from Ash resource info
+      action_type =
+        case Ash.Resource.Info.action(resource, action) do
+          %{type: type} -> type
+          _ -> nil
+        end
+
       # Check for deny first
-      has_deny = has_deny_permission?(permissions, resource_name, action_name)
+      has_deny = has_deny_permission?(permissions, resource_name, action_name, action_type)
 
       if has_deny do
         {:deny, %{reason: :denied_by_rule}}
       else
         # Check RBAC scopes
-        scopes = Evaluator.get_all_scopes(permissions, resource_name, action_name)
+        scopes = Evaluator.get_all_scopes(permissions, resource_name, action_name, action_type)
 
         # Check instance permissions
         instance_ids =
-          Evaluator.get_matching_instance_ids(permissions, resource_name, action_name)
+          Evaluator.get_matching_instance_ids(
+            permissions,
+            resource_name,
+            action_name,
+            action_type
+          )
 
         # Check field groups
-        field_groups = Evaluator.get_all_field_groups(permissions, resource_name, action_name)
+        field_groups =
+          Evaluator.get_all_field_groups(permissions, resource_name, action_name, action_type)
 
         cond do
           scopes != [] ->
@@ -328,11 +344,12 @@ defmodule AshGrant.Introspect do
     Ash.Resource.Info.actions(resource)
   end
 
-  defp has_deny_permission?(permissions, resource_name, action_name) do
+  defp has_deny_permission?(permissions, resource_name, action_name, action_type) do
     permissions
     |> Enum.map(&normalize_permission/1)
     |> Enum.any?(fn perm ->
-      Permission.deny?(perm) and Permission.matches?(perm, resource_name, action_name)
+      Permission.deny?(perm) and
+        Permission.matches?(perm, resource_name, action_name, action_type)
     end)
   end
 

--- a/lib/ash_grant/permission.ex
+++ b/lib/ash_grant/permission.ex
@@ -333,12 +333,33 @@ defmodule AshGrant.Permission do
 
   """
   @spec matches?(t(), String.t(), String.t()) :: boolean()
-  def matches?(%__MODULE__{instance_id: "*"} = perm, resource, action) do
+  def matches?(perm, resource, action), do: matches?(perm, resource, action, nil)
+
+  @doc """
+  Checks if a permission matches a resource, action, and optional Ash action type.
+
+  When `action_type` is provided, prefix patterns like `"read*"` will also match
+  actions whose Ash type equals the prefix (e.g., a `:read`-type action named
+  `list_published` matches `"read*"`).
+
+  ## Examples
+
+      iex> perm = AshGrant.Permission.parse!("blog:*:read*:all")
+      iex> AshGrant.Permission.matches?(perm, "blog", "list_published", :read)
+      true
+
+      iex> perm = AshGrant.Permission.parse!("blog:*:read*:all")
+      iex> AshGrant.Permission.matches?(perm, "blog", "list_published", :update)
+      false
+
+  """
+  @spec matches?(t(), String.t(), String.t(), atom() | nil) :: boolean()
+  def matches?(%__MODULE__{instance_id: "*"} = perm, resource, action, action_type) do
     matches_resource?(perm.resource, resource) and
-      matches_action?(perm.action, action)
+      matches_action?(perm.action, action, action_type)
   end
 
-  def matches?(%__MODULE__{}, _resource, _action) do
+  def matches?(%__MODULE__{}, _resource, _action, _action_type) do
     # Instance-level permissions don't match RBAC queries
     false
   end
@@ -426,12 +447,41 @@ defmodule AshGrant.Permission do
 
   """
   @spec matches_action?(String.t(), String.t()) :: boolean()
-  def matches_action?("*", _action), do: true
+  def matches_action?(pattern, action), do: matches_action?(pattern, action, nil)
 
-  def matches_action?(pattern, action) do
+  @doc """
+  Checks if an action pattern matches an action name, with optional Ash action type.
+
+  When `action_type` is provided and the pattern is a prefix wildcard like `"read*"`,
+  the match succeeds if the action name starts with the prefix **OR** the action type
+  matches the prefix. This allows `"read*"` to match `:read`-type actions like
+  `list_published` or `by_slug`.
+
+  ## Examples
+
+      iex> AshGrant.Permission.matches_action?("*", "anything", :read)
+      true
+      iex> AshGrant.Permission.matches_action?("read*", "list_published", :read)
+      true
+      iex> AshGrant.Permission.matches_action?("read*", "list_published", :update)
+      false
+      iex> AshGrant.Permission.matches_action?("read*", "read_all", nil)
+      true
+      iex> AshGrant.Permission.matches_action?("update*", "publish", :update)
+      true
+      iex> AshGrant.Permission.matches_action?("read", "read", :read)
+      true
+
+  """
+  @spec matches_action?(String.t(), String.t(), atom() | nil) :: boolean()
+  def matches_action?("*", _action, _action_type), do: true
+
+  def matches_action?(pattern, action, action_type) do
     if String.ends_with?(pattern, "*") do
       prefix = String.trim_trailing(pattern, "*")
-      String.starts_with?(action, prefix)
+
+      String.starts_with?(action, prefix) or
+        (action_type != nil and Atom.to_string(action_type) == prefix)
     else
       pattern == action
     end

--- a/test/ash_grant/evaluator_test.exs
+++ b/test/ash_grant/evaluator_test.exs
@@ -420,6 +420,102 @@ defmodule AshGrant.EvaluatorTest do
     end
   end
 
+  describe "has_access?/4 with action_type" do
+    test "read* matches :read type action with non-prefixed name" do
+      permissions = ["blog:*:read*:all"]
+      assert Evaluator.has_access?(permissions, "blog", "list_published", :read)
+    end
+
+    test "read* does NOT match :update type with non-prefixed name" do
+      permissions = ["blog:*:read*:all"]
+      refute Evaluator.has_access?(permissions, "blog", "list_published", :update)
+    end
+
+    test "deny-wins with action_type" do
+      permissions = [
+        "blog:*:read*:all",
+        "!blog:*:read*:all"
+      ]
+
+      refute Evaluator.has_access?(permissions, "blog", "list_published", :read)
+    end
+
+    test "backward compat: 3-arg has_access? unchanged" do
+      permissions = ["blog:*:read*:all"]
+      assert Evaluator.has_access?(permissions, "blog", "read")
+      assert Evaluator.has_access?(permissions, "blog", "read_all")
+      refute Evaluator.has_access?(permissions, "blog", "list_published")
+    end
+
+    test "update* matches :update type for publish action" do
+      permissions = ["blog:*:update*:own"]
+      assert Evaluator.has_access?(permissions, "blog", "publish", :update)
+      refute Evaluator.has_access?(permissions, "blog", "publish", :read)
+    end
+  end
+
+  describe "get_scope/4 with action_type" do
+    test "returns scope when read* matches via action_type" do
+      permissions = ["blog:*:read*:published"]
+      assert Evaluator.get_scope(permissions, "blog", "list_published", :read) == "published"
+    end
+
+    test "returns nil when action_type doesn't match" do
+      permissions = ["blog:*:read*:all"]
+      assert Evaluator.get_scope(permissions, "blog", "list_published", :update) == nil
+    end
+
+    test "returns nil when denied with action_type" do
+      permissions = ["blog:*:read*:all", "!blog:*:read*:all"]
+      assert Evaluator.get_scope(permissions, "blog", "by_slug", :read) == nil
+    end
+  end
+
+  describe "get_all_scopes/4 with action_type" do
+    test "returns all scopes matching via action_type" do
+      permissions = [
+        "blog:*:read*:own",
+        "blog:*:read*:published"
+      ]
+
+      scopes = Evaluator.get_all_scopes(permissions, "blog", "search", :read)
+      assert "own" in scopes
+      assert "published" in scopes
+    end
+
+    test "returns empty when denied with action_type" do
+      permissions = ["blog:*:read*:all", "!blog:*:read*:all"]
+      assert Evaluator.get_all_scopes(permissions, "blog", "search", :read) == []
+    end
+  end
+
+  describe "get_all_field_groups/4 with action_type" do
+    test "returns field groups matching via action_type" do
+      permissions = ["employee:*:read*:all:sensitive"]
+
+      assert Evaluator.get_all_field_groups(permissions, "employee", "by_department", :read) == [
+               "sensitive"
+             ]
+    end
+  end
+
+  describe "find_matching/4 with action_type" do
+    test "finds permissions matching via action_type" do
+      permissions = ["blog:*:read*:all", "blog:*:update*:own"]
+      matching = Evaluator.find_matching(permissions, "blog", "search", :read)
+      assert length(matching) == 1
+    end
+  end
+
+  describe "get_matching_instance_ids/4 with action_type" do
+    test "matches instance permissions via action_type" do
+      permissions = ["blog:post_abc:read*:", "blog:post_xyz:read*:"]
+      ids = Evaluator.get_matching_instance_ids(permissions, "blog", "by_slug", :read)
+      assert "post_abc" in ids
+      assert "post_xyz" in ids
+    end
+  end
+
   describe "combine/1" do
     test "combines multiple permission lists" do
       role_perms = ["blog:*:read:all"]

--- a/test/ash_grant/permission_property_test.exs
+++ b/test/ash_grant/permission_property_test.exs
@@ -389,6 +389,64 @@ defmodule AshGrant.PermissionPropertyTest do
     end
   end
 
+  describe "action_type matching" do
+    property "prefix* always matches its own action_type regardless of action name" do
+      check all(
+              type <- member_of([:read, :create, :update, :destroy]),
+              action_name <-
+                string(:alphanumeric, min_length: 1, max_length: 15)
+                |> map(&String.downcase/1)
+                |> filter(fn name ->
+                  # Exclude names that happen to start with the type prefix
+                  not String.starts_with?(name, Atom.to_string(type))
+                end)
+            ) do
+        pattern = Atom.to_string(type) <> "*"
+        assert Permission.matches_action?(pattern, action_name, type)
+      end
+    end
+
+    property "prefix* does not match a different action_type when name doesn't start with prefix" do
+      check all(
+              type <- member_of([:read, :create, :update, :destroy]),
+              other_type <-
+                member_of([:read, :create, :update, :destroy]) |> filter(&(&1 != type)),
+              action_name <-
+                string(:alphanumeric, min_length: 1, max_length: 15)
+                |> map(&String.downcase/1)
+                |> filter(fn name ->
+                  not String.starts_with?(name, Atom.to_string(type))
+                end)
+            ) do
+        pattern = Atom.to_string(type) <> "*"
+        refute Permission.matches_action?(pattern, action_name, other_type)
+      end
+    end
+
+    property "matches?/4 with action_type is consistent with matches_action?/3" do
+      check all(
+              resource <-
+                string(:alphanumeric, min_length: 1, max_length: 10) |> map(&String.downcase/1),
+              type <- member_of([:read, :create, :update, :destroy]),
+              action_name <-
+                string(:alphanumeric, min_length: 1, max_length: 10) |> map(&String.downcase/1)
+            ) do
+        pattern = Atom.to_string(type) <> "*"
+
+        perm = %Permission{
+          resource: resource,
+          instance_id: "*",
+          action: pattern,
+          scope: "all",
+          deny: false
+        }
+
+        assert Permission.matches?(perm, resource, action_name, type) ==
+                 Permission.matches_action?(pattern, action_name, type)
+      end
+    end
+  end
+
   describe "edge cases" do
     property "empty scope becomes nil" do
       check all(

--- a/test/ash_grant/permission_test.exs
+++ b/test/ash_grant/permission_test.exs
@@ -374,6 +374,79 @@ defmodule AshGrant.PermissionTest do
     end
   end
 
+  describe "matches_action?/3 with action_type" do
+    test "read* matches :read type regardless of action name" do
+      assert Permission.matches_action?("read*", "list_published", :read)
+      assert Permission.matches_action?("read*", "by_slug", :read)
+      assert Permission.matches_action?("read*", "search", :read)
+    end
+
+    test "read* still matches actions starting with read (string prefix)" do
+      assert Permission.matches_action?("read*", "read", :read)
+      assert Permission.matches_action?("read*", "read_all", :update)
+      assert Permission.matches_action?("read*", "read_published", nil)
+    end
+
+    test "read* does NOT match :update type when name doesn't start with read" do
+      refute Permission.matches_action?("read*", "list_published", :update)
+      refute Permission.matches_action?("read*", "by_slug", :destroy)
+    end
+
+    test "update* matches :update type regardless of action name" do
+      assert Permission.matches_action?("update*", "publish", :update)
+      assert Permission.matches_action?("update*", "archive", :update)
+    end
+
+    test "create* matches :create type regardless of action name" do
+      assert Permission.matches_action?("create*", "register", :create)
+      assert Permission.matches_action?("create*", "signup", :create)
+    end
+
+    test "destroy* matches :destroy type regardless of action name" do
+      assert Permission.matches_action?("destroy*", "soft_delete", :destroy)
+      assert Permission.matches_action?("destroy*", "purge", :destroy)
+    end
+
+    test "exact match still works with action_type" do
+      assert Permission.matches_action?("read", "read", :read)
+      refute Permission.matches_action?("read", "list_published", :read)
+    end
+
+    test "wildcard * matches anything regardless of action_type" do
+      assert Permission.matches_action?("*", "anything", :read)
+      assert Permission.matches_action?("*", "anything", nil)
+    end
+
+    test "backward compat: 2-arg calls still work" do
+      assert Permission.matches_action?("read*", "read_all")
+      assert Permission.matches_action?("*", "anything")
+      refute Permission.matches_action?("read", "write")
+    end
+  end
+
+  describe "matches?/4 with action_type" do
+    test "read* matches :read type action with non-prefixed name" do
+      perm = Permission.parse!("blog:*:read*:all")
+      assert Permission.matches?(perm, "blog", "list_published", :read)
+    end
+
+    test "read* does NOT match :update type with non-prefixed name" do
+      perm = Permission.parse!("blog:*:read*:all")
+      refute Permission.matches?(perm, "blog", "list_published", :update)
+    end
+
+    test "backward compat: 3-arg matches? still works" do
+      perm = Permission.parse!("blog:*:read*:all")
+      assert Permission.matches?(perm, "blog", "read_published")
+      refute Permission.matches?(perm, "blog", "list_published")
+    end
+
+    test "instance permission still returns false for matches?/4" do
+      perm = Permission.parse!("blog:post_abc123:read*:")
+      refute Permission.matches?(perm, "blog", "list_published", :read)
+    end
+  end
+
   describe "String.Chars protocol" do
     test "converts to string" do
       perm = Permission.parse!("blog:*:read:all")


### PR DESCRIPTION
## Summary

- `read*` permission pattern now matches any `:read`-type Ash action (e.g., `list_published`, `by_slug`, `search`), not just actions whose name starts with `"read"`
- Same for `create*`, `update*`, `destroy*` — all match by Ash action type
- Fixes Explainer's local `matches_action?/2` which only did exact match (no prefix support)
- Fully backward compatible: existing 2-arg/3-arg calls default `action_type` to `nil`

### Changes

| File | What |
|------|------|
| `permission.ex` | Added `matches_action?/3` and `matches?/4` with `action_type` param |
| `evaluator.ex` | Added optional `action_type` to 7 RBAC functions |
| `check.ex`, `filter_check.ex`, `field_check.ex` | Extract and pass `action.type` to Evaluator |
| `introspect.ex` | Resolve `action.type` via `Ash.Resource.Info.action/2` |
| `explainer.ex` | Use `Permission.matches?/4`, removed buggy local helper |
| Tests | 26 new unit tests + 3 new property tests |

## Test plan

- [x] `mix compile --warnings-as-errors` — no warnings
- [x] `mix test` — 767 tests, 38 doctests, 96 properties, 0 failures
- [x] `mix format --check-formatted` — pass
- [x] `mix credo` — no new issues
- [x] Backward compatibility: all existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)