### PR TITLE
release: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-03-16
+
+### Added
+
+- **`CanPerform` calculation for per-record UI visibility**: New `AshGrant.Calculation.CanPerform` module produces per-record boolean values (e.g., `:can_update?`, `:can_destroy?`) that compile to SQL via `expression/2` — no N+1 queries. Supports RBAC scopes, instance permissions, deny-wins, and multi-scope OR combination. (#58)
+- **`can_perform` DSL entity**: Declare individual CanPerform calculations inline in the `ash_grant` block with optional custom naming (e.g., `can_perform :read, name: :visible?`). The transformer auto-detects the resource module.
+- **`can_perform_actions` batch option**: Generate multiple CanPerform calculations at once (e.g., `can_perform_actions [:update, :destroy]` generates `:can_update?` and `:can_destroy?`).
+- **Compile-time action name validation**: `can_perform` and `can_perform_actions` now raise `Spark.Error.DslError` at compile time if a referenced action does not exist on the resource, preventing typos from silently producing always-false calculations. (#60)
+- **`AshGrant.Info.can_perform_actions/1`**: Introspection helper to query configured batch actions.
+
 ## [0.11.1] - 2026-03-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add `ash_grant` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ash_grant, "~> 0.11"}
+    {:ash_grant, "~> 0.12"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.11.1"
+  @version "0.12.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary
- Bump version to 0.12.0
- Update CHANGELOG.md
- Update README installation version to `~> 0.12`

### What's new in v0.12.0

- **`CanPerform` calculation** — per-record boolean for UI visibility (compiles to SQL, no N+1)
- **`can_perform` DSL entity** — individual calculation generation with custom naming
- **`can_perform_actions` batch option** — generate multiple calculations at once
- **Compile-time action validation** — typos in action names raise `DslError` at compile time
- **`AshGrant.Info.can_perform_actions/1`** — introspection helper

## Post-merge
```bash
git checkout main && git pull
git tag v0.12.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)