### PR TITLE
fix: forward changeset arguments to scope template filling

### DIFF
--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -691,13 +691,21 @@ defmodule AshGrant.Check do
     if context[:tenant], do: Keyword.put(opts, :tenant, context[:tenant]), else: opts
   end
 
-  # Resolve actor/tenant/context templates in an expression
+  # Resolve actor/tenant/context/arguments templates in an expression
   defp resolve_templates(filter, context) do
     Ash.Expr.fill_template(filter,
       actor: context[:actor],
       tenant: context[:tenant],
-      context: context[:query_context] || %{}
+      context: context[:query_context] || %{},
+      args: extract_arguments(context)
     )
+  end
+
+  defp extract_arguments(context) do
+    case context[:changeset] do
+      %{arguments: args} when is_map(args) -> args
+      _ -> %{}
+    end
   end
 
   # For belongs_to: source_attribute is the FK (e.g., :team_id)
@@ -808,9 +816,15 @@ defmodule AshGrant.Check do
     # Ash.Expr.eval cannot resolve exists() in-memory (requires DB queries).
     simplified = simplify_exists_for_eval(filter)
 
-    # Resolve actor/tenant/context templates to concrete values before eval,
-    # then pass resource: so Ash can hydrate attribute references.
-    filled = Ash.Expr.fill_template(simplified, actor: actor, tenant: tenant, context: %{})
+    # Resolve actor/tenant/context/arguments templates to concrete values before
+    # eval, then pass resource: so Ash can hydrate attribute references.
+    filled =
+      Ash.Expr.fill_template(simplified,
+        actor: actor,
+        tenant: tenant,
+        context: %{},
+        args: extract_arguments(context)
+      )
 
     case Ash.Expr.eval(filled, record: record, resource: resource, actor: actor, tenant: tenant) do
       {:ok, true} -> true

