### PR TITLE
release: v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-03-15
+
+### Changed
+
+- **Documentation**: Add domain-level DSL section to README with usage guidance, inheritance rules, and examples. Update installation version, feature list, and DSL Configuration table.
+- **Developer tooling**: Add `/pr` and `/release` slash commands for streamlined PR and release workflows with built-in documentation gates. Update CLAUDE.md architecture section.
+
 ## [0.11.0] - 2026-03-15
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.11.0"
+  @version "0.11.1"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary
- Bump version to 0.11.1
- Update CHANGELOG.md

### What's new in v0.11.1
- **Documentation**: Domain-level DSL section in README with usage guidance, inheritance rules, examples
- **Developer tooling**: `/pr` and `/release` slash commands with built-in documentation gates

## Post-merge
```bash
git checkout main && git pull
git tag v0.11.1
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)