### PR TITLE
feat: domain-level DSL for shared resolver and scope inheritance

### DIFF
--- a/lib/ash_grant.ex
+++ b/lib/ash_grant.ex
@@ -302,6 +302,8 @@ defmodule AshGrant do
   use Spark.Dsl.Extension,
     sections: AshGrant.Dsl.sections(),
     transformers: [
+      AshGrant.Transformers.MergeDomainConfig,
+      AshGrant.Transformers.ValidateResolverPresent,
       AshGrant.Transformers.ValidateScopes,
       AshGrant.Transformers.ResolveFieldGroupFields,
       AshGrant.Transformers.ValidateFieldGroups,

--- a/lib/ash_grant/domain.ex
+++ b/lib/ash_grant/domain.ex
@@ -1,0 +1,43 @@
+defmodule AshGrant.Domain do
+  @moduledoc """
+  Domain-level extension for AshGrant.
+
+  Add this extension to an Ash domain to define shared `resolver` and `scope`
+  configurations that are automatically inherited by all resources in the domain
+  that use the `AshGrant` extension.
+
+  Resources can override any inherited setting by defining their own.
+
+  ## Example
+
+      defmodule MyApp.Blog do
+        use Ash.Domain,
+          extensions: [AshGrant.Domain]
+
+        ash_grant do
+          resolver MyApp.PermissionResolver
+
+          scope :all, true
+          scope :own, expr(author_id == ^actor(:id))
+        end
+
+        resources do
+          resource MyApp.Blog.Post
+          resource MyApp.Blog.Comment
+        end
+      end
+
+  ## Inheritance Rules
+
+  | Config | Resource has it | Domain has it | Result |
+  |--------|----------------|---------------|--------|
+  | resolver | Yes | Yes | Resource wins |
+  | resolver | No | Yes | Domain's resolver used |
+  | scope (same name) | Yes | Yes | Resource wins (override) |
+  | scope | No | Yes | Domain scope inherited |
+  """
+
+  use Spark.Dsl.Extension,
+    sections: AshGrant.Domain.Dsl.sections(),
+    transformers: []
+end

--- a/lib/ash_grant/domain/dsl.ex
+++ b/lib/ash_grant/domain/dsl.ex
@@ -1,0 +1,71 @@
+defmodule AshGrant.Domain.Dsl do
+  @moduledoc """
+  DSL definition for the AshGrant domain-level extension.
+
+  This module defines the `ash_grant` DSL section that can be added to
+  Ash domains to configure shared permission settings inherited by resources.
+
+  Only `resolver` and `scope` entities are supported at the domain level.
+  Resource-specific options like `resource_name`, `default_policies`, and
+  `field_group` must be configured on each resource.
+
+  ## Example
+
+      defmodule MyApp.Blog do
+        use Ash.Domain,
+          extensions: [AshGrant.Domain]
+
+        ash_grant do
+          resolver MyApp.PermissionResolver
+
+          scope :all, true
+          scope :own, expr(author_id == ^actor(:id))
+        end
+
+        resources do
+          resource MyApp.Blog.Post   # inherits resolver + scopes
+          resource MyApp.Blog.Comment # inherits resolver + scopes
+        end
+      end
+  """
+
+  @ash_grant %Spark.Dsl.Section{
+    name: :ash_grant,
+    top_level?: false,
+    imports: [Ash.Expr],
+    describe: """
+    Shared AshGrant configuration inherited by resources in this domain.
+
+    Resources using the `AshGrant` extension will inherit the `resolver` and
+    `scope` definitions from their domain, unless they define their own.
+    """,
+    examples: [
+      """
+      ash_grant do
+        resolver MyApp.PermissionResolver
+
+        scope :all, true
+        scope :own, expr(author_id == ^actor(:id))
+      end
+      """
+    ],
+    entities: [AshGrant.Dsl.scope_entity()],
+    schema: [
+      resolver: [
+        type: {:or, [{:behaviour, AshGrant.PermissionResolver}, {:fun, 2}]},
+        required: false,
+        doc: """
+        Module implementing `AshGrant.PermissionResolver` behaviour,
+        or a 2-arity function `(actor, context) -> permissions`.
+
+        This resolver is inherited by all resources in the domain that
+        use the `AshGrant` extension and don't define their own resolver.
+        """
+      ]
+    ]
+  }
+
+  @sections [@ash_grant]
+
+  def sections, do: @sections
+end

--- a/lib/ash_grant/domain/info.ex
+++ b/lib/ash_grant/domain/info.ex
@@ -1,0 +1,45 @@
+defmodule AshGrant.Domain.Info do
+  @moduledoc """
+  Introspection helpers for AshGrant domain-level DSL configuration.
+
+  Used internally by `AshGrant.Transformers.MergeDomainConfig` to read
+  domain-level settings and merge them into resources.
+  """
+
+  @doc """
+  Gets the permission resolver configured on the domain.
+  """
+  @spec resolver(Ash.Domain.t()) :: module() | function() | nil
+  def resolver(domain) do
+    Spark.Dsl.Extension.get_opt(domain, [:ash_grant], :resolver)
+  end
+
+  @doc """
+  Gets all scope definitions from the domain.
+  """
+  @spec scopes(Ash.Domain.t()) :: [AshGrant.Dsl.Scope.t()]
+  def scopes(domain) do
+    Spark.Dsl.Extension.get_entities(domain, [:ash_grant])
+    |> Enum.filter(&match?(%AshGrant.Dsl.Scope{}, &1))
+  end
+
+  @doc """
+  Gets a specific scope by name from the domain.
+  """
+  @spec get_scope(Ash.Domain.t(), atom()) :: AshGrant.Dsl.Scope.t() | nil
+  def get_scope(domain, name) do
+    scopes(domain)
+    |> Enum.find(&(&1.name == name))
+  end
+
+  @doc """
+  Returns true if the domain has the `AshGrant.Domain` extension configured.
+  """
+  @spec configured?(Ash.Domain.t()) :: boolean()
+  def configured?(domain) do
+    extensions = Spark.extensions(domain)
+    AshGrant.Domain in extensions
+  rescue
+    _ -> false
+  end
+end

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -211,6 +211,11 @@ defmodule AshGrant.Dsl do
     ]
   }
 