--- a/test/ash_grant/argument_based_scope_test.exs
+++ b/test/ash_grant/argument_based_scope_test.exs
@@ -1,0 +1,179 @@
+defmodule AshGrant.ArgumentBasedScopeTest do
+  @moduledoc """
+  Reference implementation + tests for the "argument-based scope with
+  resource-local lazy argument resolution" pattern.
+
+  Why: when a resource (Refund) needs to authorize against a value reachable
+  only through a relationship (order.center_id), the obvious approach — a
+  relational scope `expr(order.center_id in ^actor(:own_org_unit_ids))` —
+  forces the DB-query fallback path and struggles with composite scopes,
+  function-wrapped expressions, and pre/post-state ambiguity.
+
+  This pattern instead:
+    1. Declares scopes that compare actor attributes to an *argument*
+       (`^arg(:center_id)`), keeping expressions in-memory-evaluable.
+    2. Pushes the relationship traversal into a `change` module that runs
+       before the action — but only when the actor's permissions actually
+       reference that argument (cheap scopes skip the load entirely).
+
+  Tests verify:
+    - Load runs when a relevant scope is in play, authorization succeeds on
+      match and fails on mismatch.
+    - Load is skipped when no in-play scope needs the argument, and
+      authorization still works against direct-attribute scopes.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshGrant.Test.Auth.{Order, Refund}
+
+  setup do
+    # ETS data layer persists across tests; clear between runs.
+    Refund |> Ash.read!(authorize?: false) |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+    Order |> Ash.read!(authorize?: false) |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+    :ok
+  end
+
+  defp actor_with(perms, actor_id, attrs) do
+    Map.merge(%{id: actor_id, permissions: perms}, attrs)
+  end
+
+  defp create_order!(center_id) do
+    Order
+    |> Ash.Changeset.for_create(:create, %{center_id: center_id})
+    |> Ash.create!(authorize?: false)
+  end
+
+  defp create_refund!(author_id, order_id, amount \\ 100) do
+    Refund
+    |> Ash.Changeset.for_create(:create, %{
+      author_id: author_id,
+      order_id: order_id,
+      amount: amount
+    })
+    |> Ash.create!(authorize?: false)
+  end
+
+  describe "at_own_unit scope (needs order.center_id)" do
+    test "update succeeds when order's center_id is in actor's allowed units, and order is loaded" do
+      actor_id = Ash.UUID.generate()
+      center_a = Ash.UUID.generate()
+      center_b = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund:*:update:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [center_a, center_b]
+        })
+
+      order = create_order!(center_a)
+      refund = create_refund!(actor_id, order.id)
+
+      cs =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+
+      result = Ash.update(cs, actor: actor)
+
+      assert {:ok, updated} = result
+      assert updated.amount == 200
+    end
+
+    test "update is forbidden when order's center_id is not in actor's units" do
+      actor_id = Ash.UUID.generate()
+      actor_center = Ash.UUID.generate()
+      other_center = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund:*:update:at_own_unit"], actor_id, %{own_org_unit_ids: [actor_center]})
+
+      order = create_order!(other_center)
+      refund = create_refund!(actor_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
+
+  describe "by_own_author scope (direct attribute, no relationship)" do
+    test "update succeeds on author match WITHOUT loading order (lazy load is skipped)" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with(
+          ["refund:*:update:by_own_author"],
+          actor_id,
+          # No own_org_unit_ids — proves scope doesn't need :center_id
+          %{}
+        )
+
+      # Order's center_id is irrelevant here
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(actor_id, order.id)
+
+      # Capture the changeset post-change to verify load did NOT happen.
+      # We do this by building the changeset, running changes, then asserting
+      # on its context before submitting.
+      cs =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+
+      assert cs.context[:ash_grant_test_loaded_order?] == false,
+             "expected load to be skipped for :by_own_author scope"
+
+      # And full execution still succeeds
+      assert {:ok, updated} = Ash.update(cs, actor: actor)
+      assert updated.amount == 200
+    end
+
+    test "update is forbidden when author doesn't match" do
+      actor_id = Ash.UUID.generate()
+      other_id = Ash.UUID.generate()
+
+      actor = actor_with(["refund:*:update:by_own_author"], actor_id, %{})
+
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(other_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
+
+  describe "lazy-load introspection" do
+    test "load runs when actor has a permission referencing ^arg(:center_id)" do
+      actor_id = Ash.UUID.generate()
+      center = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund:*:update:at_own_unit"], actor_id, %{own_org_unit_ids: [center]})
+
+      order = create_order!(center)
+      refund = create_refund!(actor_id, order.id)
+
+      cs = Ash.Changeset.for_update(refund, :update, %{amount: 200}, actor: actor)
+
+      assert cs.context[:ash_grant_test_loaded_order?] == true
+      assert cs.arguments[:center_id] == center
+    end
+
+    test "load skipped when actor has only a non-referencing permission" do
+      actor_id = Ash.UUID.generate()
+      actor = actor_with(["refund:*:update:by_own_author"], actor_id, %{})
+
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(actor_id, order.id)
+
+      cs = Ash.Changeset.for_update(refund, :update, %{amount: 200}, actor: actor)
+
+      assert cs.context[:ash_grant_test_loaded_order?] == false
+      refute Map.has_key?(cs.arguments, :center_id) and cs.arguments[:center_id] != nil
+    end
+  end
+end

--- a/test/support/auth_pattern/domain.ex
+++ b/test/support/auth_pattern/domain.ex
@@ -1,0 +1,9 @@
+defmodule AshGrant.Test.Auth.Domain do
+  @moduledoc false
+  use Ash.Domain, validate_config_inclusion?: false
+
+  resources do
+    resource(AshGrant.Test.Auth.Order)
+    resource(AshGrant.Test.Auth.Refund)
+  end
+end

--- a/test/support/auth_pattern/resolve_center_id_from_order.ex
+++ b/test/support/auth_pattern/resolve_center_id_from_order.ex
@@ -1,0 +1,98 @@
+defmodule AshGrant.Test.Auth.ResolveCenterIdFromOrder do
+  @moduledoc false
+  # Lazily populates the :center_id argument from order.center_id.
+  #
+  # Strategy: inspect the actor's permissions and only perform the DB load if at
+  # least one permission's scope expression references `^arg(:center_id)`. This
+  # avoids unnecessary preloading when the actor's permissions use scopes that
+  # do not need the relationship (e.g. `:by_own_author`, direct attribute).
+  #
+  # For test observability, writes `:ash_grant_test_loaded_order?` to
+  # `changeset.context` so assertions can verify whether the load actually ran.
+
+  use Ash.Resource.Change
+
+  alias AshGrant.Info
+  alias Ash.Changeset
+
+  @impl true
+  def change(changeset, _opts, change_ctx) do
+    actor = change_ctx.actor || changeset.context[:private][:actor]
+
+    if needs_center_id?(changeset.resource, actor) do
+      loaded = Ash.load!(changeset.data, :order, authorize?: false)
+
+      changeset
+      |> Changeset.set_argument(:center_id, loaded.order.center_id)
+      |> Changeset.set_context(%{ash_grant_test_loaded_order?: true})
+    else
+      Changeset.set_context(changeset, %{ash_grant_test_loaded_order?: false})
+    end
+  end
+
+  defp needs_center_id?(_resource, nil), do: false
+
+  defp needs_center_id?(resource, actor) do
+    actor
+    |> permissions_for(resource)
+    |> Enum.any?(&scope_references_center_id?(resource, &1))
+  end
+
+  defp permissions_for(%{permissions: perms}, _resource), do: perms
+  defp permissions_for(_, _), do: []
+
+  defp scope_references_center_id?(resource, perm_string) do
+    with {:ok, parsed} <- AshGrant.Permission.parse(perm_string),
+         true <- match_resource?(resource, parsed.resource),
+         scope_atom when is_atom(scope_atom) <- safe_to_atom(parsed.scope),
+         filter when filter not in [nil, true, false] <-
+           Info.resolve_write_scope_filter(resource, scope_atom, %{}) do
+      expression_references_arg?(filter, :center_id)
+    else
+      _ -> false
+    end
+  end
+
+  defp match_resource?(_resource, "*"), do: true
+
+  defp match_resource?(resource, name) do
+    to_string(Info.resource_name(resource)) == name
+  end
+
+  defp safe_to_atom(s) when is_atom(s), do: s
+
+  defp safe_to_atom(s) when is_binary(s) do
+    String.to_existing_atom(s)
+  rescue
+    ArgumentError -> nil
+  end
+
+  # Walks an Ash expression looking for a template ref {:_arg, name}.
+  defp expression_references_arg?({:_arg, name}, name), do: true
+
+  defp expression_references_arg?(%Ash.Query.Call{args: args}, name) do
+    Enum.any?(args, &expression_references_arg?(&1, name))
+  end
+
+  defp expression_references_arg?(%Ash.Query.BooleanExpression{left: l, right: r}, name) do
+    expression_references_arg?(l, name) or expression_references_arg?(r, name)
+  end
+
+  defp expression_references_arg?(%Ash.Query.Not{expression: e}, name) do
+    expression_references_arg?(e, name)
+  end
+
+  defp expression_references_arg?(%{__function__?: true, arguments: args}, name) do
+    Enum.any?(args, &expression_references_arg?(&1, name))
+  end
+
+  defp expression_references_arg?(%{__struct__: _, left: l, right: r}, name) do
+    expression_references_arg?(l, name) or expression_references_arg?(r, name)
+  end
+
+  defp expression_references_arg?(list, name) when is_list(list) do
+    Enum.any?(list, &expression_references_arg?(&1, name))
+  end
+
+  defp expression_references_arg?(_, _), do: false
+end

--- a/test/support/resources/auth_pattern_order.ex
+++ b/test/support/resources/auth_pattern_order.ex
@@ -1,0 +1,23 @@
+defmodule AshGrant.Test.Auth.Order do
+  @moduledoc false
+  # Test resource for the "argument-based scope + resource-local argument
+  # resolution" pattern. Order is the anchor that carries :center_id; Refund
+  # (the authorization target) reaches center_id only via its :order relationship.
+
+  use Ash.Resource,
+    domain: AshGrant.Test.Auth.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private?(true)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:center_id, :uuid, public?: true, allow_nil?: false)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+  end
+end

--- a/test/support/resources/auth_pattern_refund.ex
+++ b/test/support/resources/auth_pattern_refund.ex
@@ -1,0 +1,79 @@
+defmodule AshGrant.Test.Auth.Refund do
+  @moduledoc false
+  # Test resource demonstrating the "argument-based scope + resource-local
+  # argument resolution" pattern. Refund has no :center_id directly — it reaches
+  # it via order.center_id. Instead of a relational scope like
+  #   expr(order.center_id in ^actor(:own_org_unit_ids))
+  # we use:
+  #   expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+  # and a change module loads order.center_id into the :center_id argument —
+  # but only when the actor's permissions actually reference that argument.
+
+  use Ash.Resource,
+    domain: AshGrant.Test.Auth.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ets do
+    private?(true)
+  end
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    resource_name("refund")
+
+    scope(:always, true)
+    scope(:by_own_author, expr(author_id == ^actor(:id)))
+    scope(:at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids)))
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:author_id, :uuid, public?: true, allow_nil?: false)
+    attribute(:amount, :integer, public?: true, allow_nil?: false)
+  end
+
+  relationships do
+    belongs_to :order, AshGrant.Test.Auth.Order do
+      public?(true)
+      allow_nil?(false)
+      attribute_writable?(true)
+    end
+  end
+
+  policies do
+    policy action_type(:read) do
+      authorize_if(AshGrant.filter_check())
+    end
+
+    policy action_type([:create, :update, :destroy]) do
+      authorize_if(AshGrant.check())
+    end
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:author_id, :amount, :order_id])
+    end
+
+    update :update do
+      accept([:amount])
+      require_atomic?(false)
+      # Lazy-load order.center_id into :center_id argument only when a permission
+      # in play actually references it. Skips the DB load for scopes like
+      # :by_own_author that don't need the relationship.
+      argument(:center_id, :uuid, allow_nil?: true)
+      change({AshGrant.Test.Auth.ResolveCenterIdFromOrder, []})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

AshGrant documents that scope expressions support `^arg(:name)` templates, but `AshGrant.Check` never forwarded the changeset's `:arguments` map to `Ash.Expr.fill_template`. Any scope referencing `^arg(...)` crashed with `BadMapError` (`:maps.find(field, nil)`) during strict check.

This PR:

- Forwards `changeset.arguments` as `args:` to `Ash.Expr.fill_template` in both `resolve_templates/2` and the in-memory `record_matches_filter?/4`.
- Adds a reference implementation + 6 tests validating the "argument-based scope + resource-local argument resolution" pattern end-to-end.

### Why this pattern matters

For authorization that depends on a value reachable only through a relationship (e.g., `refund.order.center_id`), the obvious relational scope:

```elixir
scope :at_own_unit, expr(order.center_id in ^actor(:own_org_unit_ids))
```

forces the DB-query fallback on write actions and struggles with composite inheritance (#83, #86) and pre/post-state ambiguity. The alternative:

```elixir
scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
```

combined with a `change` module that loads the relationship and sets the argument, keeps scope expressions in-memory-evaluable and avoids the DB-query fallback entirely. The change can lazily skip loading when the actor's permissions use scopes that don't reference the argument — zero overhead for cheap scopes.

## Reference implementation (test support)

- `AshGrant.Test.Auth.Order` / `Refund` — ETS resources mirroring a Refund→Order→center_id authorization shape.
- `AshGrant.Test.Auth.ResolveCenterIdFromOrder` — lazy `Ash.Resource.Change` that inspects the actor's permissions via `AshGrant.Info.resolve_write_scope_filter/3`, and loads `:order` + sets `:center_id` argument **only when an in-play scope references `^arg(:center_id)`**.
- `test/ash_grant/argument_based_scope_test.exs` — 6 tests:
  - `:at_own_unit` + matching center → allow, load runs
  - `:at_own_unit` + mismatching → Forbidden
  - `:by_own_author` only → allow on author match, **load is skipped** (key correctness property)
  - `:by_own_author` + mismatching author → Forbidden
  - Introspection: load runs iff a permission references `^arg(:center_id)`
  - Introspection: load skipped when only direct-attribute scopes are in play

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 38 doctests, 96 properties, 912 tests, 0 failures (6 new)
- [x] `mix format --check-formatted` clean
- [x] `mix credo` — no new issues (7 pre-existing)

## Follow-up

A companion PR will add `guides/argument-based-scope.md` documenting the pattern with the Refund/Order example — using the implementation in this PR as the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)