### PR TITLE
fix: should_use_db_query? uses resolved filter (closes #83)

### DIFF
--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -483,10 +483,10 @@ defmodule AshGrant.Check do
   # Used when: scope has relationship references, no explicit write: option, and resource has a data layer.
   defp should_use_db_query?(nil, _filter, _resource), do: false
 
-  defp should_use_db_query?(scope_def, _filter, resource) do
+  defp should_use_db_query?(scope_def, filter, resource) do
     is_nil(scope_def.write) and
       has_data_layer?(resource) and
-      contains_relationship_reference?(scope_def.filter)
+      contains_relationship_reference?(filter)
   end
 
   defp has_data_layer?(resource) do
@@ -495,9 +495,13 @@ defmodule AshGrant.Check do
     _ -> false
   end
 
-  # Check if an Ash expression contains relationship references (exists() or dot-paths)
+  # Check if an Ash expression contains relationship references (exists() or dot-paths).
+  # The filter at this stage is a mix of hydrated (%Ref{}, %Exists{}) and unhydrated
+  # (%Ash.Query.Call{}) nodes, so we walk the AST manually rather than using
+  # Ash.Filter.relationship_paths/4 (which assumes a fully hydrated filter).
   defp contains_relationship_reference?(true), do: false
   defp contains_relationship_reference?(false), do: false
+  defp contains_relationship_reference?(nil), do: false
   defp contains_relationship_reference?(%Ash.Query.Exists{}), do: true
 
   defp contains_relationship_reference?(%Ash.Query.Ref{relationship_path: p}) when p != [],
@@ -514,8 +518,19 @@ defmodule AshGrant.Check do
     Enum.any?(args, &contains_relationship_reference?/1)
   end
 
+  # Hydrated Ash function structs (if/is_nil/contains/fragment/etc.) carry args in :arguments
+  defp contains_relationship_reference?(%{__function__?: true, arguments: arguments}) do
+    Enum.any?(arguments, &contains_relationship_reference?/1)
+  end
+
+  # Operators and other binary-shape structs
   defp contains_relationship_reference?(%{__struct__: _, left: l, right: r}) do
     contains_relationship_reference?(l) or contains_relationship_reference?(r)
+  end
+
+  # Lists appear as RHS of `in` operator and function arguments
+  defp contains_relationship_reference?(list) when is_list(list) do
+    Enum.any?(list, &contains_relationship_reference?/1)
   end
 
   defp contains_relationship_reference?(_), do: false

--- a/test/ash_grant/db_query_write_test.exs
+++ b/test/ash_grant/db_query_write_test.exs
@@ -504,4 +504,131 @@ defmodule AshGrant.DbQueryWriteTest do
       assert :ok = result
     end
   end
+
+  # ============================================================
+  # BUG: Composite scopes inheriting relational parents on CREATE
+  #
+  # should_use_db_query?/3 checks scope_def.filter (the CHILD's own filter)
+  # instead of the fully resolved filter (with inherited parent filters).
+  #
+  # For composite scope :team_member_and_own (inherits :team_member):
+  #   - scope_def.filter = expr(author_id == ^actor(:id))  ← no relationship ref
+  #   - resolved filter  = author_id == ^actor(:id) AND exists(team.memberships, ...)
+  #
+  # Because scope_def.filter has no relationship ref, should_use_db_query?
+  # returns false. The resolved filter (with exists()) is then evaluated
+  # in-memory on a virtual record that has no loaded relationships → Forbidden.
+  # ============================================================
+
+  describe "BUG: composite scope inheriting relational parent on create" do
+    test "create with composite scope (inherits exists()) and valid conditions succeeds" do
+      actor_id = Ash.UUID.generate()
+      actor = actor_with_perms(["item:*:create:team_member_and_own"], actor_id)
+
+      team = create_team!("Composite Create Team")
+      create_membership!(team, actor_id)
+
+      # Both conditions should be met:
+      # - :team_member parent: actor has membership in team
+      # - :team_member_and_own child: author_id == actor.id
+      result =
+        BulkItem
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Composite Scope Item",
+          author_id: actor_id,
+          team_id: team.id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:ok, item} = result
+      assert item.title == "Composite Scope Item"
+    end
+
+    test "create with composite scope (inherits exists()) rejects when parent condition fails" do
+      actor_id = Ash.UUID.generate()
+      actor = actor_with_perms(["item:*:create:team_member_and_own"], actor_id)
+
+      team = create_team!("No Member Composite Team")
+      # No membership created — parent :team_member condition fails
+
+      result =
+        BulkItem
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Should Fail",
+          author_id: actor_id,
+          team_id: team.id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "create with composite scope (inherits exists()) rejects when child condition fails" do
+      actor_id = Ash.UUID.generate()
+      other_id = Ash.UUID.generate()
+      actor = actor_with_perms(["item:*:create:team_member_and_own"], actor_id)
+
+      team = create_team!("Composite Child Fail Team")
+      create_membership!(team, actor_id)
+
+      # Membership exists but author_id doesn't match actor
+      result =
+        BulkItem
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Wrong Author",
+          author_id: other_id,
+          team_id: team.id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "create with composite scope (inherits dot-path) and valid conditions succeeds" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with_perms(["item:*:create:named_team_and_own"], actor_id)
+        |> Map.put(:team_name, "Composite Dot Path")
+
+      team = create_team!("Composite Dot Path")
+
+      # Both conditions should be met:
+      # - :named_team parent: team.name == actor.team_name
+      # - :named_team_and_own child: author_id == actor.id
+      result =
+        BulkItem
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Composite Dot Path Item",
+          author_id: actor_id,
+          team_id: team.id
+        })
+        |> Ash.create(actor: actor)
+
+      assert {:ok, item} = result
+      assert item.title == "Composite Dot Path Item"
+    end
+
+    test "update with composite scope (inherits exists()) and valid conditions succeeds" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with_perms(
+          ["item:*:update:team_member_and_own", "item:*:read:always"],
+          actor_id
+        )
+
+      team = create_team!("Composite Update Team")
+      create_membership!(team, actor_id)
+      item = create_item!(%{title: "Update Me", author_id: actor_id, team_id: team.id})
+
+      result =
+        item
+        |> Ash.Changeset.for_update(:update, %{title: "Updated Composite"})
+        |> Ash.update(actor: actor)
+
+      assert {:ok, updated} = result
+      assert updated.title == "Updated Composite"
+    end
+  end
 end

