### PR TITLE
release: v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-03-15
+
+### Added
+
+- **Domain-level DSL (`AshGrant.Domain`)**: Define shared `resolver` and `scope` at the Ash Domain level. Resources using the `AshGrant` extension automatically inherit domain config, eliminating repeated `ash_grant do` blocks across resources. Resource-level settings take precedence (resolver override, same-name scope override). Cross-boundary scope inheritance is supported (resource scope can inherit from a domain-defined parent). (#54)
+
 ## [0.10.3] - 2026-03-15
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.10.3"
+  @version "0.11.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary

- Bump version to 0.11.0
- Update CHANGELOG.md with v0.11.0 entry

### What's new in v0.11.0

- **Domain-level DSL (`AshGrant.Domain`)**: Define shared `resolver` and `scope` at the Ash Domain level, inherited by all resources (#54)

## Post-merge

```bash
git checkout main && git pull
git tag v0.11.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)