### PR TITLE
refactor: remove noisy :all/:always scope warning

### DIFF
--- a/lib/ash_grant/transformers/validate_scopes.ex
+++ b/lib/ash_grant/transformers/validate_scopes.ex
@@ -4,7 +4,6 @@ defmodule AshGrant.Transformers.ValidateScopes do
 
   This transformer provides helpful warnings for common scope configuration issues:
 
-  - Warns if `:all` scope is commonly expected but not defined
   - Warns about deprecated `owner_field` and `scope_resolver` usage
 
   ## See Also
@@ -32,30 +31,11 @@ defmodule AshGrant.Transformers.ValidateScopes do
     resolver = Transformer.get_option(dsl_state, [:ash_grant], :resolver)
 
     if resolver do
-      validate_common_scopes(dsl_state, resource)
       validate_deprecated_options(dsl_state, resource)
       validate_instance_key(dsl_state, resource)
     end
 
     {:ok, dsl_state}
-  end
-
-  defp validate_common_scopes(dsl_state, resource) do
-    scopes = get_scope_entities(dsl_state)
-    scope_names = Enum.map(scopes, & &1.name)
-
-    # Warn if :all scope is missing - it's commonly expected
-    unless :all in scope_names do
-      IO.warn(
-        """
-        AshGrant: scope :all is not defined in #{inspect(resource)}.
-        Consider adding: scope :all, true
-
-        This scope is commonly used for permissions like "#{derive_resource_name(resource)}:*:read:all"
-        """,
-        []
-      )
-    end
   end
 
   defp validate_deprecated_options(dsl_state, resource) do
@@ -113,17 +93,5 @@ defmodule AshGrant.Transformers.ValidateScopes do
               "Available attributes: #{inspect(attr_names)}"
       end
     end
-  end
-
-  defp get_scope_entities(dsl_state) do
-    Transformer.get_entities(dsl_state, [:ash_grant])
-    |> Enum.filter(&match?(%AshGrant.Dsl.Scope{}, &1))
-  end
-
-  defp derive_resource_name(resource) do
-    resource
-    |> Module.split()
-    |> List.last()
-    |> Macro.underscore()
   end
 end


### PR DESCRIPTION
## Summary
- Remove `validate_common_scopes/2` from `ValidateScopes` transformer — it warned when no `:all` or `:always` scope was defined on a resource
- Remove unused helper functions (`get_scope_entities/1`, `derive_resource_name/1`)
- The warning was a best-practice hint, not a real validation error, and produced excessive noise in projects with many resources (especially with `--warnings-as-errors`)

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` — 900 tests, 96 properties, 38 doctests, 0 failures
- [x] `mix format --check-formatted` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)