### PR TITLE
fix: extract tenant from action_input for generic actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Generic action authorization**: `AshGrant.Check` now correctly extracts tenant from `action_input` for generic actions (type `:action`). Previously, `get_tenant/1` only handled `query` and `changeset`, causing tenant-aware resolvers to return empty permissions for generic actions. The same fix is applied to `FilterCheck` and `FieldCheck`. (#76)
+
 ## [0.13.2] - 2026-03-29
 
 ### Changed

--- a/guides/checks-and-policies.md
+++ b/guides/checks-and-policies.md
@@ -16,17 +16,43 @@ policy action_type(:read) do
 end
 ```
 
-### `check/1` - For Write Actions
+### `check/1` - For Write and Generic Actions
 
 Returns `true` or `false` based on whether the actor has permission.
 Simple scopes are evaluated in-memory. Scopes with relationship references
 (`exists()` or dot-paths) automatically use a DB query to verify the scope.
 
 ```elixir
-policy action(:destroy) do
+policy action_type([:create, :update, :destroy]) do
+  authorize_if AshGrant.check()
+end
+
+# Generic actions require an explicit policy (not covered by default_policies)
+policy action_type(:action) do
   authorize_if AshGrant.check()
 end
 ```
+
+#### Generic Actions
+
+Generic actions (Ash actions with `type: :action`) use `Ash.ActionInput` instead
+of `Ash.Query` or `Ash.Changeset`. `check/1` handles this correctly, including
+tenant extraction from `action_input` for multi-tenant authorization.
+
+Generic actions must be authorized by **specific action name** in the permission
+string. Type wildcards do not apply because each generic action is individually
+unique:
+
+```elixir
+# Grants access to the specific "ping" action only
+"service_request:*:ping:all"
+
+# Wildcard (*) grants access to all actions including generic ones
+"service_request:*:*:all"
+```
+
+Since generic actions have no target record, only non-record scopes (like
+`scope :all, true`) will pass scope evaluation.
 
 ### `CanPerform` Calculation - Per-Record UI Visibility
 
@@ -148,6 +174,16 @@ policies do
   end
 end
 ```
+
+> **Note:** `default_policies` does not generate a policy for generic actions
+> (`action_type(:action)`). If your resource has generic actions, add an
+> explicit policy:
+>
+> ```elixir
+> policy action_type(:action) do
+>   authorize_if AshGrant.check()
+> end
+> ```
 
 ### Per-Action Authorization with default_policies
 

--- a/guides/permissions.md
+++ b/guides/permissions.md
@@ -62,6 +62,27 @@ with `type: :read`.
 > using `read*` would grant access to both. Use exact action names instead:
 > `post:*:list:all` and `post:*:read:own`.
 
+### Generic Actions
+
+Generic actions (Ash actions with `type: :action`) must be authorized by their
+**specific action name**. Type wildcards do not apply — each generic action is
+individually unique (one might send email, another processes a payment), so
+blanket type-level access is not supported.
+
+| Permission | Matches | Why |
+|------------|---------|-----|
+| `service:*:ping:all` | `:ping` only | Exact action name match |
+| `service:*:*:all` | All actions including generic | Universal wildcard |
+| `service:*:check_status:all` | `:check_status` only | Exact action name match |
+
+```elixir
+# Grant access to specific generic actions
+["service:*:ping:all", "service:*:check_status:all"]
+
+# Or use the universal wildcard for admin access
+["service:*:*:all"]
+```
+
 ## RBAC Permissions (instance_id = `*`)
 
 ```elixir

--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -1,10 +1,10 @@
 defmodule AshGrant.Check do
   @moduledoc """
-  SimpleCheck for write actions (create, update, destroy).
+  SimpleCheck for write and generic actions.
 
   This check integrates with Ash's policy system to provide permission-based
-  authorization for write operations. It returns `true` or `false` based on
-  whether the actor has the required permission.
+  authorization for write operations and generic actions. It returns `true` or
+  `false` based on whether the actor has the required permission.
 
   For read actions, use `AshGrant.FilterCheck` instead, which returns a filter
   expression to limit query results.
@@ -12,8 +12,8 @@ defmodule AshGrant.Check do
   > #### Auto-generated Policies {: .info}
   >
   > When using `default_policies: true` in your resource's `ash_grant` block,
-  > this check is automatically configured for write actions. You don't need
-  > to manually add it to your policies.
+  > this check is automatically configured for write actions. Generic actions
+  > require an explicit policy — see "Generic Actions" below.
 
   ## When to Use
 
@@ -21,7 +21,7 @@ defmodule AshGrant.Check do
   - `:create` actions
   - `:update` actions
   - `:destroy` actions
-  - Custom actions that modify data
+  - `:action` (generic actions)
 
   ## Usage in Policies
 
@@ -31,11 +31,41 @@ defmodule AshGrant.Check do
           authorize_if AshGrant.check()
         end
 
+        # For generic actions (not included in default_policies)
+        policy action_type(:action) do
+          authorize_if AshGrant.check()
+        end
+
         # For a specific action
         policy action(:publish) do
           authorize_if AshGrant.check(action: "publish")
         end
       end
+
+  ## Generic Actions
+
+  Generic actions (Ash actions with `type: :action`) use `Ash.ActionInput`
+  instead of `Ash.Query` or `Ash.Changeset`. This check correctly extracts
+  tenant from `action_input` for multi-tenant authorization.
+
+  Generic actions must be authorized by their specific action name in the
+  permission string — type wildcards (`action*`) do not apply because generic
+  actions are individually unique:
+
+      # Permission grants access to the specific "ping" action
+      "service_request:*:ping:all"
+
+      # Wildcard (*) grants access to all actions including generic ones
+      "service_request:*:*:all"
+
+  Since generic actions have no target record, only `scope :all, true` (or
+  other non-record scopes) will pass scope evaluation. Record-based scopes
+  like `scope :own, expr(author_id == ^actor(:id))` are not applicable.
+
+  > #### default_policies and generic actions {: .warning}
+  >
+  > `default_policies: true` does **not** generate policies for generic actions.
+  > You must add an explicit `policy action_type(:action)` block.
 
   ## Options
 
@@ -975,6 +1005,7 @@ defmodule AshGrant.Check do
     case authorizer do
       %{query: %{tenant: tenant}} when not is_nil(tenant) -> tenant
       %{changeset: %{tenant: tenant}} when not is_nil(tenant) -> tenant
+      %{action_input: %{tenant: tenant}} when not is_nil(tenant) -> tenant
       _ -> nil
     end
   end

--- a/lib/ash_grant/checks/field_check.ex
+++ b/lib/ash_grant/checks/field_check.ex
@@ -127,6 +127,7 @@ defmodule AshGrant.FieldCheck do
     case authorizer do
       %{query: %{tenant: tenant}} when not is_nil(tenant) -> tenant
       %{changeset: %{tenant: tenant}} when not is_nil(tenant) -> tenant
+      %{action_input: %{tenant: tenant}} when not is_nil(tenant) -> tenant
       _ -> nil
     end
   end

--- a/lib/ash_grant/checks/filter_check.ex
+++ b/lib/ash_grant/checks/filter_check.ex
@@ -455,6 +455,7 @@ defmodule AshGrant.FilterCheck do
     case authorizer do
       %{query: %{tenant: tenant}} when not is_nil(tenant) -> tenant
       %{changeset: %{tenant: tenant}} when not is_nil(tenant) -> tenant
+      %{action_input: %{tenant: tenant}} when not is_nil(tenant) -> tenant
       _ -> nil
     end
   end

--- a/priv/test_repo/migrations/20250108000000_create_service_requests_table.exs
+++ b/priv/test_repo/migrations/20250108000000_create_service_requests_table.exs
@@ -1,0 +1,14 @@
+defmodule AshGrant.TestRepo.Migrations.CreateServiceRequestsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:service_requests, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :title, :text, null: false
+      add :requester_id, :uuid
+      add :tenant_id, :uuid
+      add :status, :text, default: "open"
+      timestamps()
+    end
+  end
+end

--- a/test/ash_grant/generic_action_test.exs
+++ b/test/ash_grant/generic_action_test.exs
@@ -1,0 +1,286 @@
+defmodule AshGrant.GenericActionTest do
+  @moduledoc """
+  Tests for generic action (type: :action) authorization.
+
+  Generic actions use Ash.ActionInput instead of Ash.Query or Ash.Changeset.
+  This module tests that AshGrant correctly handles ActionInput, specifically:
+
+  1. Tenant extraction from action_input (issue #76)
+  2. Permission checking for generic actions
+  3. Deny-wins semantics for generic actions
+  4. Ash.can? integration with ActionInput
+  5. Mixed CRUD + generic actions on the same resource
+
+  ## Permission Format for Generic Actions
+
+  Generic actions must be authorized by their specific name, not by type wildcard.
+  Unlike CRUD actions where `read*` matches all read-type actions, generic actions
+  are individually unique (one might send email, another processes payment), so
+  type-based wildcards don't apply.
+
+  - `"service_request:*:ping:all"` — allows the specific "ping" action
+  - `"service_request:*:*:all"` — allows ALL actions (admin wildcard)
+  """
+  use AshGrant.DataCase, async: true
+
+  import AshGrant.Test.Generator
+
+  alias AshGrant.Test.ServiceRequest
+
+  defp run_action(action, params, opts) do
+    ServiceRequest
+    |> Ash.ActionInput.for_action(action, params, opts)
+    |> Ash.run_action()
+  end
+
+  # ============================================
+  # 1. Basic Generic Action Authorization
+  # ============================================
+
+  describe "basic generic action authorization" do
+    test "admin can run generic action" do
+      actor = %{id: Ash.UUID.generate(), role: :admin}
+
+      assert {:ok, "pong"} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "actor with explicit action-name permission can run generic action" do
+      actor = custom_actor(permissions: ["service_request:*:ping:all"])
+
+      assert {:ok, "pong"} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "actor with wildcard (*) permission can run generic action" do
+      actor = custom_actor(permissions: ["service_request:*:*:all"])
+
+      assert {:ok, "pong"} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "nil actor cannot run generic action" do
+      assert {:error, %Ash.Error.Forbidden{}} = run_action(:ping, %{}, actor: nil)
+    end
+
+    test "actor without permission cannot run generic action" do
+      actor = custom_actor(permissions: [])
+
+      assert {:error, %Ash.Error.Forbidden{}} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "actor with only read permission cannot run generic action" do
+      actor = custom_actor(permissions: ["service_request:*:read:all"])
+
+      assert {:error, %Ash.Error.Forbidden{}} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "permission for different action name does not grant access" do
+      # Has permission for check_status but not ping
+      actor = custom_actor(permissions: ["service_request:*:check_status:all"])
+
+      assert {:error, %Ash.Error.Forbidden{}} = run_action(:ping, %{}, actor: actor)
+    end
+  end
+
+  # ============================================
+  # 2. Tenant Extraction from ActionInput (#76)
+  # ============================================
+
+  describe "tenant extraction from action_input" do
+    test "tenant_operator can run generic action with correct tenant" do
+      tenant_id = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: tenant_id}
+
+      assert {:ok, "pong"} = run_action(:ping, %{}, actor: actor, tenant: tenant_id)
+    end
+
+    test "tenant_operator cannot run generic action without tenant" do
+      tenant_id = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: tenant_id}
+
+      # No tenant passed — resolver returns [] because context.tenant is nil
+      assert {:error, %Ash.Error.Forbidden{}} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "tenant_operator cannot run generic action with wrong tenant" do
+      actor_tenant = Ash.UUID.generate()
+      other_tenant = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: actor_tenant}
+
+      # Pass different tenant — resolver returns [] because tenants don't match
+      assert {:error, %Ash.Error.Forbidden{}} =
+               run_action(:ping, %{}, actor: actor, tenant: other_tenant)
+    end
+
+    test "tenant is passed to resolver context for generic action with arguments" do
+      tenant_id = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: tenant_id}
+
+      assert {:ok, _} =
+               run_action(
+                 :check_status,
+                 %{request_id: Ash.UUID.generate()},
+                 actor: actor,
+                 tenant: tenant_id
+               )
+    end
+  end
+
+  # ============================================
+  # 3. Deny-Wins for Generic Actions
+  # ============================================
+
+  describe "deny-wins semantics for generic actions" do
+    test "deny permission blocks generic action even with allow" do
+      actor =
+        custom_actor(
+          permissions: [
+            "service_request:*:ping:all",
+            "!service_request:*:ping:all"
+          ]
+        )
+
+      assert {:error, %Ash.Error.Forbidden{}} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "deny on specific action blocks only that action" do
+      actor =
+        custom_actor(
+          permissions: [
+            "service_request:*:*:all",
+            "!service_request:*:ping:all"
+          ]
+        )
+
+      assert {:error, %Ash.Error.Forbidden{}} = run_action(:ping, %{}, actor: actor)
+    end
+
+    test "deny on one action does not block another" do
+      actor =
+        custom_actor(
+          permissions: [
+            "service_request:*:ping:all",
+            "service_request:*:check_status:all",
+            "!service_request:*:check_status:all"
+          ]
+        )
+
+      # ping is NOT denied
+      assert {:ok, "pong"} = run_action(:ping, %{}, actor: actor)
+
+      # check_status IS denied
+      assert {:error, %Ash.Error.Forbidden{}} =
+               run_action(:check_status, %{request_id: Ash.UUID.generate()}, actor: actor)
+    end
+  end
+
+  # ============================================
+  # 4. Ash.can? with Generic Actions
+  # ============================================
+
+  describe "Ash.can? with generic action input" do
+    test "returns true for authorized actor" do
+      actor = custom_actor(permissions: ["service_request:*:ping:all"])
+
+      input = Ash.ActionInput.for_action(ServiceRequest, :ping, %{})
+      assert {:ok, true} = Ash.can(input, actor)
+    end
+
+    test "returns false for unauthorized actor" do
+      actor = custom_actor(permissions: [])
+
+      input = Ash.ActionInput.for_action(ServiceRequest, :ping, %{})
+      assert {:ok, false} = Ash.can(input, actor)
+    end
+
+    test "returns true for tenant_operator with correct tenant" do
+      tenant_id = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: tenant_id}
+
+      input = Ash.ActionInput.for_action(ServiceRequest, :ping, %{}, tenant: tenant_id)
+      assert {:ok, true} = Ash.can(input, actor)
+    end
+
+    test "returns false for tenant_operator without tenant" do
+      tenant_id = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: tenant_id}
+
+      input = Ash.ActionInput.for_action(ServiceRequest, :ping, %{})
+      assert {:ok, false} = Ash.can(input, actor)
+    end
+  end
+
+  # ============================================
+  # 5. CRUD Actions Still Work (Regression)
+  # ============================================
+
+  describe "CRUD actions on same resource are unaffected" do
+    test "admin can create service request" do
+      actor = %{id: Ash.UUID.generate(), role: :admin}
+
+      {:ok, record} =
+        Ash.create(ServiceRequest, %{title: "Test Request"}, actor: actor)
+
+      assert record.title == "Test Request"
+    end
+
+    test "admin can read service requests" do
+      actor = %{id: Ash.UUID.generate(), role: :admin}
+      generate(service_request())
+
+      records = Ash.read!(ServiceRequest, actor: actor)
+      assert records != []
+    end
+
+    test "tenant_operator can create with correct tenant" do
+      tenant_id = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: tenant_id}
+
+      {:ok, record} =
+        Ash.create(
+          ServiceRequest,
+          %{title: "Tenant Request", tenant_id: tenant_id},
+          actor: actor,
+          tenant: tenant_id
+        )
+
+      assert record.title == "Tenant Request"
+    end
+
+    test "tenant_operator cannot create without tenant context" do
+      tenant_id = Ash.UUID.generate()
+      actor = %{id: Ash.UUID.generate(), role: :tenant_operator, tenant_id: tenant_id}
+
+      result =
+        Ash.create(
+          ServiceRequest,
+          %{title: "No Tenant Request"},
+          actor: actor
+        )
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
+
+  # ============================================
+  # 6. Generic Action with Arguments
+  # ============================================
+
+  describe "generic action with arguments" do
+    test "authorized actor can run action with arguments" do
+      actor = custom_actor(permissions: ["service_request:*:check_status:all"])
+      request_id = Ash.UUID.generate()
+
+      assert {:ok, status} =
+               run_action(:check_status, %{request_id: request_id}, actor: actor)
+
+      assert String.contains?(status, request_id)
+    end
+
+    test "unauthorized actor cannot run action with arguments" do
+      actor = custom_actor(permissions: [])
+      request_id = Ash.UUID.generate()
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               run_action(:check_status, %{request_id: request_id}, actor: actor)
+    end
+  end
+end

--- a/test/ash_grant/policy_test/runner_test.exs
+++ b/test/ash_grant/policy_test/runner_test.exs
@@ -10,6 +10,7 @@ defmodule AshGrant.PolicyTest.RunnerTest do
   # Fixture modules from test/support/policy_test_fixtures.ex
   alias AshGrant.PolicyTest.Fixtures.{
     DocumentPolicyTest,
+    GenericActionPolicyTest,
     PostPolicyTest,
     TestWithResource
   }
@@ -76,6 +77,15 @@ defmodule AshGrant.PolicyTest.RunnerTest do
       # All DocumentPolicyTest tests should pass
       assert summary.failed == 0
       assert summary.passed == length(summary.results)
+    end
+
+    test "generic action policy tests all pass" do
+      summary =
+        Runner.run_all(modules: [GenericActionPolicyTest])
+
+      assert summary.failed == 0
+      assert summary.passed == length(summary.results)
+      assert summary.passed > 0
     end
 
     test "includes module name in results" do

--- a/test/fixtures/policy_tests/generic_action.yaml
+++ b/test/fixtures/policy_tests/generic_action.yaml
@@ -1,0 +1,64 @@
+resource: AshGrant.Test.ServiceRequest
+
+actors:
+  operator:
+    permissions:
+      - "service_request:*:ping:all"
+      - "service_request:*:check_status:all"
+  ping_only:
+    permissions:
+      - "service_request:*:ping:all"
+  crud_only:
+    permissions:
+      - "service_request:*:read:all"
+      - "service_request:*:create:all"
+  denied_ping:
+    permissions:
+      - "service_request:*:ping:all"
+      - "!service_request:*:ping:all"
+  nobody:
+    permissions: []
+
+tests:
+  # Generic actions are authorized by specific action name
+  - name: "operator can ping"
+    assert_can:
+      actor: operator
+      action: ping
+
+  - name: "operator can check_status"
+    assert_can:
+      actor: operator
+      action: check_status
+
+  - name: "ping_only can ping"
+    assert_can:
+      actor: ping_only
+      action: ping
+
+  - name: "ping_only cannot check_status"
+    assert_cannot:
+      actor: ping_only
+      action: check_status
+
+  # CRUD permissions do not grant generic action access
+  - name: "crud_only cannot ping"
+    assert_cannot:
+      actor: crud_only
+      action: ping
+
+  - name: "crud_only can read"
+    assert_can:
+      actor: crud_only
+      action: read
+
+  # Deny-wins
+  - name: "denied_ping cannot ping"
+    assert_cannot:
+      actor: denied_ping
+      action: ping
+
+  - name: "nobody cannot ping"
+    assert_cannot:
+      actor: nobody
+      action: ping

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -58,5 +58,8 @@ defmodule AshGrant.Test.Domain do
 
     # Scope through test resource (parent instance permission propagation)
     resource(AshGrant.Test.ChildComment)
+
+    # Generic action test resource (action_input tenant extraction)
+    resource(AshGrant.Test.ServiceRequest)
   end
 end

--- a/test/support/generator.ex
+++ b/test/support/generator.ex
@@ -31,7 +31,8 @@ defmodule AshGrant.Test.Generator do
     SharedDocument,
     Article,
     TenantPost,
-    Feed
+    Feed,
+    ServiceRequest
   }
 
   # ============================================
@@ -492,6 +493,25 @@ defmodule AshGrant.Test.Generator do
 
   def published_feed(opts \\ []), do: feed(Keyword.put(opts, :status, :published))
   def draft_feed(opts \\ []), do: feed(Keyword.put(opts, :status, :draft))
+
+  # ============================================
+  # 10. ServiceRequest Generators (generic action test)
+  # ============================================
+
+  def service_request(opts \\ []) do
+    seed_generator(
+      %ServiceRequest{
+        id: Ash.UUID.generate(),
+        title: sequence(:service_request_title, &"Service Request #{&1}"),
+        requester_id: Ash.UUID.generate(),
+        tenant_id: Ash.UUID.generate(),
+        status: :open,
+        inserted_at: DateTime.utc_now(),
+        updated_at: DateTime.utc_now()
+      },
+      overrides: opts
+    )
+  end
 
   # ============================================
   # Scenario Helpers

--- a/test/support/policy_test_fixtures.ex
+++ b/test/support/policy_test_fixtures.ex
@@ -372,3 +372,74 @@ defmodule AshGrant.PolicyTest.Fixtures.ScopeThroughTest do
     assert_cannot(:nobody, :read)
   end
 end
+
+# Generic action policy tests
+
+defmodule AshGrant.PolicyTest.Fixtures.GenericActionPolicyTest do
+  @moduledoc false
+  use AshGrant.PolicyTest
+
+  resource(AshGrant.Test.ServiceRequest)
+
+  # Actor with specific generic action permissions (by name)
+  actor(:operator, %{
+    permissions: ["service_request:*:ping:all", "service_request:*:check_status:all"]
+  })
+
+  # Actor with only ping permission
+  actor(:ping_only, %{permissions: ["service_request:*:ping:all"]})
+  # Actor with CRUD but no generic action permission
+  actor(:crud_only, %{
+    permissions: ["service_request:*:read:all", "service_request:*:create:all"]
+  })
+
+  # Actor with deny on specific generic action
+  actor(:denied_ping, %{
+    permissions: ["service_request:*:ping:all", "!service_request:*:ping:all"]
+  })
+
+  # No permissions at all
+  actor(:nobody, %{permissions: []})
+
+  describe "generic action access by name" do
+    test "operator can ping" do
+      assert_can(:operator, :ping)
+    end
+
+    test "operator can check_status" do
+      assert_can(:operator, :check_status)
+    end
+
+    test "ping_only can ping" do
+      assert_can(:ping_only, :ping)
+    end
+
+    test "ping_only cannot check_status" do
+      assert_cannot(:ping_only, :check_status)
+    end
+  end
+
+  describe "CRUD permission does not grant generic action access" do
+    test "crud_only cannot ping" do
+      assert_cannot(:crud_only, :ping)
+    end
+
+    test "crud_only cannot check_status" do
+      assert_cannot(:crud_only, :check_status)
+    end
+
+    test "crud_only can read" do
+      assert_can(:crud_only, :read)
+    end
+  end
+
+  describe "deny-wins for generic actions" do
+    test "denied_ping cannot ping" do
+      assert_cannot(:denied_ping, :ping)
+    end
+
+    test "nobody cannot ping" do
+      assert_cannot(:nobody, :ping)
+    end
+  end
+end

--- a/test/support/resources/service_request.ex
+++ b/test/support/resources/service_request.ex
@@ -1,0 +1,116 @@
+defmodule AshGrant.Test.ServiceRequest do
+  @moduledoc """
+  Test resource for generic action authorization.
+
+  This resource is specifically designed to test AshGrant's handling of
+  Ash generic actions (type: :action), which use ActionInput instead of
+  Query or Changeset.
+
+  ## Key Test Scenarios
+
+  - Tenant extraction from action_input (the #76 bug)
+  - Generic action authorization with various scopes
+  - Mixed CRUD + generic actions on the same resource
+  """
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: AshPostgres.DataLayer,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  postgres do
+    table("service_requests")
+    repo(AshGrant.TestRepo)
+  end
+
+  ash_grant do
+    # Tenant-aware resolver: uses context.tenant to look up permissions
+    resolver(fn actor, context ->
+      case actor do
+        nil ->
+          []
+
+        %{permissions: perms} ->
+          perms
+
+        # Simulates a tenant-scoped permission lookup:
+        # Returns different permissions depending on the tenant in context
+        %{role: :tenant_operator, tenant_id: actor_tenant} ->
+          if context[:tenant] != nil and to_string(context[:tenant]) == to_string(actor_tenant) do
+            [
+              "service_request:*:read:all",
+              "service_request:*:create:all",
+              "service_request:*:update:own",
+              "service_request:*:destroy:own",
+              "service_request:*:ping:all",
+              "service_request:*:check_status:all"
+            ]
+          else
+            []
+          end
+
+        %{role: :admin} ->
+          ["service_request:*:*:all"]
+
+        _ ->
+          []
+      end
+    end)
+
+    resource_name("service_request")
+
+    scope(:all, true)
+    scope(:own, expr(requester_id == ^actor(:id)))
+  end
+
+  policies do
+    bypass actor_attribute_equals(:role, :admin) do
+      authorize_if(always())
+    end
+
+    policy action_type(:read) do
+      authorize_if(AshGrant.filter_check())
+    end
+
+    policy action_type([:create, :update, :destroy]) do
+      authorize_if(AshGrant.check())
+    end
+
+    policy action_type(:action) do
+      authorize_if(AshGrant.check())
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:requester_id, :uuid, public?: true)
+    attribute(:tenant_id, :uuid, public?: true)
+
+    attribute :status, :atom do
+      constraints(one_of: [:open, :in_progress, :closed])
+      default(:open)
+      public?(true)
+    end
+
+    create_timestamp(:inserted_at)
+    update_timestamp(:updated_at)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+
+    # Generic actions — use ActionInput, not Query/Changeset
+    action :ping, :string do
+      run(fn _input, _context -> {:ok, "pong"} end)
+    end
+
+    action :check_status, :string do
+      argument(:request_id, :uuid, allow_nil?: false)
+
+      run(fn input, _context ->
+        {:ok, "status for #{input.arguments.request_id}"}
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Fix `get_tenant/1`** in `Check`, `FilterCheck`, and `FieldCheck` to extract tenant from `action_input` for generic actions (type `:action`). Previously only `query` and `changeset` were handled, causing tenant-aware resolvers to return empty permissions. (#76)
- **Document generic action authorization**: permissions must use specific action names (not type wildcards), and `default_policies` does not cover generic actions.

## Changes

### Code (3 files, 1 line each)
- `lib/ash_grant/checks/check.ex` — add `action_input` clause to `get_tenant/1`
- `lib/ash_grant/checks/filter_check.ex` — same
- `lib/ash_grant/checks/field_check.ex` — same

### Tests
- `test/ash_grant/generic_action_test.exs` — 24 ExUnit tests (basic auth, tenant extraction, deny-wins, Ash.can?, CRUD regression, arguments)
- `test/support/policy_test_fixtures.ex` — `GenericActionPolicyTest` DSL fixture (9 tests, verified via runner)
- `test/fixtures/policy_tests/generic_action.yaml` — 8 YAML policy tests
- `test/support/resources/service_request.ex` — test resource with tenant-aware resolver + generic actions

### Documentation
- `CHANGELOG.md` — [Unreleased] fix entry
- `lib/ash_grant/checks/check.ex` — @moduledoc: "Generic Actions" section, default_policies warning
- `guides/checks-and-policies.md` — generic action section, default_policies note
- `guides/permissions.md` — generic action matching rules (name-based, no type wildcards)

## Test plan

- [x] `mix compile --warnings-as-errors` — no warnings
- [x] `mix test` — 896 tests, 0 failures
- [x] `mix credo` — no new issues
- [x] `mix format --check-formatted` — clean
- [x] `MIX_ENV=test mix ash_grant.verify test/fixtures/policy_tests/generic_action.yaml` — 8/8 passed
- [x] Policy DSL fixture verified via `Runner.run_all` — 9/9 passed

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)