--- a/test/support/resources/bulk_item.ex
+++ b/test/support/resources/bulk_item.ex
@@ -15,6 +15,8 @@ defmodule AshGrant.Test.BulkItem do
   | :team_member | exists(team.memberships, user_id == ^actor(:id)) |
   | :own_in_team | author_id == ^actor(:id) AND exists(team.memberships, ...) |
   | :named_team | team.name == ^actor(:team_name) (dot-path) |
+  | :team_member_and_own | inherits :team_member + author_id == ^actor(:id) |
+  | :named_team_and_own | inherits :named_team + author_id == ^actor(:id) |
   """
   use Ash.Resource,
     domain: AshGrant.Test.Domain,
@@ -50,6 +52,13 @@ defmodule AshGrant.Test.BulkItem do
     )
 
     scope(:named_team, [], expr(team.name == ^actor(:team_name)))
+
+    # Composite scopes: inherit from a relational parent + add direct-attribute check.
+    # These reproduce a bug where should_use_db_query? checks only the child's own
+    # filter (no relationship ref) instead of the resolved filter (with inherited
+    # relationship refs), causing in-memory eval to fail on create actions.
+    scope(:team_member_and_own, [:team_member], expr(author_id == ^actor(:id)))
+    scope(:named_team_and_own, [:named_team], expr(author_id == ^actor(:id)))
   end
 
   attributes do


### PR DESCRIPTION
## Summary

- Fixes `AshGrant.Check.should_use_db_query?/3` to inspect the **resolved** scope filter (with inheritance applied) instead of the child scope's raw `scope_def.filter`.
- Closes #83 — composite scopes inheriting a relational parent (`exists()` or dot-path) no longer bypass the DB query fallback on create actions.
- Extends `contains_relationship_reference?/1` coverage: Ash function structs (`__function__?: true` with `:arguments`), lists (for `in` RHS and function arg collections), and a `nil` guard.
- 5 reproduction tests added; previously 2 failed (1 security bypass + 1 false-deny).

## Before vs after

| Scenario | Parent scope | Before fix | After fix |
|---|---|---|---|
| CREATE, both conditions met | `exists()` | succeeds (accidentally — `exists()` truthy in-memory) | succeeds (via DB query) |
| CREATE, parent condition fails | `exists()` | **succeeds — security bypass** | Forbidden |
| CREATE, child condition fails | `exists()` | Forbidden | Forbidden |
| CREATE, both conditions met | dot-path | Forbidden (false — `nil` on virtual record) | succeeds |
| UPDATE, both conditions met | `exists()` | succeeds | succeeds |

## Base branch

Based on #84 (`refactor/rename-all-scope-to-always`) because the reproduction tests reference `"item:*:read:always"` permission strings. Once #84 merges, this rebases onto `main`.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 38 doctests, 96 properties, 906 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] `mix credo` — no new issues
- [x] All 5 reproduction tests in `"BUG: composite scope inheriting relational parent on create"` pass

## Follow-up

A separate issue will track a related (pre-existing) limitation: `db_query_create_check/4` cannot handle relational refs nested inside function calls like `if(exists(...), ...)`. That path fails safely (Forbidden) but blocks legitimate use. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)