### PR TITLE
fix: use fill_template and resource: in Ash.Expr.eval for write scope checks

### DIFF
--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -753,21 +753,22 @@ defmodule AshGrant.Check do
   defp record_matches_filter?(_record, false, _context, _opts), do: false
 
   defp record_matches_filter?(record, filter, context, _opts) do
-    # Use Ash.Expr.eval/2 to properly evaluate expressions with actor and tenant references
-    # This handles all Ash expression operators, actor template resolution, and ^tenant() resolution
     actor = context[:actor]
     tenant = context[:tenant]
+    resource = context[:resource]
 
     # Replace exists() nodes with true before in-memory evaluation.
     # Ash.Expr.eval cannot resolve exists() in-memory (requires DB queries).
-    # - For create: exists() is meaningless (record doesn't exist yet)
-    # - For update/destroy: exists() requires data layer queries that can't run in-memory
-    # Attribute-based checks (e.g., author_id == ^actor(:id)) are preserved.
     simplified = simplify_exists_for_eval(filter)
 
-    case Ash.Expr.eval(simplified, record: record, actor: actor, tenant: tenant) do
+    # Resolve actor/tenant/context templates to concrete values before eval,
+    # then pass resource: so Ash can hydrate attribute references.
+    filled = Ash.Expr.fill_template(simplified, actor: actor, tenant: tenant, context: %{})
+
+    case Ash.Expr.eval(filled, record: record, resource: resource, actor: actor, tenant: tenant) do
       {:ok, true} -> true
       {:ok, false} -> false
+      {:ok, nil} -> false
       {:ok, _other} -> true
       :unknown -> fallback_evaluation(record, filter, context)
       {:error, _} -> fallback_evaluation(record, filter, context)

--- a/lib/ash_grant/policy_test/assertions.ex
+++ b/lib/ash_grant/policy_test/assertions.ex
@@ -370,7 +370,7 @@ defmodule AshGrant.PolicyTest.Assertions do
       context = %{actor: actor}
       filter = AshGrant.Info.resolve_scope_filter(resource, scope_atom, context)
 
-      case evaluate_filter_against_record(filter, record, actor) do
+      case evaluate_filter_against_record(filter, record, actor, resource) do
         true ->
           {:allow, permission_details}
 
@@ -381,14 +381,17 @@ defmodule AshGrant.PolicyTest.Assertions do
   end
 
   @doc false
-  def evaluate_filter_against_record(true, _record, _actor), do: true
-  def evaluate_filter_against_record(false, _record, _actor), do: false
+  def evaluate_filter_against_record(filter, record, actor, resource \\ nil)
+  def evaluate_filter_against_record(true, _record, _actor, _resource), do: true
+  def evaluate_filter_against_record(false, _record, _actor, _resource), do: false
 
-  def evaluate_filter_against_record(filter, record, actor) do
-    # Use Ash.Expr.eval to evaluate the filter against the record
-    case Ash.Expr.eval(filter, record: record, actor: actor) do
+  def evaluate_filter_against_record(filter, record, actor, resource) do
+    filled = Ash.Expr.fill_template(filter, actor: actor, context: %{})
+
+    case Ash.Expr.eval(filled, record: record, resource: resource, actor: actor) do
       {:ok, true} -> true
       {:ok, false} -> false
+      {:ok, nil} -> false
       {:ok, _other} -> true
       :unknown -> fallback_evaluation(filter, record, actor)
       {:error, _} -> fallback_evaluation(filter, record, actor)

--- a/lib/ash_grant/policy_test/yaml_parser.ex
+++ b/lib/ash_grant/policy_test/yaml_parser.ex
@@ -410,7 +410,7 @@ defmodule AshGrant.PolicyTest.YamlParser do
     scope_atom = if is_binary(scope_name), do: String.to_atom(scope_name), else: scope_name
     filter = AshGrant.Info.resolve_scope_filter(resource, scope_atom, %{actor: actor})
 
-    if Assertions.evaluate_filter_against_record(filter, record, actor) do
+    if Assertions.evaluate_filter_against_record(filter, record, actor, resource) do
       {:allow, details}
     else
       {:deny, %{reason: :scope_mismatch}}

--- a/test/ash_grant/db_integration_test.exs
+++ b/test/ash_grant/db_integration_test.exs
@@ -645,4 +645,82 @@ defmodule AshGrant.DbIntegrationTest do
       assert nyc_posts == []
     end
   end