+  @doc """
+  Returns the scope entity definition for reuse by `AshGrant.Domain.Dsl`.
+  """
+  def scope_entity, do: @scope
+
   @field_group %Spark.Dsl.Entity{
     name: :field_group,
     describe: """
@@ -314,12 +319,13 @@ defmodule AshGrant.Dsl do
     schema: [
       resolver: [
         type: {:or, [{:behaviour, AshGrant.PermissionResolver}, {:fun, 2}]},
-        required: true,
+        required: false,
         doc: """
         Module implementing `AshGrant.PermissionResolver` behaviour,
         or a 2-arity function `(actor, context) -> permissions`.
 
         This resolves permissions for the current actor.
+        Can be inherited from the domain if the domain uses `AshGrant.Domain`.
         """
       ],
       scope_resolver: [

--- a/lib/ash_grant/transformers/merge_domain_config.ex
+++ b/lib/ash_grant/transformers/merge_domain_config.ex
@@ -1,0 +1,80 @@
+defmodule AshGrant.Transformers.MergeDomainConfig do
+  @moduledoc """
+  Spark DSL transformer that merges domain-level AshGrant configuration into resources.
+
+  This transformer runs on resources (registered in the `AshGrant` extension) and
+  copies `resolver` and `scope` definitions from the domain if the domain uses
+  `AshGrant.Domain`.
+
+  ## Merge Rules
+
+  - **Resolver**: Inherited from domain only if the resource has no resolver.
+  - **Scopes**: Domain scopes are added to the resource unless the resource
+    defines a scope with the same name (resource wins).
+
+  This transformer runs before all other AshGrant transformers so that downstream
+  consumers (`Info`, `Check`, `FilterCheck`, etc.) see the merged state.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+
+  @impl true
+  def before?(_), do: true
+
+  @impl true
+  def after?(_), do: false
+
+  @impl true
+  def transform(dsl_state) do
+    domain = Transformer.get_persisted(dsl_state, :domain)
+
+    if domain && domain_has_ash_grant?(domain) do
+      dsl_state = maybe_merge_resolver(dsl_state, domain)
+      dsl_state = merge_scopes(dsl_state, domain)
+      {:ok, dsl_state}
+    else
+      {:ok, dsl_state}
+    end
+  end
+
+  defp domain_has_ash_grant?(domain) do
+    AshGrant.Domain.Info.configured?(domain)
+  end
+
+  defp maybe_merge_resolver(dsl_state, domain) do
+    resource_resolver = Transformer.get_option(dsl_state, [:ash_grant], :resolver)
+
+    if resource_resolver do
+      dsl_state
+    else
+      case AshGrant.Domain.Info.resolver(domain) do
+        nil ->
+          dsl_state
+
+        domain_resolver ->
+          Transformer.set_option(dsl_state, [:ash_grant], :resolver, domain_resolver)
+      end
+    end
+  end
+
+  defp merge_scopes(dsl_state, domain) do
+    resource_scopes = get_scope_entities(dsl_state)
+    resource_scope_names = MapSet.new(resource_scopes, & &1.name)
+    domain_scopes = AshGrant.Domain.Info.scopes(domain)
+
+    Enum.reduce(domain_scopes, dsl_state, fn domain_scope, acc ->
+      if MapSet.member?(resource_scope_names, domain_scope.name) do
+        acc
+      else
+        Transformer.add_entity(acc, [:ash_grant], domain_scope)
+      end
+    end)
+  end
+
+  defp get_scope_entities(dsl_state) do
+    Transformer.get_entities(dsl_state, [:ash_grant])
+    |> Enum.filter(&match?(%AshGrant.Dsl.Scope{}, &1))
+  end
+end

--- a/lib/ash_grant/transformers/validate_resolver_present.ex
+++ b/lib/ash_grant/transformers/validate_resolver_present.ex
@@ -1,0 +1,55 @@
+defmodule AshGrant.Transformers.ValidateResolverPresent do
+  @moduledoc """
+  Spark DSL transformer that validates a resolver is present after domain merge.
+
+  This runs after `MergeDomainConfig` and before `ValidateScopes`.
+  It raises a compile error if no resolver was found from either the resource
+  or the domain.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+
+  @impl true
+  def after?(AshGrant.Transformers.MergeDomainConfig), do: true
+  def after?(_), do: false
+
+  @impl true
+  def before?(AshGrant.Transformers.MergeDomainConfig), do: false
+  def before?(_), do: true
+
+  @impl true
+  def transform(dsl_state) do
+    resolver = Transformer.get_option(dsl_state, [:ash_grant], :resolver)
+
+    if resolver do
+      {:ok, dsl_state}
+    else
+      resource = Transformer.get_persisted(dsl_state, :module)
+
+      {:error,
+       Spark.Error.DslError.exception(
+         module: resource,
+         path: [:ash_grant, :resolver],
+         message: """
+         No resolver configured for #{inspect(resource)}.
+
+         Either set a resolver on the resource:
+
+             ash_grant do
+               resolver MyApp.PermissionResolver
+             end
+
+         Or set one on the domain using the AshGrant.Domain extension:
+
+             use Ash.Domain, extensions: [AshGrant.Domain]
+
+             ash_grant do
+               resolver MyApp.PermissionResolver
+             end
+         """
+       )}
+    end
+  end
+end

--- a/test/ash_grant/domain_inheritance_test.exs
+++ b/test/ash_grant/domain_inheritance_test.exs
@@ -1,0 +1,481 @@
+defmodule AshGrant.DomainInheritanceTest do
+  use ExUnit.Case, async: true
+
+  alias AshGrant.Info
+  alias AshGrant.Test.DomainInheritedPost
+  alias AshGrant.Test.DomainOverridePost
+  alias AshGrant.Test.DomainMinimalPost
+  alias AshGrant.Test.DomainCrossInheritPost
+  alias AshGrant.Test.ResolverOnlyPost
+  alias AshGrant.Test.ScopesOnlyPost
+
+  # ── helpers ──────────────────────────────────────────────
+
+  defp actor(id, perms), do: %{id: id, permissions: perms}
+
+  defp create!(resource, attrs) do
+    resource
+    |> Ash.Changeset.for_create(:create, attrs, authorize?: false)
+    |> Ash.create!()
+  end
+
+  defp read_ids(resource, actor) do
+    resource
+    |> Ash.read!(actor: actor)
+    |> Enum.map(& &1.id)
+    |> MapSet.new()
+  end
+
+  # ── DSL introspection: resolver ──────────────────────────
+
+  describe "resolver inheritance" do
+    test "resource inherits resolver from domain" do
+      resolver = Info.resolver(DomainInheritedPost)
+      assert is_function(resolver, 2)
+
+      a = %{permissions: ["domain_inherited_post:*:read:all"]}
+      assert resolver.(a, %{}) == ["domain_inherited_post:*:read:all"]
+    end
+
+    test "resource resolver takes precedence over domain" do
+      resolver = Info.resolver(DomainOverridePost)
+      assert is_function(resolver, 2)
+
+      assert resolver.(%{role: :admin}, %{}) == ["domain_override_post:*:*:all"]
+    end
+
+    test "existing resource in plain domain keeps own resolver" do
+      resolver = Info.resolver(AshGrant.Test.Post)
+      assert is_function(resolver, 2)
+      assert resolver.(%{role: :admin}, %{}) == ["post:*:*:all"]
+    end
+
+    test "domain provides resolver only, resource adds scopes" do
+      resolver = Info.resolver(ResolverOnlyPost)
+      assert is_function(resolver, 2)
+
+      a = %{permissions: ["resolver_only_post:*:read:all"]}
+      assert resolver.(a, %{}) == ["resolver_only_post:*:read:all"]
+    end
+
+    test "resource provides resolver, domain provides scopes only" do
+      resolver = Info.resolver(ScopesOnlyPost)
+      assert is_function(resolver, 2)
+
+      a = %{permissions: ["scopes_only_post:*:read:all"]}
+      assert resolver.(a, %{}) == ["scopes_only_post:*:read:all"]
+    end
+  end
+
+  # ── DSL introspection: scopes ────────────────────────────
+
+  describe "scope inheritance" do
+    test "resource inherits all scopes from domain" do
+      names = scope_names(DomainInheritedPost)
+      assert :all in names
+      assert :own in names
+    end
+
+    test "resource scope overrides domain scope with same name" do
+      filter_str =
+        DomainOverridePost
+        |> Info.resolve_scope_filter(:own, %{})
+        |> inspect()
+
+      # resource uses creator_id, domain uses author_id
+      assert filter_str =~ "creator_id"
+      refute filter_str =~ "author_id"
+    end
+
+    test "resource adds scopes beyond domain's" do
+      names = scope_names(DomainMinimalPost)
+      assert :all in names
+      assert :own in names
+      assert :published in names
+    end
+
+    test "domain and resource scopes are merged (no duplicates)" do
+      assert scope_names(DomainMinimalPost) |> Enum.sort() == [:all, :own, :published]
+    end
+
+    test "domain :all scope inherits correctly as true" do
+      assert Info.resolve_scope_filter(DomainInheritedPost, :all, %{}) == true
+    end
+
+    test "domain provides scopes only, resource inherits them" do
+      names = scope_names(ScopesOnlyPost)
+      assert :all in names
+      assert :own in names
+      assert :published in names
+    end
+
+    test "domain provides resolver only, resource defines own scopes" do
+      names = scope_names(ResolverOnlyPost)
+      assert :all in names
+      assert :own in names
+    end
+
+    test "unknown scope returns false" do
+      assert Info.resolve_scope_filter(DomainInheritedPost, :nonexistent, %{}) == false
+    end
+  end
+
+  # ── cross-boundary scope inheritance ─────────────────────
+
+  describe "cross-boundary scope inheritance" do
+    test "resource scope inherits from domain-defined parent" do
+      scope = Info.get_scope(DomainCrossInheritPost, :own_draft)
+      assert scope.inherits == [:own]
+
+      # :own must be present (merged from domain)
+      assert Info.get_scope(DomainCrossInheritPost, :own) != nil
+    end
+
+    test "resolve_scope_filter combines parent and child" do
+      filter_str =
+        DomainCrossInheritPost
+        |> Info.resolve_scope_filter(:own_draft, %{})
+        |> inspect()
+
+      # :own (author_id) AND :own_draft (status == :draft)
+      assert filter_str =~ "author_id"
+      assert filter_str =~ "status"
+    end
+
+    test "resolve_write_scope_filter works with domain-inherited parent" do
+      filter_str =
+        DomainCrossInheritPost
+        |> Info.resolve_write_scope_filter(:own_draft, %{})
+        |> inspect()
+
+      assert filter_str =~ "author_id"
+      assert filter_str =~ "status"
+    end
+  end
+
+  # ── Domain.Info unit tests ───────────────────────────────
+
+  describe "AshGrant.Domain.Info" do
+    test "configured? returns true for domain with AshGrant.Domain" do
+      assert AshGrant.Domain.Info.configured?(AshGrant.Test.GrantDomain)
+    end
+
+    test "configured? returns false for domain without AshGrant.Domain" do
+      refute AshGrant.Domain.Info.configured?(AshGrant.Test.Domain)
+    end
+
+    test "resolver/1 returns domain resolver" do
+      resolver = AshGrant.Domain.Info.resolver(AshGrant.Test.GrantDomain)
+      assert is_function(resolver, 2)
+    end
+
+    test "resolver/1 returns nil when domain has no resolver" do
+      assert AshGrant.Domain.Info.resolver(AshGrant.Test.ScopesOnlyDomain) == nil
+    end
+
+    test "scopes/1 returns domain scopes" do
+      names =
+        AshGrant.Test.GrantDomain
+        |> AshGrant.Domain.Info.scopes()
+        |> Enum.map(& &1.name)
+
+      assert :all in names
+      assert :own in names
+    end
+
+    test "scopes/1 returns empty for domain with no scopes" do
+      assert AshGrant.Domain.Info.scopes(AshGrant.Test.ResolverOnlyDomain) == []
+    end
+
+    test "get_scope/2 finds a scope by name" do
+      scope = AshGrant.Domain.Info.get_scope(AshGrant.Test.GrantDomain, :own)
+      assert scope.name == :own
+    end
+
+    test "get_scope/2 returns nil for unknown scope" do
+      assert AshGrant.Domain.Info.get_scope(AshGrant.Test.GrantDomain, :nope) == nil
+    end
+  end
+
+  # ── validation ───────────────────────────────────────────
+
+  describe "validation" do
+    test "compile error when no resolver in resource or domain" do
+      assert_raise Spark.Error.DslError, ~r/No resolver configured/, fn ->
+        defmodule NoResolverResource do
+          use Ash.Resource,
+            domain: AshGrant.Test.Domain,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [AshGrant]
+
+          ash_grant do
+            scope(:all, true)
+          end
+
+          attributes do
+            uuid_primary_key(:id)
+          end
+
+          actions do
+            defaults([:read])
+          end
+        end
+      end
+    end
+  end
+
+  # ── end-to-end authorization ─────────────────────────────
+
+  describe "e2e: read with domain-inherited config" do
+    test "actor with :all scope reads all records" do
+      id = Ash.UUID.generate()
+      r1 = create!(DomainInheritedPost, %{title: "A", author_id: id})
+      r2 = create!(DomainInheritedPost, %{title: "B", author_id: Ash.UUID.generate()})
+
+      ids = read_ids(DomainInheritedPost, actor(id, ["domain_inherited_post:*:read:all"]))
+
+      assert r1.id in ids
+      assert r2.id in ids
+    end
+
+    test "actor with :own scope reads only own records" do
+      me = Ash.UUID.generate()
+      other = Ash.UUID.generate()
+      mine = create!(DomainInheritedPost, %{title: "Mine", author_id: me})
+      theirs = create!(DomainInheritedPost, %{title: "Theirs", author_id: other})
+
+      ids = read_ids(DomainInheritedPost, actor(me, ["domain_inherited_post:*:read:own"]))
+
+      assert mine.id in ids
+      refute theirs.id in ids
+    end
+
+    test "actor with no permissions gets Forbidden" do
+      create!(DomainInheritedPost, %{title: "X", author_id: Ash.UUID.generate()})
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        Ash.read!(DomainInheritedPost, actor: actor(Ash.UUID.generate(), []))
+      end
+    end
+
+    test "nil actor gets Forbidden" do
+      create!(DomainInheritedPost, %{title: "X", author_id: Ash.UUID.generate()})
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        Ash.read!(DomainInheritedPost, actor: nil)
+      end
+    end
+  end
+
+  describe "e2e: write with domain-inherited config" do
+    test "actor with create permission can create" do
+      me = Ash.UUID.generate()
+      a = actor(me, ["domain_inherited_post:*:create:all"])
+
+      result =
+        DomainInheritedPost
+        |> Ash.Changeset.for_create(:create, %{title: "New", author_id: me}, actor: a)
+        |> Ash.create!()
+
+      assert result.title == "New"
+    end
+
+    test "actor without create permission gets Forbidden" do
+      me = Ash.UUID.generate()
+      a = actor(me, ["domain_inherited_post:*:read:all"])
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        DomainInheritedPost
+        |> Ash.Changeset.for_create(:create, %{title: "Nope", author_id: me}, actor: a)
+        |> Ash.create!()
+      end
+    end
+
+    test "actor with :own update scope can update own record" do
+      me = Ash.UUID.generate()
+      rec = create!(DomainInheritedPost, %{title: "Old", author_id: me})
+      a = actor(me, ["domain_inherited_post:*:update:own"])
+
+      updated =
+        rec
+        |> Ash.Changeset.for_update(:update, %{title: "New"}, actor: a)
+        |> Ash.update!()
+
+      assert updated.title == "New"
+    end
+
+    test "actor with :own update scope cannot update others' record" do
+      me = Ash.UUID.generate()
+      other = Ash.UUID.generate()
+      rec = create!(DomainInheritedPost, %{title: "Other", author_id: other})
+      a = actor(me, ["domain_inherited_post:*:update:own"])
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        rec
+        |> Ash.Changeset.for_update(:update, %{title: "Hack"}, actor: a)
+        |> Ash.update!()
+      end
+    end
+  end
+
+  describe "e2e: overridden scope" do
+    test "override :own uses resource's field, not domain's" do
+      me = Ash.UUID.generate()
+
+      # creator_id = me (resource's :own field), author_id = someone else
+      mine =
+        create!(DomainOverridePost, %{
+          title: "Mine",
+          creator_id: me,
+          author_id: Ash.UUID.generate()
+        })
+
+      # author_id = me but creator_id = someone else — should NOT match resource's :own
+      not_mine =
+        create!(DomainOverridePost, %{
+          title: "Not mine",
+          creator_id: Ash.UUID.generate(),
+          author_id: me
+        })
+
+      ids = read_ids(DomainOverridePost, actor(me, ["domain_override_post:*:read:own"]))
+
+      assert mine.id in ids
+      refute not_mine.id in ids
+    end
+  end
+
+  describe "e2e: merged scopes (domain + resource)" do
+    test "actor reads via resource-only :published scope" do
+      me = Ash.UUID.generate()
+      pub = create!(DomainMinimalPost, %{title: "Pub", author_id: me, status: :published})
+      draft = create!(DomainMinimalPost, %{title: "Draft", author_id: me, status: :draft})
+
+      ids = read_ids(DomainMinimalPost, actor(me, ["domain_minimal_post:*:read:published"]))
+
+      assert pub.id in ids
+      refute draft.id in ids
+    end
+
+    test "actor reads via domain-inherited :own scope" do
+      me = Ash.UUID.generate()
+      other = Ash.UUID.generate()
+      mine = create!(DomainMinimalPost, %{title: "Mine", author_id: me, status: :draft})
+      theirs = create!(DomainMinimalPost, %{title: "Theirs", author_id: other, status: :draft})
+
+      ids = read_ids(DomainMinimalPost, actor(me, ["domain_minimal_post:*:read:own"]))
+
+      assert mine.id in ids
+      refute theirs.id in ids
+    end
+  end
+
+  describe "e2e: cross-boundary scope inheritance" do
+    test "own_draft scope filters by author + draft status" do
+      me = Ash.UUID.generate()
+      other = Ash.UUID.generate()
+
+      my_draft =
+        create!(DomainCrossInheritPost, %{title: "My Draft", author_id: me, status: :draft})
+
+      my_pub =
+        create!(DomainCrossInheritPost, %{title: "My Pub", author_id: me, status: :published})
+
+      other_draft =
+        create!(DomainCrossInheritPost, %{title: "Other Draft", author_id: other, status: :draft})
+
+      ids =
+        read_ids(
+          DomainCrossInheritPost,
+          actor(me, ["domain_cross_inherit_post:*:read:own_draft"])
+        )
+
+      assert my_draft.id in ids
+      refute my_pub.id in ids
+      refute other_draft.id in ids
+    end
+  end
+
+  describe "e2e: scopes-only domain (resource provides resolver)" do
+    test "read works with resource resolver + domain scopes" do
+      me = Ash.UUID.generate()
+      pub = create!(ScopesOnlyPost, %{title: "Pub", author_id: me, status: :published})
+      draft = create!(ScopesOnlyPost, %{title: "Draft", author_id: me, status: :draft})
+
+      ids = read_ids(ScopesOnlyPost, actor(me, ["scopes_only_post:*:read:published"]))
+
+      assert pub.id in ids
+      refute draft.id in ids
+    end
+  end
+
+  describe "e2e: resolver-only domain (resource provides scopes)" do
+    test "read works with domain resolver + resource scopes" do
+      me = Ash.UUID.generate()
+      other = Ash.UUID.generate()
+      mine = create!(ResolverOnlyPost, %{title: "Mine", author_id: me})
+      theirs = create!(ResolverOnlyPost, %{title: "Theirs", author_id: other})
+
+      ids = read_ids(ResolverOnlyPost, actor(me, ["resolver_only_post:*:read:own"]))
+
+      assert mine.id in ids
+      refute theirs.id in ids
+    end
+  end
+
+  # ── deny-wins with domain inheritance ────────────────────
+
+  describe "e2e: deny-wins with domain-inherited config" do
+    test "deny rule overrides allow" do
+      me = Ash.UUID.generate()
+      create!(DomainInheritedPost, %{title: "X", author_id: me})
+
+      a =
+        actor(me, [
+          "domain_inherited_post:*:read:all",
+          "!domain_inherited_post:*:read:all"
+        ])
+
+      assert_raise Ash.Error.Forbidden, fn ->
+        Ash.read!(DomainInheritedPost, actor: a)
+      end
+    end
+  end
+
+  # ── regression ───────────────────────────────────────────
+
+  describe "regression" do
+    test "existing resources in plain domain still work" do
+      assert Info.resolver(AshGrant.Test.Post) != nil
+      assert Info.scopes(AshGrant.Test.Post) != []
+    end
+
+    test "resource_name derivation works with domain inheritance" do
+      assert Info.resource_name(DomainInheritedPost) == "domain_inherited_post"
+    end
+
+    test "default_policies setting preserved with domain inheritance" do
+      assert Info.default_policies(DomainInheritedPost) == true
+    end
+
+    test "configured? returns true after domain merge" do
+      assert Info.configured?(DomainInheritedPost)
+    end
+
+    test "multiple resources in same domain are independent" do
+      # DomainOverridePost has own :own scope, DomainInheritedPost has domain's :own
+      override_filter = Info.resolve_scope_filter(DomainOverridePost, :own, %{}) |> inspect()
+      inherited_filter = Info.resolve_scope_filter(DomainInheritedPost, :own, %{}) |> inspect()
+
+      assert override_filter =~ "creator_id"
+      assert inherited_filter =~ "author_id"
+      refute inherited_filter =~ "creator_id"
+    end
+  end
+
+  # ── private ──────────────────────────────────────────────
+
+  defp scope_names(resource) do
+    resource |> Info.scopes() |> Enum.map(& &1.name)
+  end
+end

--- a/test/support/grant_domain.ex
+++ b/test/support/grant_domain.ex
@@ -1,0 +1,26 @@
+defmodule AshGrant.Test.GrantDomain do
+  @moduledoc false
+  use Ash.Domain,
+    extensions: [AshGrant.Domain],
+    validate_config_inclusion?: false
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    scope(:all, true)
+    scope(:own, expr(author_id == ^actor(:id)))
+  end
+
+  resources do
+    resource(AshGrant.Test.DomainInheritedPost)
+    resource(AshGrant.Test.DomainOverridePost)
+    resource(AshGrant.Test.DomainMinimalPost)
+    resource(AshGrant.Test.DomainCrossInheritPost)
+  end
+end

--- a/test/support/resolver_only_domain.ex
+++ b/test/support/resolver_only_domain.ex
@@ -1,0 +1,20 @@
+defmodule AshGrant.Test.ResolverOnlyDomain do
+  @moduledoc false
+  use Ash.Domain,
+    extensions: [AshGrant.Domain],
+    validate_config_inclusion?: false
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+  end
+
+  resources do
+    resource(AshGrant.Test.ResolverOnlyPost)
+  end
+end

--- a/test/support/resources/domain_cross_inherit_post.ex
+++ b/test/support/resources/domain_cross_inherit_post.ex
@@ -1,0 +1,39 @@
+defmodule AshGrant.Test.DomainCrossInheritPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshGrant.Test.GrantDomain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    default_policies(true)
+
+    # Inherits from :own which is defined at domain level
+    scope(:own_draft, [:own], expr(status == :draft))
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:author_id, :uuid, public?: true)
+
+    attribute :status, :atom do
+      constraints(one_of: [:draft, :published])
+      default(:draft)
+      public?(true)
+    end
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:title, :author_id, :status])
+    end
+
+    update :update do
+      accept([:title, :status])
+    end
+  end
+end

--- a/test/support/resources/domain_inherited_post.ex
+++ b/test/support/resources/domain_inherited_post.ex
@@ -1,0 +1,36 @@
+defmodule AshGrant.Test.DomainInheritedPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshGrant.Test.GrantDomain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    default_policies(true)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:author_id, :uuid, public?: true)
+
+    attribute :status, :atom do
+      constraints(one_of: [:draft, :published])
+      default(:draft)
+      public?(true)
+    end
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:title, :author_id, :status])
+    end
+
+    update :update do
+      accept([:title, :status])
+    end
+  end
+end

--- a/test/support/resources/domain_minimal_post.ex
+++ b/test/support/resources/domain_minimal_post.ex
@@ -1,0 +1,39 @@
+defmodule AshGrant.Test.DomainMinimalPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshGrant.Test.GrantDomain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    default_policies(true)
+
+    # Extra scope beyond domain's :all and :own
+    scope(:published, expr(status == :published))
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:author_id, :uuid, public?: true)
+
+    attribute :status, :atom do
+      constraints(one_of: [:draft, :published])
+      default(:draft)
+      public?(true)
+    end
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:title, :author_id, :status])
+    end
+
+    update :update do
+      accept([:title, :status])
+    end
+  end
+end

--- a/test/support/resources/domain_override_post.ex
+++ b/test/support/resources/domain_override_post.ex
@@ -1,0 +1,50 @@
+defmodule AshGrant.Test.DomainOverridePost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshGrant.Test.GrantDomain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    # Own resolver overrides domain's
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        %{role: :admin} -> ["domain_override_post:*:*:all"]
+        _ -> []
+      end
+    end)
+
+    default_policies(true)
+
+    # Own :own scope overrides domain's :own
+    scope(:own, expr(creator_id == ^actor(:id)))
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:creator_id, :uuid, public?: true)
+    attribute(:author_id, :uuid, public?: true)
+
+    attribute :status, :atom do
+      constraints(one_of: [:draft, :published])
+      default(:draft)
+      public?(true)
+    end
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:title, :creator_id, :author_id, :status])
+    end
+
+    update :update do
+      accept([:title, :status])
+    end
+  end
+end

--- a/test/support/resources/resolver_only_post.ex
+++ b/test/support/resources/resolver_only_post.ex
@@ -1,0 +1,29 @@
+defmodule AshGrant.Test.ResolverOnlyPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshGrant.Test.ResolverOnlyDomain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    default_policies(true)
+
+    scope(:all, true)
+    scope(:own, expr(author_id == ^actor(:id)))
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:author_id, :uuid, public?: true)
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:title, :author_id])
+    end
+  end
+end

--- a/test/support/resources/scopes_only_post.ex
+++ b/test/support/resources/scopes_only_post.ex
@@ -1,0 +1,45 @@
+defmodule AshGrant.Test.ScopesOnlyPost do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshGrant.Test.ScopesOnlyDomain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    # Resolver on resource, scopes from domain
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    default_policies(true)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:author_id, :uuid, public?: true)
+
+    attribute :status, :atom do
+      constraints(one_of: [:draft, :published])
+      default(:draft)
+      public?(true)
+    end
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:title, :author_id, :status])
+    end
+
+    update :update do
+      accept([:title, :status])
+    end
+  end
+end

--- a/test/support/scopes_only_domain.ex
+++ b/test/support/scopes_only_domain.ex
@@ -1,0 +1,16 @@
+defmodule AshGrant.Test.ScopesOnlyDomain do
+  @moduledoc false
+  use Ash.Domain,
+    extensions: [AshGrant.Domain],
+    validate_config_inclusion?: false
+
+  ash_grant do
+    scope(:all, true)
+    scope(:own, expr(author_id == ^actor(:id)))
+    scope(:published, expr(status == :published))
+  end
+
+  resources do
+    resource(AshGrant.Test.ScopesOnlyPost)
+  end
+end


### PR DESCRIPTION
## Summary

- Add `AshGrant.Domain` extension so domains can define shared `resolver` and `scope` configurations inherited by all resources
- Resources override inherited config: resource resolver wins over domain's, same-name scope wins over domain's
- Cross-boundary scope inheritance works (resource scope can inherit from domain-defined parent)
- Compile error if no resolver found from either resource or domain after merge
- 45 new tests: DSL introspection, Domain.Info unit tests, end-to-end authorization (read/write/deny-wins), edge cases (resolver-only domain, scopes-only domain), regression

## New Modules

| Module | Purpose |
|--------|---------|
| `AshGrant.Domain` | Domain extension (`use Spark.Dsl.Extension`) |
| `AshGrant.Domain.Dsl` | Domain DSL section (resolver + scope entities) |
| `AshGrant.Domain.Info` | Domain introspection (resolver, scopes, configured?) |
| `AshGrant.Transformers.MergeDomainConfig` | Compile-time merge of domain config into resources |
| `AshGrant.Transformers.ValidateResolverPresent` | Post-merge resolver validation |

## Usage

```elixir
defmodule MyApp.Blog do
  use Ash.Domain, extensions: [AshGrant.Domain]

  ash_grant do
    resolver MyApp.PermissionResolver
    scope :all, true
    scope :own, expr(author_id == ^actor(:id))
  end

  resources do
    resource MyApp.Blog.Post    # inherits resolver + scopes
    resource MyApp.Blog.Comment # inherits resolver + scopes
  end
end

# Resource only needs resource-specific config
defmodule MyApp.Blog.Post do
  use Ash.Resource, extensions: [AshGrant]

  ash_grant do
    default_policies true
    scope :published, expr(status == :published)  # extra scope
  end
end
```

## Test plan

- [x] Resolver inheritance (5 tests): inherit, override, plain domain, resolver-only, scopes-only
- [x] Scope inheritance (8 tests): inherit all, override same-name, add extra, merge, edge cases
- [x] Cross-boundary (3 tests): parent from domain, read filter, write filter
- [x] Domain.Info unit (8 tests): configured?, resolver, scopes, get_scope
- [x] Validation (1 test): compile error when no resolver
- [x] E2E read (4 tests): :all, :own, no perms, nil actor
- [x] E2E write (4 tests): create allow/deny, :own update allow/deny
- [x] E2E overridden scope (1 test): resource field vs domain field
- [x] E2E merged scopes (2 tests): resource-only + domain-inherited
- [x] E2E cross-boundary (1 test): own_draft = author + draft
- [x] E2E scopes-only domain (1 test): resource resolver + domain scopes
- [x] E2E resolver-only domain (1 test): domain resolver + resource scopes
- [x] E2E deny-wins (1 test): deny overrides allow with inherited config
- [x] Regression (5 tests): plain domain, resource_name, default_policies, configured?, independence
- [x] Full suite: 821 tests, 0 failures
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix credo` no issues
- [x] `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)