### PR TITLE
release: v0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.3] - 2026-04-06
 
 ### Fixed
 
 - **Generic action authorization**: `AshGrant.Check` now correctly extracts tenant from `action_input` for generic actions (type `:action`). Previously, `get_tenant/1` only handled `query` and `changeset`, causing tenant-aware resolvers to return empty permissions for generic actions. The same fix is applied to `FilterCheck` and `FieldCheck`. (#76)
+- **Write scope evaluation**: Use `fill_template` and pass `resource:` option to `Ash.Expr.eval` for correct template resolution and attribute hydration in write scope checks. (#75)
 
 ## [0.13.2] - 2026-03-29
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.13.2"
+  @version "0.13.3"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary
- Bump version to 0.13.3
- Update CHANGELOG.md

### What's new in v0.13.3

#### Fixed
- **Generic action authorization**: `get_tenant/1` in Check, FilterCheck, and FieldCheck now extracts tenant from `action_input` for generic actions. (#76)
- **Write scope evaluation**: Use `fill_template` and pass `resource:` to `Ash.Expr.eval` for correct template resolution in write scope checks. (#75)

## Post-merge
```bash
git checkout main && git pull
git tag v0.13.3
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)