+
+  # Regression tests: Ash.Expr.eval requires resource: to properly resolve
+  # attribute references. Without it, pure attribute-based scopes (no actor/tenant
+  # refs) silently fall through to fallback evaluation which returns true.
+  describe "write actions with attribute-based scope (resource: eval regression)" do
+    test "update with :published scope succeeds for published record" do
+      actor_id = Ash.UUID.generate()
+      actor = custom_perms_actor(["post:*:update:published", "post:*:read:all"], actor_id)
+      post = create_post!(%{title: "Pub Post", status: :published, author_id: actor_id})
+
+      result =
+        post
+        |> Ash.Changeset.for_update(:update, %{title: "Updated"})
+        |> Ash.update(actor: actor)
+
+      assert {:ok, updated} = result
+      assert updated.title == "Updated"
+    end
+
+    test "update with :published scope is forbidden for draft record" do
+      actor_id = Ash.UUID.generate()
+      actor = custom_perms_actor(["post:*:update:published", "post:*:read:all"], actor_id)
+      draft = create_post!(%{title: "Draft Post", status: :draft, author_id: actor_id})
+
+      result =
+        draft
+        |> Ash.Changeset.for_update(:update, %{title: "Should Fail"})
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "destroy with :published scope is forbidden for draft record" do
+      actor_id = Ash.UUID.generate()
+      actor = custom_perms_actor(["post:*:destroy:published", "post:*:read:all"], actor_id)
+      draft = create_post!(%{title: "Draft Post", status: :draft, author_id: actor_id})
+
+      result =
+        draft
+        |> Ash.Changeset.for_destroy(:destroy)
+        |> Ash.destroy(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "create with :published scope succeeds for published status" do
+      actor_id = Ash.UUID.generate()
+      actor = custom_perms_actor(["post:*:create:published"], actor_id)
+
+      result =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          title: "New Published",
+          status: :published,
+          author_id: actor_id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:ok, post} = result
+      assert post.status == :published
+    end
+
+    test "create with :published scope is forbidden for draft status" do
+      actor_id = Ash.UUID.generate()
+      actor = custom_perms_actor(["post:*:create:published"], actor_id)
+
+      result =
+        Post
+        |> Ash.Changeset.for_create(:create, %{
+          title: "New Draft",
+          status: :draft,
+          author_id: actor_id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- **Bug**: `Ash.Expr.eval` in `record_matches_filter?` (Check module) was called without `resource:` and without resolving `{:_actor, :id}` templates via `fill_template`. This caused pure attribute-based scopes (e.g., `:published` = `expr(status == :published)`) to silently fall through to fallback evaluation, which returns `true` when no actor/tenant references are found — **incorrectly granting write access**.
- **Root cause**: Ash runtime treats `{:_actor, _}` as `:unknown` — templates must be substituted via `Ash.Expr.fill_template` before eval. Additionally, `resource:` is needed for `Ash.Filter.hydrate_refs` to resolve attribute references.
- **Fix applied to 3 files**:
  - `check.ex`: add `fill_template` + `resource:` + handle `{:ok, nil}` as `false`
  - `assertions.ex`: same pattern, extend signature to accept `resource` parameter
  - `yaml_parser.ex`: pass `resource` to `evaluate_filter_against_record`
- **5 regression tests** added: write actions (create/update/destroy) with `:published` scope

> Note: A fork contributor (alemoreau) identified the missing `resource:` but their fix was incomplete — adding only `resource:` without `fill_template` breaks actor-based scopes (`:own`) because `{:_actor, :id}` evaluates to `nil`, matching `{:ok, _other} -> true` and granting access to all records.

## Test plan

- [x] `mix compile --warnings-as-errors` — pass
- [x] `mix test` — 871 tests, 0 failures
- [x] `mix credo` — only pre-existing refactoring suggestions
- [x] `mix format --check-formatted` — pass
- [x] Regression: update published record with `:published` scope → allowed
- [x] Regression: update draft record with `:published` scope → Forbidden
- [x] Regression: destroy draft record with `:published` scope → Forbidden
- [x] Regression: create with published status + `:published` scope → allowed
- [x] Regression: create with draft status + `:published` scope → Forbidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)