### PR TITLE
feat: resolve_argument DSL sugar for argument-based scopes

### DIFF
--- a/guides/argument-based-scope.md
+++ b/guides/argument-based-scope.md
@@ -29,7 +29,7 @@ actually need them.**
 
 ## Why argument-based instead of relational?
 
-| Property | Relational scope `order.center_id in ...` | Argument-based scope `^arg(:center_id) in ...` |
+| Property | Relational `order.center_id in ...` | Argument-based `^arg(:center_id) in ...` |
 |---|---|---|
 | Expression evaluator | DB-query fallback on writes | In-memory, always |
 | Composite inheritance | Fragile (see #83, #86) | Not involved |
@@ -43,20 +43,12 @@ The last two rows are where this pattern distinguishes itself. A scope like
 The pattern lets you add relational scopes alongside it **without** forcing
 every write to preload `order`.
 
-## Full example: Refund → Order → center_id
+## Using the DSL sugar (recommended)
 
-### The resources
+AshGrant provides a `resolve_argument` entity that wires up the argument and
+the lazy `change` automatically:
 
 ```elixir
-defmodule MyApp.Orders.Order do
-  use Ash.Resource, domain: MyApp.Orders, data_layer: AshPostgres.DataLayer
-
-  attributes do
-    uuid_primary_key :id
-    attribute :center_id, :uuid, public?: true, allow_nil?: false
-  end
-end
-
 defmodule MyApp.Orders.Refund do
   use Ash.Resource,
     domain: MyApp.Orders,
@@ -72,19 +64,25 @@ defmodule MyApp.Orders.Refund do
     scope :by_own_author, expr(author_id == ^actor(:id))
 
     # Argument-based: compares an action argument, not a relationship
-    scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+    scope :at_own_unit,
+      expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+
+    scope :at_own_unit_and_small,
+      [:at_own_unit],
+      expr(total_amount <= 100)
+
+    # Auto-generates :center_id argument + lazy change on every write action
+    resolve_argument :center_id, from_path: [:order, :center_id]
   end
 
   attributes do
     uuid_primary_key :id
     attribute :author_id, :uuid, public?: true, allow_nil?: false
-    attribute :amount,   :integer, public?: true, allow_nil?: false
+    attribute :total_amount, :integer, public?: true, allow_nil?: false
   end
 
   relationships do
-    belongs_to :order, MyApp.Orders.Order do
-      allow_nil? false
-    end
+    belongs_to :order, MyApp.Orders.Order, allow_nil?: false
   end
 
   policies do
@@ -94,13 +92,11 @@ defmodule MyApp.Orders.Refund do
 
   actions do
     defaults [:read, :destroy]
-    create :create, do: accept [:author_id, :amount, :order_id]
+    create :create, do: accept [:author_id, :total_amount, :order_id]
 
     update :update do
-      accept [:amount]
+      accept [:total_amount]
       require_atomic? false
-      argument :center_id, :uuid, allow_nil?: true
-      change {MyApp.Orders.ResolveCenterIdFromOrder, []}
     end
   end
 end
@@ -112,93 +108,67 @@ Notice what the scope **doesn't** say:
 - No dot-path `order.center_id`
 - Just a plain comparison between an argument and an actor attribute
 
-### The argument resolver
+### What the transformer generates
+
+`AshGrant.Transformers.AddArgumentResolvers` walks every scope at compile time
+and records which arguments each scope references. For each `resolve_argument`
+declaration, it then:
+
+1. Validates the path: intermediates must be `belongs_to` relationships, the
+   leaf must be an attribute. Invalid paths fail the compile.
+2. Validates that at least one scope references `^arg(:center_id)` — a
+   declaration no scope uses is a compile error.
+3. Adds an `argument :center_id, <inferred_type>, allow_nil?: true` to every
+   targeted write action (create, update, destroy).
+4. Installs `AshGrant.Changes.ResolveArgument` on every targeted write action,
+   with the compile-time list of "scopes that need this argument" baked in.
+
+### Multi-hop paths
 
 ```elixir
-defmodule MyApp.Orders.ResolveCenterIdFromOrder do
-  use Ash.Resource.Change
-  alias Ash.Changeset
-
-  @impl true
-  def change(changeset, _opts, change_ctx) do
-    actor = change_ctx.actor || changeset.context[:private][:actor]
-
-    if needs_center_id?(changeset.resource, actor) do
-      loaded = Ash.load!(changeset.data, :order, authorize?: false)
-      Changeset.set_argument(changeset, :center_id, loaded.order.center_id)
-    else
-      changeset
-    end
-  end
-
-  defp needs_center_id?(_resource, nil), do: false
-
-  defp needs_center_id?(resource, actor) do
-    actor
-    |> permissions_for()
-    |> Enum.any?(&scope_references_arg?(resource, &1, :center_id))
-  end
-
-  defp permissions_for(%{permissions: perms}), do: perms
-  defp permissions_for(_), do: []
-
-  # Walks the scope's resolved filter expression looking for `^arg(name)`.
-  defp scope_references_arg?(resource, perm_string, arg_name) do
-    with {:ok, parsed} <- AshGrant.Permission.parse(perm_string),
-         scope_atom when is_atom(scope_atom) <- safe_to_atom(parsed.scope),
-         filter when filter not in [nil, true, false] <-
-           AshGrant.Info.resolve_write_scope_filter(resource, scope_atom, %{}) do
-      references_template?(filter, {:_arg, arg_name})
-    else
-      _ -> false
-    end
-  end
-
-  defp safe_to_atom(s) when is_atom(s), do: s
-  defp safe_to_atom(s) when is_binary(s),
-    do: (try do: String.to_existing_atom(s), rescue: (ArgumentError -> nil))
-
-  defp references_template?(template, template), do: true
-  defp references_template?(%Ash.Query.Call{args: args}, template),
-    do: Enum.any?(args, &references_template?(&1, template))
-  defp references_template?(%Ash.Query.BooleanExpression{left: l, right: r}, t),
-    do: references_template?(l, t) or references_template?(r, t)
-  defp references_template?(%Ash.Query.Not{expression: e}, t),
-    do: references_template?(e, t)
-  defp references_template?(%{__function__?: true, arguments: args}, t),
-    do: Enum.any?(args, &references_template?(&1, t))
-  defp references_template?(%{__struct__: _, left: l, right: r}, t),
-    do: references_template?(l, t) or references_template?(r, t)
-  defp references_template?(list, t) when is_list(list),
-    do: Enum.any?(list, &references_template?(&1, t))
-  defp references_template?(_, _), do: false
-end
+resolve_argument :organization_id,
+  from_path: [:order, :customer, :organization_id]
 ```
 
-### What happens at runtime
+Works the same way — intermediates are belongs_to, leaf is an attribute.
+
+### Restricting to specific actions
+
+```elixir
+resolve_argument :center_id,
+  from_path: [:order, :center_id],
+  for_actions: [:update, :destroy]
+```
+
+Defaults to all write actions; use `for_actions:` to narrow.
+
+### Runtime behavior
+
+For each write action's execution:
+
+1. The change runs. If the actor is `nil` or none of the actor's permissions
+   are for a scope that references this argument → **no-op**, argument stays
+   unset.
+2. Otherwise:
+   - **create**: the change reads the first-hop foreign key from the
+     changeset's attributes (e.g., `:order_id`), loads the head record, then
+     walks any remaining path keys through loaded relationships.
+   - **update / destroy**: the change loads the relationship path on
+     `changeset.data` and reads the leaf attribute.
+3. `Changeset.set_argument(:center_id, value)` is set; authorization proceeds.
 
 #### Actor holds only `"refund:*:update:by_own_author"`
 
-1. Caller invokes `Refund.update(refund, %{amount: 200})` with the actor.
-2. `for_update/4` runs the `change`. `needs_center_id?/2` walks the actor's
-   permissions and asks: "does any scope in play reference `^arg(:center_id)`?"
-   The only in-play scope is `:by_own_author`, which compares `author_id`
-   directly. Answer: **no**.
-3. The change **skips `Ash.load!`** and returns the changeset unchanged.
-4. Authorization evaluates `author_id == ^actor(:id)` in-memory. No DB load.
+`:by_own_author` does not reference `^arg(:center_id)`. The change skips the
+DB load and returns the changeset unchanged. Authorization evaluates
+`author_id == ^actor(:id)` in-memory. Zero overhead.
 
 #### Actor holds only `"refund:*:update:at_own_unit"`
 
-1. `for_update/4` runs the `change`. `needs_center_id?/2` finds that
-   `:at_own_unit` references `^arg(:center_id)`. Answer: **yes**.
-2. The change calls `Ash.load!(refund, :order)` and `Changeset.set_argument(:center_id, loaded.order.center_id)`.
-3. Authorization evaluates `^arg(:center_id) in ^actor(:own_org_unit_ids)` —
-   filled in as `<loaded-center-id> in <actor-unit-list>`. Plain boolean.
-
-#### Actor holds both
-
-The change runs one load (deduped by Ash). Both scopes evaluate correctly:
-`by_own_author` from direct attributes, `at_own_unit` from the injected argument.
+`:at_own_unit` references `^arg(:center_id)`, which is in the
+`scopes_needing` set baked in at compile time. The change loads `:order`,
+sets the argument, and authorization evaluates
+`^arg(:center_id) in ^actor(:own_org_unit_ids)`.
 
 ## Why this is safe
 
@@ -208,17 +178,13 @@ actually updating a record from a different center.
 
 This pattern avoids that entirely: **the resource itself computes the argument
 from its own authoritative FK relationships.** The caller doesn't supply
-`:center_id`; the resource's `change` does. The only way an attacker could
-influence the argument is to influence the actual `order_id` — which would
-change what record is updated in the first place.
-
-If you ever need to accept a caller-supplied argument as an optimization (e.g.,
-it's already in hand from a prior query), validate it against the resource's
-own resolution before trusting it.
+`:center_id`; the change does. The only way an attacker could influence the
+argument is to influence the actual `order_id` — which would change what
+record is updated in the first place.
 
 ## When to use this pattern
 
-Prefer argument-based scope + resource-local argument resolution when:
+Prefer argument-based scope + `resolve_argument` when:
 
 - The authorization check reads through one or more relationships
   (`refund.order.center_id`, `comment.post.author_id`, etc.).
@@ -237,43 +203,107 @@ Prefer relational scopes (`expr(order.center_id in ...)`) when:
 
 ### `for_update`/`for_create`/`for_destroy` must receive the actor
 
-The `change` runs during `for_<action>/4`. It needs the actor to introspect
+The change runs during `for_<action>/4`. It needs the actor to introspect
 permissions. If your caller builds the changeset without the actor and only
 passes it to `Ash.update/2`, the change sees `nil` and skips the load — and
 the authorization fails with nil arguments.
 
-**Always pass `actor:` to `for_*/4` when using this pattern.** Ash's
-conventions recommend this anyway.
+**Always pass `actor:` to `for_*/4` when using this pattern.**
 
 ### `require_atomic? false` on update/destroy
 
-Functions-as-changes don't implement the atomic protocol by default. If your
-resource's data layer supports atomic updates (most do), set
-`require_atomic? false` on the action, or provide an `atomic/3` callback on
-the change.
+The generated change does not implement the atomic protocol. If your data
+layer supports atomic updates (most do), set `require_atomic? false` on
+affected actions.
 
-### The change should be idempotent
+### Relationship with the `write:` scope option
 
-The introspection walks the scope expressions each call. If you have many
-scopes and many writes, and the walk shows up in profiles, cache the
-per-resource "scope → uses arg X?" map. The logic is pure and compile-time
-computable from the DSL.
+The `write:` option on `scope` was designed to provide a simpler, in-memory-
+evaluable expression for write actions when the main filter uses relational
+traversal. With argument-based scopes + `resolve_argument`, the scope is
+already in-memory-evaluable and `write:` is typically not needed.
 
-## Relation to `default_policies`
+For new code, prefer this pattern over `write:`. `write:` remains supported
+for existing resources.
 
-`default_policies true` auto-generates a blanket `AshGrant.check()` policy for
-write actions. This pattern is fully compatible: declare the argument and
-change on the action, and `default_policies` does the rest.
+## Hand-rolled version (under the hood)
 
-If you want argument resolution to happen without explicitly wiring a change on
-every action, encapsulate the change + argument declaration in a small macro
-or a global action template.
+The DSL sugar is equivalent to the following hand-rolled wiring. Useful to
+know when you need a customized variant (e.g., different resolution logic for
+specific actions):
+
+```elixir
+# Resource — no resolve_argument entity
+ash_grant do
+  scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+end
+
+actions do
+  update :update do
+    accept [:total_amount]
+    require_atomic? false
+    argument :center_id, :uuid, allow_nil?: true
+    change {MyApp.Orders.ResolveCenterIdFromOrder, []}
+  end
+end
+```
+
+```elixir
+defmodule MyApp.Orders.ResolveCenterIdFromOrder do
+  use Ash.Resource.Change
+  alias Ash.Changeset
+
+  @impl true
+  def change(changeset, _opts, ctx) do
+    actor = ctx.actor || changeset.context[:private][:actor]
+
+    if needs_center_id?(changeset.resource, actor) do
+      loaded = Ash.load!(changeset.data, :order, authorize?: false)
+      Changeset.set_argument(changeset, :center_id, loaded.order.center_id)
+    else
+      changeset
+    end
+  end
+
+  defp needs_center_id?(_resource, nil), do: false
+
+  defp needs_center_id?(resource, %{permissions: perms}) when is_list(perms) do
+    Enum.any?(perms, &scope_references_center_id?(resource, &1))
+  end
+
+  defp needs_center_id?(_, _), do: false
+
+  defp scope_references_center_id?(resource, perm_string) do
+    with {:ok, parsed} <- AshGrant.Permission.parse(perm_string),
+         scope_atom when is_atom(scope_atom) <- safe_to_atom(parsed.scope),
+         filter when filter not in [nil, true, false] <-
+           AshGrant.Info.resolve_write_scope_filter(resource, scope_atom, %{}) do
+      AshGrant.ArgumentAnalyzer.references_arg?(filter, :center_id)
+    else
+      _ -> false
+    end
+  end
+
+  defp safe_to_atom(s) when is_atom(s), do: s
+
+  defp safe_to_atom(s) when is_binary(s) do
+    String.to_existing_atom(s)
+  rescue
+    ArgumentError -> nil
+  end
+end
+```
+
+Prefer the DSL sugar unless you need this kind of surgical control.
 
 ## Reference implementation
 
-See the test suite for a working implementation:
+See the test suite for working implementations of both styles:
 
-- `test/support/resources/auth_pattern_order.ex`
-- `test/support/resources/auth_pattern_refund.ex`
-- `test/support/auth_pattern/resolve_center_id_from_order.ex`
-- `test/ash_grant/argument_based_scope_test.exs`
+- `test/support/resources/auth_pattern_refund_dsl.ex` — DSL sugar
+- `test/support/resources/auth_pattern_refund.ex` — hand-rolled change module
+- `test/ash_grant/resolve_argument_dsl_test.exs` — DSL behavior tests
+- `test/ash_grant/argument_based_scope_test.exs` — hand-rolled behavior tests
+- `test/ash_grant/argument_analyzer_test.exs` — unit tests for the AST walker
+- `test/ash_grant/resolve_argument_validation_test.exs` — compile-time errors
+- `test/ash_grant/resolve_argument_property_test.exs` — property-based tests

--- a/lib/ash_grant.ex
+++ b/lib/ash_grant.ex
@@ -316,6 +316,7 @@ defmodule AshGrant do
       AshGrant.Transformers.ValidateScopeThroughs,
       AshGrant.Transformers.ResolveFieldGroupFields,
       AshGrant.Transformers.ValidateFieldGroups,
+      AshGrant.Transformers.AddArgumentResolvers,
       AshGrant.Transformers.AddDefaultPolicies,
       AshGrant.Transformers.AddFieldPolicies,
       AshGrant.Transformers.AddMaskingPreparation,

--- a/lib/ash_grant/argument_analyzer.ex
+++ b/lib/ash_grant/argument_analyzer.ex
@@ -1,0 +1,105 @@
+defmodule AshGrant.ArgumentAnalyzer do
+  @moduledoc """
+  Compile-time analysis of which scopes reference which `^arg(...)` templates.
+
+  Given a resource, walks every scope's resolved (inheritance-applied) filter
+  expression and records the set of `{:_arg, name}` references per scope.
+  Inverting that mapping produces `%{arg_name => [scope_atoms]}`, which the
+  `AshGrant.Transformers.AddArgumentResolvers` transformer uses to wire up
+  `AshGrant.Changes.ResolveArgument` only where the argument is actually needed.
+
+  The walker understands the same AST shapes as
+  `AshGrant.Check.contains_relationship_reference?/1`:
+
+    * `%Ash.Query.BooleanExpression{}`, `%Ash.Query.Not{}`
+    * `%Ash.Query.Call{args: [...]}`
+    * `%Ash.Query.Exists{expr: ...}`
+    * `%Ash.Query.Ref{}`
+    * structs with `__function__?: true` and `:arguments`
+    * structs with `__operator__?: true` / `:left` + `:right`
+    * lists (for `in` operator RHS and function arg collections)
+    * bare `{:_arg, name}` template tuples
+  """
+
+  alias AshGrant.Info
+
+  @type scope_name :: atom()
+  @type arg_name :: atom()
+
+  @doc """
+  Returns `%{arg_name => [scope_names]}` for all args referenced by any scope
+  on the given resource. Uses write-scope resolution so inheritance is applied.
+  """
+  @spec arg_to_scopes(Ash.Resource.t()) :: %{arg_name() => [scope_name()]}
+  def arg_to_scopes(resource) do
+    resource
+    |> Info.scopes()
+    |> Enum.reduce(%{}, fn scope, acc ->
+      filter = safe_resolve(resource, scope.name)
+      args = referenced_args(filter)
+
+      Enum.reduce(args, acc, fn arg, inner ->
+        Map.update(inner, arg, [scope.name], &Enum.uniq([scope.name | &1]))
+      end)
+    end)
+  end
+
+  @doc """
+  Returns the list of `{:_arg, name}` argument names referenced anywhere in the
+  expression.
+  """
+  @spec referenced_args(any()) :: [arg_name()]
+  def referenced_args(expr) do
+    expr
+    |> walk_args()
+    |> Enum.uniq()
+  end
+
+  @doc """
+  True iff the expression references `{:_arg, name}` anywhere.
+  """
+  @spec references_arg?(any(), arg_name()) :: boolean()
+  def references_arg?(expr, name) do
+    name in referenced_args(expr)
+  end
+
+  # --- internals -----------------------------------------------------------
+
+  defp safe_resolve(resource, name) do
+    Info.resolve_write_scope_filter(resource, name, %{})
+  rescue
+    _ -> nil
+  end
+
+  defp walk_args(true), do: []
+  defp walk_args(false), do: []
+  defp walk_args(nil), do: []
+  defp walk_args({:_arg, name}) when is_atom(name), do: [name]
+
+  defp walk_args(%Ash.Query.BooleanExpression{left: l, right: r}),
+    do: walk_args(l) ++ walk_args(r)
+
+  defp walk_args(%Ash.Query.Not{expression: e}), do: walk_args(e)
+
+  defp walk_args(%Ash.Query.Call{args: args}) when is_list(args),
+    do: Enum.flat_map(args, &walk_args/1)
+
+  defp walk_args(%Ash.Query.Exists{expr: e}), do: walk_args(e)
+
+  defp walk_args(%Ash.Query.Ref{}), do: []
+
+  defp walk_args(%{__function__?: true, arguments: args}) when is_list(args),
+    do: Enum.flat_map(args, &walk_args/1)
+
+  defp walk_args(%{__struct__: _, left: l, right: r}),
+    do: walk_args(l) ++ walk_args(r)
+
+  defp walk_args(list) when is_list(list), do: Enum.flat_map(list, &walk_args/1)
+
+  # Generic tuples (including keyword-list entries like {:do, expr}, {:else, expr}).
+  # The `{:_arg, name}` case is matched earlier; here we fall through and walk elements.
+  defp walk_args(tuple) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> Enum.flat_map(&walk_args/1)
+
+  defp walk_args(_), do: []
+end

--- a/lib/ash_grant/changes/resolve_argument.ex
+++ b/lib/ash_grant/changes/resolve_argument.ex
@@ -1,0 +1,215 @@
+defmodule AshGrant.Changes.ResolveArgument do
+  @moduledoc """
+  Runtime change that lazily populates an action argument from the record's
+  own relationships.
+
+  Installed automatically by `AshGrant.Transformers.AddArgumentResolvers` when a
+  resource declares `resolve_argument` in its `ash_grant` block. Users rarely
+  reference this module directly.
+
+  ## Options
+
+    * `:name` — argument name to set
+    * `:path` — list of atoms walking relationships to a leaf attribute
+      (e.g. `[:order, :center_id]`, `[:order, :customer, :organization_id]`).
+      Intermediate keys are belongs_to relationships; the last is an attribute.
+    * `:scopes_needing` — list of scope atoms whose resolved filter references
+      `^arg(<name>)`. Injected by the transformer at compile time.
+
+  ## Runtime contract
+
+  If the actor is nil, or none of the actor's permissions use a scope in
+  `:scopes_needing`, the change is a no-op — no DB load is performed.
+
+  Otherwise, the change resolves the path:
+
+    * **create**: read the first-hop foreign key from the changeset's
+      attributes, fetch the head record, then walk the remaining path keys
+      through loaded relationships.
+    * **update/destroy**: load the relationship path on `changeset.data`, then
+      read the leaf attribute.
+
+  If any intermediate value is nil or the path cannot be resolved (e.g., the
+  referenced record was deleted), the change returns the changeset unchanged —
+  the scope will then evaluate against a `nil` argument and typically fail
+  closed (authorization denied).
+  """
+
+  use Ash.Resource.Change
+
+  alias Ash.Changeset
+
+  @impl true
+  def change(changeset, opts, ctx) do
+    name = Keyword.fetch!(opts, :name)
+    path = Keyword.fetch!(opts, :path)
+    scopes_needing = Keyword.fetch!(opts, :scopes_needing)
+
+    actor = actor_from_context(ctx, changeset)
+
+    if needs_resolution?(actor, changeset.resource, scopes_needing) do
+      case resolve_value(changeset, path) do
+        {:ok, value} -> Changeset.set_argument(changeset, name, value)
+        :skip -> changeset
+      end
+    else
+      changeset
+    end
+  end
+
+  defp actor_from_context(%{actor: actor}, _) when not is_nil(actor), do: actor
+
+  defp actor_from_context(_, %{context: context}) when is_map(context) do
+    case context do
+      %{private: %{actor: actor}} when not is_nil(actor) -> actor
+      %{actor: actor} when not is_nil(actor) -> actor
+      _ -> nil
+    end
+  end
+
+  defp actor_from_context(_, _), do: nil
+
+  defp needs_resolution?(nil, _resource, _scopes_needing), do: false
+  defp needs_resolution?(_actor, _resource, []), do: false
+
+  defp needs_resolution?(actor, resource, scopes_needing) do
+    actor
+    |> permissions()
+    |> Enum.any?(&permission_uses_listed_scope?(&1, resource, scopes_needing))
+  end
+
+  defp permissions(%{permissions: perms}) when is_list(perms), do: perms
+  defp permissions(_), do: []
+
+  defp permission_uses_listed_scope?(perm_string, resource, scopes_needing) do
+    case AshGrant.Permission.parse(perm_string) do
+      {:ok, %{resource: res_name, scope: scope_str}} ->
+        resource_matches?(resource, res_name) and
+          scope_atom_in?(scope_str, scopes_needing)
+
+      _ ->
+        false
+    end
+  end
+
+  defp resource_matches?(_resource, "*"), do: true
+
+  defp resource_matches?(resource, name) when is_binary(name) do
+    to_string(AshGrant.Info.resource_name(resource)) == name
+  end
+
+  defp resource_matches?(_, _), do: false
+
+  defp scope_atom_in?(scope_str, scopes) do
+    case safe_to_existing_atom(scope_str) do
+      nil -> false
+      atom -> atom in scopes
+    end
+  end
+
+  defp safe_to_existing_atom(s) when is_atom(s), do: s
+
+  defp safe_to_existing_atom(s) when is_binary(s) do
+    String.to_existing_atom(s)
+  rescue
+    ArgumentError -> nil
+  end
+
+  # --- path resolution ------------------------------------------------------
+
+  defp resolve_value(%{action_type: :create} = cs, [first_rel | rest]) do
+    with %{source_attribute: source_attr, destination: destination} <-
+           Ash.Resource.Info.relationship(cs.resource, first_rel),
+         fk_value when not is_nil(fk_value) <- Changeset.get_attribute(cs, source_attr),
+         head when not is_nil(head) <- safe_get(destination, fk_value) do
+      traverse(head, rest)
+    else
+      _ -> :skip
+    end
+  end
+
+  defp resolve_value(cs, path) do
+    {rel_path, leaf} = split_relationship_path(cs.resource, path)
+
+    case safe_load(cs.data, build_load(rel_path)) do
+      {:ok, loaded} -> traverse_loaded(loaded, rel_path, leaf)
+      :error -> :skip
+    end
+  end
+
+  # Walk down a path that's already loaded (for create case, we've already
+  # loaded the first hop — traverse the rest).
+  defp traverse(record, []), do: {:ok, record}
+
+  defp traverse(record, [key | rest]) do
+    case Map.get(record, key) do
+      nil -> :skip
+      %Ash.NotLoaded{} -> :skip
+      next -> traverse(next, rest)
+    end
+  end
+
+  # For update/destroy: we load the relationship chain, then dereference.
+  defp traverse_loaded(loaded, rel_path, leaf) do
+    case drill(loaded, rel_path) do
+      nil -> :skip
+      %Ash.NotLoaded{} -> :skip
+      record -> {:ok, Map.get(record, leaf)}
+    end
+  end
+
+  defp drill(record, []), do: record
+
+  defp drill(record, [key | rest]) do
+    case Map.get(record, key) do
+      nil -> nil
+      %Ash.NotLoaded{} -> nil
+      next -> drill(next, rest)
+    end
+  end
+
+  # Split [:order, :center_id] into {rel_path=[:order], leaf=:center_id} by
+  # walking relationships until we hit a non-relationship key.
+  @doc false
+  def split_relationship_path(resource, path) do
+    do_split(resource, path, [])
+  end
+
+  defp do_split(_resource, [leaf], rel_path), do: {Enum.reverse(rel_path), leaf}
+
+  defp do_split(resource, [key | rest], rel_path) do
+    case Ash.Resource.Info.relationship(resource, key) do
+      nil ->
+        # Key is not a relationship — treat as leaf if nothing follows, else error.
+        # (The transformer validates this shape at compile time; at runtime we
+        # treat it as a leaf to avoid crashing.)
+        if rest == [] do
+          {Enum.reverse(rel_path), key}
+        else
+          {Enum.reverse(rel_path), key}
+        end
+
+      %{destination: destination} ->
+        do_split(destination, rest, [key | rel_path])
+    end
+  end
+
+  # Build a load spec usable by Ash.load — [:order] | [order: :customer] | etc.
+  defp build_load([]), do: nil
+  defp build_load([rel]), do: rel
+  defp build_load([rel | rest]), do: [{rel, build_load(rest)}]
+
+  defp safe_get(resource, id) do
+    Ash.get!(resource, id, authorize?: false)
+  rescue
+    _ -> nil
+  end
+
+  defp safe_load(_data, nil), do: {:ok, nil}
+
+  defp safe_load(data, load_spec) do
+    {:ok, Ash.load!(data, load_spec, authorize?: false)}
+  rescue
+    _ -> :error
+  end
+end

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -339,6 +339,64 @@ defmodule AshGrant.Dsl do
     ]
   }
 
+  @resolve_argument %Spark.Dsl.Entity{
+    name: :resolve_argument,
+    describe: """
+    Declares an action argument that should be auto-populated from the record's
+    own relationships before scope evaluation, enabling argument-based scopes
+    like `expr(^arg(:center_id) in ^actor(:own_org_unit_ids))`.
+
+    The transformer generates an `argument` declaration and a lazy `change` on
+    each write action (create, update, destroy) on the resource. At runtime the
+    change only performs the DB load if one of the actor's in-play permissions
+    uses a scope that actually references `^arg(<name>)` — so scopes that do
+    not need the value pay nothing.
+
+    ## Examples
+
+        # Single-hop — Refund → Order.center_id
+        resolve_argument :center_id, from_path: [:order, :center_id]
+
+        # Multi-hop — Refund → Order.customer.organization_id
+        resolve_argument :organization_id,
+          from_path: [:order, :customer, :organization_id]
+
+        # Limit to specific write actions
+        resolve_argument :center_id,
+          from_path: [:order, :center_id],
+          for_actions: [:update, :destroy]
+    """,
+    examples: [
+      "resolve_argument :center_id, from_path: [:order, :center_id]",
+      "resolve_argument :organization_id, from_path: [:order, :customer, :organization_id]",
+      "resolve_argument :center_id, from_path: [:order, :center_id], for_actions: [:update]"
+    ],
+    target: AshGrant.Dsl.ResolveArgument,
+    args: [:name],
+    schema: [
+      name: [
+        type: :atom,
+        required: true,
+        doc:
+          "The argument name to populate — must be referenced as `^arg(<name>)` in at least one scope"
+      ],
+      from_path: [
+        type: {:list, :atom},
+        required: true,
+        doc:
+          "Path from this resource to the leaf attribute. Intermediate keys must be belongs_to " <>
+            "relationships; the final key must be an attribute. Example: `[:order, :center_id]`."
+      ],
+      for_actions: [
+        type: {:list, :atom},
+        required: false,
+        doc:
+          "Restrict argument resolution to specific write actions. " <>
+            "Defaults to all create/update/destroy actions on the resource."
+      ]
+    ]
+  }
+
   @scope_through %Spark.Dsl.Entity{
     name: :scope_through,
     describe: """
@@ -403,7 +461,7 @@ defmodule AshGrant.Dsl do
       end
       """
     ],
-    entities: [@scope, @field_group, @can_perform, @scope_through],
+    entities: [@scope, @field_group, @can_perform, @scope_through, @resolve_argument],
     schema: [
       resolver: [
         type: {:or, [{:behaviour, AshGrant.PermissionResolver}, {:fun, 2}]},
@@ -620,6 +678,32 @@ defmodule AshGrant.Dsl.FieldGroup do
           mask: [atom()] | nil,
           mask_with: (any(), atom() -> any()) | nil,
           description: String.t() | nil,
+          __spark_metadata__: map() | nil
+        }
+end
+
+defmodule AshGrant.Dsl.ResolveArgument do
+  @moduledoc """
+  Represents a `resolve_argument` declaration in the AshGrant DSL.
+
+  Declares that an action argument should be auto-populated from the resource's
+  own relationships so that argument-based scopes (e.g., `^arg(:center_id)`)
+  evaluate correctly without the scope itself having to traverse relationships.
+
+  ## Fields
+
+  - `:name` — the argument name
+  - `:from_path` — list of atoms walking relationships to the leaf attribute
+    (intermediates must be belongs_to, leaf must be an attribute)
+  - `:for_actions` — optional list of action names; defaults to all write actions
+  """
+
+  defstruct [:name, :from_path, :for_actions, :__spark_metadata__]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          from_path: [atom()],
+          for_actions: [atom()] | nil,
           __spark_metadata__: map() | nil
         }
 end

--- a/lib/ash_grant/info.ex
+++ b/lib/ash_grant/info.ex
@@ -176,6 +176,15 @@ defmodule AshGrant.Info do
   end
 
   @doc """
+  Gets all `resolve_argument` declarations for a resource.
+  """
+  @spec resolve_arguments(Ash.Resource.t()) :: [AshGrant.Dsl.ResolveArgument.t()]
+  def resolve_arguments(resource) do
+    Spark.Dsl.Extension.get_entities(resource, [:ash_grant])
+    |> Enum.filter(&match?(%AshGrant.Dsl.ResolveArgument{}, &1))
+  end
+
+  @doc """
   Gets all field group definitions for a resource.
   """
   @spec field_groups(Ash.Resource.t()) :: [AshGrant.Dsl.FieldGroup.t()]

--- a/lib/ash_grant/transformers/add_argument_resolvers.ex
+++ b/lib/ash_grant/transformers/add_argument_resolvers.ex
@@ -1,0 +1,353 @@
+defmodule AshGrant.Transformers.AddArgumentResolvers do
+  @moduledoc """
+  Spark DSL transformer that wires up `resolve_argument` declarations.
+
+  For every `resolve_argument :name, from_path: [...]` declaration:
+
+    1. Validates the path at compile time (intermediates are belongs_to, leaf
+       is an attribute).
+    2. Validates that at least one scope references `^arg(:name)` in its
+       resolved filter (rejecting dead declarations).
+    3. For every targeted write action (`:create`, `:update`, `:destroy`, or
+       the explicit `:for_actions` list), injects:
+        * an `argument :name, <type>, allow_nil?: true` with the type inferred
+          from the leaf attribute (if the action does not already declare it)
+        * a `change {AshGrant.Changes.ResolveArgument, [name:, path:,
+          scopes_needing:]}` with `scopes_needing` computed at compile time
+  """
+
+  use Spark.Dsl.Transformer
+
+  require Ash.Expr
+
+  alias Spark.Dsl.Transformer
+  alias AshGrant.ArgumentAnalyzer
+
+  @write_action_types [:create, :update, :destroy]
+
+  @impl true
+  def after?(AshGrant.Transformers.MergeDomainConfig), do: true
+  def after?(_), do: false
+
+  @impl true
+  def before?(Ash.Policy.Authorizer), do: true
+  def before?(AshGrant.Transformers.AddDefaultPolicies), do: true
+  def before?(_), do: false
+
+  @impl true
+  def transform(dsl_state) do
+    resolve_args =
+      dsl_state
+      |> Transformer.get_entities([:ash_grant])
+      |> Enum.filter(&match?(%AshGrant.Dsl.ResolveArgument{}, &1))
+
+    case resolve_args do
+      [] ->
+        {:ok, dsl_state}
+
+      declarations ->
+        resource = Transformer.get_persisted(dsl_state, :module)
+        arg_map = build_arg_map(dsl_state)
+
+        Enum.reduce_while(declarations, {:ok, dsl_state}, fn decl, {:ok, state} ->
+          with :ok <- validate_referenced_by_scope(decl, arg_map, resource),
+               {:ok, leaf_type} <- validate_and_resolve_path(state, decl, resource),
+               {:ok, new_state} <-
+                 install_on_actions(state, decl, leaf_type, arg_map, resource) do
+            {:cont, {:ok, new_state}}
+          else
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+        end)
+    end
+  end
+
+  # Compute %{arg_name => [scope_names]} by walking all scope filters in the
+  # DSL state (not the compiled resource — it's not compiled yet).
+  defp build_arg_map(dsl_state) do
+    dsl_state
+    |> Transformer.get_entities([:ash_grant])
+    |> Enum.filter(&match?(%AshGrant.Dsl.Scope{}, &1))
+    |> Enum.reduce(%{}, fn scope, acc ->
+      resolved = resolve_scope_in_dsl(dsl_state, scope)
+      args = ArgumentAnalyzer.referenced_args(resolved)
+
+      Enum.reduce(args, acc, fn arg, inner ->
+        Map.update(inner, arg, [scope.name], &Enum.uniq([scope.name | &1]))
+      end)
+    end)
+  end
+
+  # Resolve a scope's filter with inheritance from the in-progress DSL state.
+  defp resolve_scope_in_dsl(dsl_state, %AshGrant.Dsl.Scope{} = scope) do
+    base = if scope.write == nil, do: scope.filter, else: scope.write
+
+    case base do
+      false ->
+        false
+
+      _ ->
+        parents = scope.inherits || []
+
+        parent_filters =
+          Enum.map(parents, fn parent_name ->
+            find_scope(dsl_state, parent_name)
+            |> case do
+              nil -> true
+              parent -> resolve_scope_in_dsl(dsl_state, parent)
+            end
+          end)
+
+        combine(parent_filters, base)
+    end
+  end
+
+  defp find_scope(dsl_state, name) do
+    dsl_state
+    |> Transformer.get_entities([:ash_grant])
+    |> Enum.find(&(match?(%AshGrant.Dsl.Scope{}, &1) and &1.name == name))
+  end
+
+  defp combine(parent_filters, base) do
+    non_true = Enum.reject(parent_filters, &(&1 == true))
+
+    case {non_true, base} do
+      {[], filter} -> filter
+      {filters, true} -> and_all(filters)
+      {filters, filter} -> and_all(filters ++ [filter])
+    end
+  end
+
+  defp and_all([single]), do: single
+
+  defp and_all([first | rest]) do
+    Enum.reduce(rest, first, fn f, acc -> Ash.Expr.expr(^acc and ^f) end)
+  end
+
+  defp validate_referenced_by_scope(%{name: name} = decl, arg_map, resource) do
+    if Map.has_key?(arg_map, name) and arg_map[name] != [] do
+      :ok
+    else
+      {:error,
+       Spark.Error.DslError.exception(
+         module: resource,
+         path: [:ash_grant, :resolve_argument, name],
+         message: """
+         resolve_argument :#{name} is declared but no scope references ^arg(:#{name}).
+
+         Either add an expression like `expr(^arg(:#{name}) == some_attribute)` to at
+         least one scope, or remove this declaration. Declaration: #{inspect(decl)}
+         """
+       )}
+    end
+  end
+
+  defp validate_and_resolve_path(dsl_state, %{name: name, from_path: path}, resource) do
+    do_validate_path(dsl_state, resource, path, [], {:dsl, dsl_state, resource}, name)
+  end
+
+  defp do_validate_path(_dsl_state, _original_resource, [], _traversed, _cursor, name) do
+    {:error,
+     Spark.Error.DslError.exception(
+       path: [:ash_grant, :resolve_argument, name],
+       message: "resolve_argument :#{name} requires a non-empty from_path"
+     )}
+  end
+
+  defp do_validate_path(dsl_state, original_resource, [leaf], traversed, cursor, name) do
+    case lookup_relationship(cursor, leaf) do
+      {:ok, _rel} ->
+        {:error,
+         Spark.Error.DslError.exception(
+           module: original_resource,
+           path: [:ash_grant, :resolve_argument, name],
+           message: """
+           resolve_argument :#{name} — path #{inspect(traversed ++ [leaf])} ends on a
+           relationship (:#{leaf}). The final path segment must be an attribute, not
+           a relationship.
+           """
+         )}
+
+      :error ->
+        case lookup_attribute(cursor, leaf) do
+          {:ok, %{type: type}} ->
+            _ = dsl_state
+            {:ok, type}
+
+          :error ->
+            {:error,
+             Spark.Error.DslError.exception(
+               module: original_resource,
+               path: [:ash_grant, :resolve_argument, name],
+               message: """
+               resolve_argument :#{name} — path #{inspect(traversed ++ [leaf])} ends at
+               :#{leaf} on #{inspect(cursor_module(cursor))}, but that is neither a
+               relationship nor an attribute. The final path segment must be an attribute.
+               """
+             )}
+        end
+    end
+  end
+
+  defp do_validate_path(dsl_state, original_resource, [key | rest], traversed, cursor, name) do
+    case lookup_relationship(cursor, key) do
+      :error ->
+        {:error,
+         Spark.Error.DslError.exception(
+           module: original_resource,
+           path: [:ash_grant, :resolve_argument, name],
+           message: """
+           resolve_argument :#{name} — #{inspect(cursor_module(cursor))} has no
+           relationship :#{key} (at path segment #{inspect(traversed ++ [key])}).
+           """
+         )}
+
+      {:ok, %{type: :belongs_to, destination: destination}} ->
+        do_validate_path(
+          dsl_state,
+          original_resource,
+          rest,
+          traversed ++ [key],
+          {:compiled, destination},
+          name
+        )
+
+      {:ok, %{type: type}} ->
+        {:error,
+         Spark.Error.DslError.exception(
+           module: original_resource,
+           path: [:ash_grant, :resolve_argument, name],
+           message: """
+           resolve_argument :#{name} — intermediate relationship :#{key} on
+           #{inspect(cursor_module(cursor))} is a :#{type}, but only :belongs_to is
+           supported for intermediate path segments.
+           """
+         )}
+    end
+  end
+
+  # --- cursor helpers -------------------------------------------------------
+  # {:dsl, dsl_state, resource} — we are inside the current resource's DSL
+  # {:compiled, module}         — we are on a different, already-compiled resource
+
+  defp cursor_module({:dsl, _dsl_state, resource}), do: resource
+  defp cursor_module({:compiled, module}), do: module
+
+  defp lookup_relationship({:dsl, dsl_state, _resource}, name) do
+    dsl_state
+    |> Transformer.get_entities([:relationships])
+    |> Enum.find(&(&1.name == name))
+    |> case do
+      nil -> :error
+      rel -> {:ok, rel}
+    end
+  end
+
+  defp lookup_relationship({:compiled, module}, name) do
+    case Ash.Resource.Info.relationship(module, name) do
+      nil -> :error
+      rel -> {:ok, rel}
+    end
+  end
+
+  defp lookup_attribute({:dsl, dsl_state, _resource}, name) do
+    dsl_state
+    |> Transformer.get_entities([:attributes])
+    |> Enum.find(&(&1.name == name))
+    |> case do
+      nil -> :error
+      attr -> {:ok, attr}
+    end
+  end
+
+  defp lookup_attribute({:compiled, module}, name) do
+    case Ash.Resource.Info.attribute(module, name) do
+      nil -> :error
+      attr -> {:ok, attr}
+    end
+  end
+
+  defp install_on_actions(dsl_state, decl, leaf_type, arg_map, resource) do
+    scopes_needing = Map.get(arg_map, decl.name, [])
+
+    target_actions =
+      dsl_state
+      |> Transformer.get_entities([:actions])
+      |> Enum.filter(&target_action?(&1, decl.for_actions))
+
+    validate_explicit_actions_exist!(decl, target_actions, resource)
+
+    result =
+      Enum.reduce(target_actions, dsl_state, fn action, state ->
+        {:ok, new_state} = install_on_action(state, action, decl, leaf_type, scopes_needing)
+        new_state
+      end)
+
+    {:ok, result}
+  end
+
+  defp target_action?(%{type: type, name: name}, for_actions) do
+    type in @write_action_types and
+      (for_actions == nil or name in for_actions)
+  end
+
+  defp target_action?(_, _), do: false
+
+  defp validate_explicit_actions_exist!(%{for_actions: nil}, _actions, _resource), do: :ok
+
+  defp validate_explicit_actions_exist!(
+         %{for_actions: requested, name: arg_name},
+         matched_actions,
+         resource
+       ) do
+    matched_names = MapSet.new(matched_actions, & &1.name)
+    missing = Enum.reject(requested, &MapSet.member?(matched_names, &1))
+
+    if missing == [] do
+      :ok
+    else
+      raise Spark.Error.DslError,
+        module: resource,
+        path: [:ash_grant, :resolve_argument, arg_name, :for_actions],
+        message: """
+        resolve_argument :#{arg_name} :for_actions references actions
+        #{inspect(missing)} that are not defined as create/update/destroy actions on
+        #{inspect(resource)}.
+        """
+    end
+  end
+
+  defp install_on_action(dsl_state, action, decl, leaf_type, scopes_needing) do
+    new_action =
+      action
+      |> ensure_argument(decl.name, leaf_type)
+      |> append_change(decl, scopes_needing)
+
+    matcher = fn existing ->
+      existing.__struct__ == action.__struct__ and existing.name == action.name
+    end
+
+    {:ok, Transformer.replace_entity(dsl_state, [:actions], new_action, matcher)}
+  end
+
+  defp ensure_argument(action, arg_name, leaf_type) do
+    if Enum.any?(action.arguments, &(&1.name == arg_name)) do
+      action
+    else
+      {:ok, argument} =
+        Ash.Resource.Builder.build_action_argument(arg_name, leaf_type, allow_nil?: true)
+
+      %{action | arguments: action.arguments ++ [argument]}
+    end
+  end
+
+  defp append_change(action, decl, scopes_needing) do
+    {:ok, change} =
+      Ash.Resource.Builder.build_action_change(
+        {AshGrant.Changes.ResolveArgument,
+         name: decl.name, path: decl.from_path, scopes_needing: scopes_needing}
+      )
+
+    %{action | changes: action.changes ++ [change]}
+  end
+end

--- a/test/ash_grant/argument_analyzer_test.exs
+++ b/test/ash_grant/argument_analyzer_test.exs
@@ -1,0 +1,120 @@
+defmodule AshGrant.ArgumentAnalyzerTest do
+  @moduledoc """
+  Unit tests for `AshGrant.ArgumentAnalyzer` — the compile-time AST walker that
+  extracts `^arg(...)` references from scope expressions.
+
+  Tests use raw Ash expression AST fragments (not full DSL wiring) to isolate
+  the walker from the rest of the extension.
+  """
+  use ExUnit.Case, async: true
+
+  require Ash.Expr
+  import Ash.Expr
+
+  alias AshGrant.ArgumentAnalyzer
+
+  describe "referenced_args/1 — leaves" do
+    test "true/false/nil return []" do
+      assert ArgumentAnalyzer.referenced_args(true) == []
+      assert ArgumentAnalyzer.referenced_args(false) == []
+      assert ArgumentAnalyzer.referenced_args(nil) == []
+    end
+
+    test "bare template tuple is detected" do
+      assert ArgumentAnalyzer.referenced_args({:_arg, :center_id}) == [:center_id]
+    end
+
+    test "an actor template alone returns []" do
+      assert ArgumentAnalyzer.referenced_args({:_actor, :id}) == []
+    end
+
+    test "plain values return []" do
+      assert ArgumentAnalyzer.referenced_args(42) == []
+      assert ArgumentAnalyzer.referenced_args("hello") == []
+      assert ArgumentAnalyzer.referenced_args(:an_atom) == []
+    end
+  end
+
+  describe "referenced_args/1 — Ash expressions" do
+    test "direct-attribute == actor has no arg refs" do
+      expr = expr(author_id == ^actor(:id))
+      assert ArgumentAnalyzer.referenced_args(expr) == []
+    end
+
+    test "^arg(...) == actor(...) is detected" do
+      expr = expr(^arg(:center_id) == ^actor(:team_id))
+      assert ArgumentAnalyzer.referenced_args(expr) == [:center_id]
+    end
+
+    test "^arg(...) in ^actor(list) is detected" do
+      expr = expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+      assert ArgumentAnalyzer.referenced_args(expr) == [:center_id]
+    end
+
+    test "conjunction of two arg refs yields both, no duplicates" do
+      expr =
+        expr(
+          ^arg(:center_id) in ^actor(:own_org_unit_ids) and
+            ^arg(:organization_id) == ^actor(:org_id)
+        )
+
+      assert :center_id in ArgumentAnalyzer.referenced_args(expr)
+      assert :organization_id in ArgumentAnalyzer.referenced_args(expr)
+      assert length(ArgumentAnalyzer.referenced_args(expr)) == 2
+    end
+
+    test "same arg repeated yields a single entry" do
+      expr = expr(^arg(:x) == 1 or ^arg(:x) == 2)
+      assert ArgumentAnalyzer.referenced_args(expr) == [:x]
+    end
+
+    test "not(...) traverses into inner expression" do
+      expr = expr(not (^arg(:x) == 1))
+      assert ArgumentAnalyzer.referenced_args(expr) == [:x]
+    end
+
+    test "if(...) function wrapper exposes inner arg refs" do
+      expr =
+        expr(if(^arg(:enabled) == true, do: ^arg(:center_id), else: nil) == nil)
+
+      args = ArgumentAnalyzer.referenced_args(expr)
+      assert :enabled in args
+      assert :center_id in args
+    end
+
+    test "exists() body arg refs surface" do
+      expr = expr(exists(items, ^arg(:threshold) < amount))
+      assert ArgumentAnalyzer.referenced_args(expr) == [:threshold]
+    end
+
+    test "only actor/tenant references but no arg yield []" do
+      expr = expr(org_id == ^actor(:org_id) and tenant_id == ^tenant())
+      assert ArgumentAnalyzer.referenced_args(expr) == []
+    end
+  end
+
+  describe "references_arg?/2" do
+    test "delegates to referenced_args/1" do
+      expr = expr(^arg(:a) == ^arg(:b))
+      assert ArgumentAnalyzer.references_arg?(expr, :a)
+      assert ArgumentAnalyzer.references_arg?(expr, :b)
+      refute ArgumentAnalyzer.references_arg?(expr, :c)
+    end
+  end
+
+  describe "arg_to_scopes/1" do
+    test "returns %{} when no scopes reference any arg" do
+      # BulkItem has no ^arg(...) scopes at all
+      assert ArgumentAnalyzer.arg_to_scopes(AshGrant.Test.BulkItem) == %{}
+    end
+
+    test "includes every scope (including composites) that transitively references the arg" do
+      # RefundDsl has scope :at_own_unit referencing ^arg(:center_id).
+      # :by_own_author and :always do not.
+      map = ArgumentAnalyzer.arg_to_scopes(AshGrant.Test.Auth.RefundDsl)
+
+      assert Map.keys(map) == [:center_id]
+      assert Enum.sort(map[:center_id]) == [:at_own_unit]
+    end
+  end
+end

--- a/test/ash_grant/resolve_argument_defaults_test.exs
+++ b/test/ash_grant/resolve_argument_defaults_test.exs
@@ -1,0 +1,194 @@
+defmodule AshGrant.ResolveArgumentDefaultsTest do
+  @moduledoc """
+  Validates that `default_policies true` + `resolve_argument` compose cleanly:
+  a resource can declare its entire authorization setup inside the `ash_grant`
+  block with no explicit `policies` or per-action `argument`/`change` wiring.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshGrant.Test.Auth.{Order, RefundDefaults}
+
+  setup do
+    RefundDefaults
+    |> Ash.read!(authorize?: false)
+    |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+
+    Order
+    |> Ash.read!(authorize?: false)
+    |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+
+    :ok
+  end
+
+  defp actor_with(perms, actor_id, attrs) do
+    Map.merge(%{id: actor_id, permissions: perms}, attrs)
+  end
+
+  defp create_order!(center_id) do
+    Order
+    |> Ash.Changeset.for_create(:create, %{center_id: center_id})
+    |> Ash.create!(authorize?: false)
+  end
+
+  defp create_refund!(author_id, order_id, amount \\ 100) do
+    RefundDefaults
+    |> Ash.Changeset.for_create(
+      :create,
+      %{author_id: author_id, order_id: order_id, amount: amount}
+    )
+    |> Ash.create!(authorize?: false)
+  end
+
+  describe "zero-boilerplate authorization via default_policies + resolve_argument" do
+    test "update succeeds when the relational scope matches" do
+      actor_id = Ash.UUID.generate()
+      center = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund_defaults:*:update:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [center]
+        })
+
+      order = create_order!(center)
+      refund = create_refund!(actor_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+        |> Ash.update(actor: actor)
+
+      assert {:ok, updated} = result
+      assert updated.amount == 200
+    end
+
+    test "update is forbidden when the relational scope does not match" do
+      actor_id = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund_defaults:*:update:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [Ash.UUID.generate()]
+        })
+
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(actor_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "direct-attribute scope still works without loading order" do
+      actor_id = Ash.UUID.generate()
+      actor = actor_with(["refund_defaults:*:update:by_own_author"], actor_id, %{})
+
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(actor_id, order.id)
+
+      cs = Ash.Changeset.for_update(refund, :update, %{amount: 200}, actor: actor)
+
+      # Lazy load skipped: no perm references ^arg(:center_id)
+      refute match?(%{center_id: v} when not is_nil(v), cs.arguments)
+
+      assert {:ok, _} = Ash.update(cs, actor: actor)
+    end
+
+    test "create succeeds with the relational scope" do
+      actor_id = Ash.UUID.generate()
+      center = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund_defaults:*:create:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [center]
+        })
+
+      order = create_order!(center)
+
+      result =
+        RefundDefaults
+        |> Ash.Changeset.for_create(
+          :create,
+          %{author_id: actor_id, order_id: order.id, amount: 50},
+          actor: actor
+        )
+        |> Ash.create(actor: actor)
+
+      assert {:ok, _} = result
+    end
+
+    test "read is filter-checked via default_policies" do
+      actor_id = Ash.UUID.generate()
+      order = create_order!(Ash.UUID.generate())
+      _refund = create_refund!(actor_id, order.id)
+
+      # With read:by_own_author, filter_check produces a matching filter
+      granted = actor_with(["refund_defaults:*:read:by_own_author"], actor_id, %{})
+      assert {:ok, [_]} = Ash.read(RefundDefaults, actor: granted)
+
+      # Same actor, a different author's record should be invisible
+      other_id = Ash.UUID.generate()
+      _other_refund = create_refund!(other_id, order.id)
+
+      assert {:ok, results} = Ash.read(RefundDefaults, actor: granted)
+      assert length(results) == 1
+      assert hd(results).author_id == actor_id
+    end
+
+    test "without any authorizing permission, write is forbidden" do
+      actor_id = Ash.UUID.generate()
+      actor = actor_with([], actor_id, %{})
+
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(actor_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
+
+  describe "DSL introspection" do
+    test "transformer injected both argument and change despite no explicit wiring" do
+      for action_name <- [:create, :update, :destroy] do
+        action = Ash.Resource.Info.action(RefundDefaults, action_name)
+
+        assert Enum.any?(action.arguments, &(&1.name == :center_id)),
+               "expected :center_id argument on :#{action_name}"
+
+        assert Enum.any?(action.changes, fn c ->
+                 match?({AshGrant.Changes.ResolveArgument, _}, c.change)
+               end),
+               "expected ResolveArgument change on :#{action_name}"
+      end
+    end
+
+    test "default_policies generated read + write policies" do
+      policies = Ash.Policy.Info.policies(RefundDefaults)
+
+      # One read policy (filter_check), one write policy (check), one generic action policy
+      assert Enum.any?(policies, fn p ->
+               Enum.any?(p.condition, fn
+                 {Ash.Policy.Check.ActionType, opts} -> opts[:type] == [:read]
+                 _ -> false
+               end)
+             end),
+             "expected a default-generated read policy"
+
+      assert Enum.any?(policies, fn p ->
+               Enum.any?(p.condition, fn
+                 {Ash.Policy.Check.ActionType, opts} ->
+                   opts[:type] == [:create, :update, :destroy]
+
+                 _ ->
+                   false
+               end)
+             end),
+             "expected a default-generated write policy"
+    end
+  end
+end

--- a/test/ash_grant/resolve_argument_dsl_test.exs
+++ b/test/ash_grant/resolve_argument_dsl_test.exs
@@ -1,0 +1,232 @@
+defmodule AshGrant.ResolveArgumentDslTest do
+  @moduledoc """
+  Tests the `resolve_argument` DSL sugar end-to-end: the transformer injects an
+  argument declaration + a lazy change on each write action, and the change
+  only performs the DB load when a permission-in-play references the argument.
+
+  Mirrors the semantics tested by `AshGrant.ArgumentBasedScopeTest` (which
+  uses a hand-rolled change module) so the two implementations can be compared
+  1:1.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshGrant.Test.Auth.{Order, RefundDsl}
+
+  setup do
+    RefundDsl |> Ash.read!(authorize?: false) |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+    Order |> Ash.read!(authorize?: false) |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+    :ok
+  end
+
+  defp actor_with(perms, actor_id, attrs) do
+    Map.merge(%{id: actor_id, permissions: perms}, attrs)
+  end
+
+  defp create_order!(center_id) do
+    Order
+    |> Ash.Changeset.for_create(:create, %{center_id: center_id})
+    |> Ash.create!(authorize?: false)
+  end
+
+  defp create_refund!(author_id, order_id, amount \\ 100) do
+    RefundDsl
+    |> Ash.Changeset.for_create(:create, %{
+      author_id: author_id,
+      order_id: order_id,
+      amount: amount
+    })
+    |> Ash.create!(authorize?: false)
+  end
+
+  describe ":at_own_unit scope (argument-based, needs order.center_id)" do
+    test "update succeeds when order's center_id is in actor's allowed units" do
+      actor_id = Ash.UUID.generate()
+      center_a = Ash.UUID.generate()
+      center_b = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund_dsl:*:update:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [center_a, center_b]
+        })
+
+      order = create_order!(center_a)
+      refund = create_refund!(actor_id, order.id)
+
+      cs = Ash.Changeset.for_update(refund, :update, %{amount: 200}, actor: actor)
+
+      # DSL-injected change populated the argument
+      assert cs.arguments[:center_id] == center_a
+
+      assert {:ok, updated} = Ash.update(cs, actor: actor)
+      assert updated.amount == 200
+    end
+
+    test "update is forbidden when order's center_id is not in actor's units" do
+      actor_id = Ash.UUID.generate()
+      actor_center = Ash.UUID.generate()
+      other_center = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund_dsl:*:update:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [actor_center]
+        })
+
+      order = create_order!(other_center)
+      refund = create_refund!(actor_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "create succeeds when order's center_id is in actor's allowed units" do
+      actor_id = Ash.UUID.generate()
+      center = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund_dsl:*:create:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [center]
+        })
+
+      order = create_order!(center)
+
+      result =
+        RefundDsl
+        |> Ash.Changeset.for_create(
+          :create,
+          %{author_id: actor_id, order_id: order.id, amount: 50},
+          actor: actor
+        )
+        |> Ash.create(actor: actor)
+
+      assert {:ok, _} = result
+    end
+
+    test "create is forbidden when order's center_id is not in actor's units" do
+      actor_id = Ash.UUID.generate()
+      actor_center = Ash.UUID.generate()
+      other_center = Ash.UUID.generate()
+
+      actor =
+        actor_with(["refund_dsl:*:create:at_own_unit"], actor_id, %{
+          own_org_unit_ids: [actor_center]
+        })
+
+      order = create_order!(other_center)
+
+      result =
+        RefundDsl
+        |> Ash.Changeset.for_create(
+          :create,
+          %{author_id: actor_id, order_id: order.id, amount: 50},
+          actor: actor
+        )
+        |> Ash.create(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "destroy succeeds when order's center_id is in actor's units" do
+      actor_id = Ash.UUID.generate()
+      center = Ash.UUID.generate()
+
+      actor =
+        actor_with(
+          ["refund_dsl:*:destroy:at_own_unit", "refund_dsl:*:read:always"],
+          actor_id,
+          %{own_org_unit_ids: [center]}
+        )
+
+      order = create_order!(center)
+      refund = create_refund!(actor_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_destroy(:destroy, %{}, actor: actor)
+        |> Ash.destroy(actor: actor)
+
+      assert :ok = result
+    end
+  end
+
+  describe ":by_own_author scope (direct attribute, no relationship)" do
+    test "update succeeds on author match without populating the argument" do
+      actor_id = Ash.UUID.generate()
+
+      actor = actor_with(["refund_dsl:*:update:by_own_author"], actor_id, %{})
+
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(actor_id, order.id)
+
+      cs = Ash.Changeset.for_update(refund, :update, %{amount: 200}, actor: actor)
+
+      # Key correctness property: the DSL-injected change saw no permission
+      # referencing ^arg(:center_id), so it left the argument unset.
+      refute match?(%{center_id: value} when not is_nil(value), cs.arguments)
+
+      assert {:ok, updated} = Ash.update(cs, actor: actor)
+      assert updated.amount == 200
+    end
+
+    test "update is forbidden when author doesn't match" do
+      actor_id = Ash.UUID.generate()
+      other_id = Ash.UUID.generate()
+
+      actor = actor_with(["refund_dsl:*:update:by_own_author"], actor_id, %{})
+
+      order = create_order!(Ash.UUID.generate())
+      refund = create_refund!(other_id, order.id)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor)
+        |> Ash.update(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
+
+  describe "DSL-driven argument injection" do
+    test ":center_id argument is declared on every write action by the transformer" do
+      # All three write actions should carry the injected argument.
+      for action_name <- [:create, :update, :destroy] do
+        action = Ash.Resource.Info.action(RefundDsl, action_name)
+
+        assert Enum.any?(action.arguments, &(&1.name == :center_id)),
+               "expected :center_id argument on action :#{action_name}"
+
+        assert Enum.any?(action.changes, fn c ->
+                 match?({AshGrant.Changes.ResolveArgument, _}, c.change)
+               end),
+               "expected ResolveArgument change on action :#{action_name}"
+      end
+    end
+
+    test "change's :scopes_needing option lists exactly the scopes referencing ^arg(:center_id)" do
+      update = Ash.Resource.Info.action(RefundDsl, :update)
+
+      change =
+        Enum.find(update.changes, fn c ->
+          match?({AshGrant.Changes.ResolveArgument, _}, c.change)
+        end)
+
+      {_mod, opts} = change.change
+      scopes = Keyword.fetch!(opts, :scopes_needing) |> Enum.sort()
+
+      # Only :at_own_unit references ^arg(:center_id) on RefundDsl;
+      # :by_own_author and :always do not.
+      assert scopes == [:at_own_unit]
+    end
+
+    test "argument type is inferred from the leaf attribute type" do
+      update = Ash.Resource.Info.action(RefundDsl, :update)
+      arg = Enum.find(update.arguments, &(&1.name == :center_id))
+
+      # Order.center_id is :uuid
+      assert arg.type == Ash.Type.UUID
+    end
+  end
+end

--- a/test/ash_grant/resolve_argument_property_test.exs
+++ b/test/ash_grant/resolve_argument_property_test.exs
@@ -1,0 +1,211 @@
+defmodule AshGrant.ResolveArgumentPropertyTest do
+  @moduledoc """
+  Property-based tests for `AshGrant.ArgumentAnalyzer` and the
+  `AshGrant.Changes.ResolveArgument` permission-matching logic.
+
+  Rather than test DSL-compiled resources (which can't be generated at runtime),
+  these properties operate directly on:
+
+    * raw Ash expressions constructed with various argument references
+    * mock permission strings + scope maps → check that the runtime would
+      decide correctly whether a load is needed
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  require Ash.Expr
+  import Ash.Expr
+
+  alias AshGrant.ArgumentAnalyzer
+
+  # --- generators ----------------------------------------------------------
+
+  defp arg_name_gen do
+    # small pool for collisions
+    one_of([
+      constant(:center_id),
+      constant(:organization_id),
+      constant(:team_id),
+      constant(:unit_id),
+      constant(:tenant_id)
+    ])
+  end
+
+  # A leaf expression: either a reference, a literal, or an ^arg(...) template.
+  defp leaf_gen do
+    one_of([
+      arg_name_gen() |> map(&{:_arg, &1}),
+      constant({:_actor, :id}),
+      integer(),
+      boolean(),
+      constant(nil),
+      string(:alphanumeric, max_length: 5)
+    ])
+  end
+
+  # Nested expressions of bounded depth built from AshExpr operators. We build
+  # the nested shape via Ash.Expr constructors so the output goes through the
+  # same pipeline as real scope filters.
+  defp expr_gen(depth) when depth <= 0, do: leaf_gen()
+
+  defp expr_gen(depth) do
+    sub = expr_gen(depth - 1)
+
+    one_of([
+      leaf_gen(),
+      bind({sub, sub}, fn {l, r} -> constant(expr(^l == ^r)) end),
+      bind({sub, sub}, fn {l, r} -> constant(expr(^l and ^r)) end),
+      bind({sub, sub}, fn {l, r} -> constant(expr(^l or ^r)) end),
+      bind(sub, fn e -> constant(expr(not (^e))) end)
+    ])
+  end
+
+  # Collect all {:_arg, name} references in an expression via a naive walk so
+  # we can sanity-check the analyzer against an independent implementation.
+  defp reference_walk({:_arg, name}), do: [name]
+
+  defp reference_walk(value) when is_list(value),
+    do: Enum.flat_map(value, &reference_walk/1)
+
+  defp reference_walk(value) when is_tuple(value),
+    do: value |> Tuple.to_list() |> Enum.flat_map(&reference_walk/1)
+
+  defp reference_walk(%{} = m) when not is_struct(m),
+    do: Enum.flat_map(m, fn {k, v} -> reference_walk(k) ++ reference_walk(v) end)
+
+  defp reference_walk(%_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> Enum.flat_map(fn {k, v} -> reference_walk(k) ++ reference_walk(v) end)
+  end
+
+  defp reference_walk(_), do: []
+
+  # --- properties ----------------------------------------------------------
+
+  property "analyzer finds every ^arg(...) reference present in the expression" do
+    check all(expression <- expr_gen(3)) do
+      analyzer_args = MapSet.new(ArgumentAnalyzer.referenced_args(expression))
+      oracle_args = MapSet.new(reference_walk(expression))
+
+      # Analyzer must find every arg the oracle does. Oracle may have MORE
+      # in theory, but here they must be equal because our expression shapes
+      # only contain arg refs through constructors the analyzer knows about.
+      assert analyzer_args == oracle_args,
+             """
+             analyzer and oracle disagreed.
+               analyzer: #{inspect(analyzer_args)}
+               oracle  : #{inspect(oracle_args)}
+               expr    : #{inspect(expression)}
+             """
+    end
+  end
+
+  property "analyzer returns a list without duplicates" do
+    check all(expression <- expr_gen(3)) do
+      result = ArgumentAnalyzer.referenced_args(expression)
+      assert result == Enum.uniq(result)
+    end
+  end
+
+  property "references_arg?/2 is consistent with referenced_args/1" do
+    check all(
+            expression <- expr_gen(3),
+            probe <- arg_name_gen()
+          ) do
+      expected = probe in ArgumentAnalyzer.referenced_args(expression)
+      assert ArgumentAnalyzer.references_arg?(expression, probe) == expected
+    end
+  end
+
+  # --- runtime permission-matching property --------------------------------
+
+  # Simulates what AshGrant.Changes.ResolveArgument does at runtime:
+  # iterate the actor's permission list, parse each one, and check whether
+  # its scope belongs to scopes_needing for this resource.
+  defp simulate_needs?(actor_perms, resource_name, scopes_needing) do
+    scopes_set = MapSet.new(scopes_needing)
+
+    Enum.any?(actor_perms, fn perm ->
+      case AshGrant.Permission.parse(perm) do
+        {:ok, %{resource: r, scope: s}} ->
+          (r == "*" or r == resource_name) and
+            try do
+              MapSet.member?(scopes_set, String.to_existing_atom(s))
+            rescue
+              ArgumentError -> false
+            end
+
+        _ ->
+          false
+      end
+    end)
+  end
+
+  defp perm_gen(resource, scope_names) do
+    bind({member_of([resource, "*"]), member_of(scope_names)}, fn {r, s} ->
+      constant("#{r}:*:update:#{s}")
+    end)
+  end
+
+  property "needs? is true iff at least one permission's scope is in scopes_needing" do
+    all_scopes = [:at_own_unit, :by_own_author, :within_window, :always]
+    resource_name = "widget"
+
+    check all(
+            scopes_needing <- list_of(member_of(all_scopes), max_length: 4),
+            perms <-
+              list_of(
+                one_of([
+                  constant("widget:*:update:at_own_unit"),
+                  constant("widget:*:update:by_own_author"),
+                  constant("widget:*:update:within_window"),
+                  constant("widget:*:update:always"),
+                  constant("other:*:update:at_own_unit")
+                ]),
+                max_length: 6
+              )
+          ) do
+      scopes_needing = Enum.uniq(scopes_needing)
+
+      expected =
+        Enum.any?(perms, fn p ->
+          case AshGrant.Permission.parse(p) do
+            {:ok, %{resource: r, scope: s}} ->
+              (r == "*" or r == resource_name) and
+                String.to_existing_atom(s) in scopes_needing
+
+            _ ->
+              false
+          end
+        end)
+
+      assert simulate_needs?(perms, resource_name, scopes_needing) == expected
+    end
+  end
+
+  # Property: the analyzer + simulated runtime decision agree — if an actor has
+  # some permissions, the load should fire iff at least one of those perms
+  # references some scope whose resolved expression contains ^arg(:center_id).
+  property "end-to-end: analyzer output drives simulate_needs? consistently" do
+    # Fix the scope set for this property: we'll model a resource with two
+    # scopes — :uses_arg references ^arg(:x), :plain does not.
+    scopes_using_arg = [:uses_arg]
+    scope_pool = [:uses_arg, :plain]
+
+    check all(
+            perms <-
+              list_of(
+                bind(member_of(scope_pool), fn s ->
+                  constant("widget:*:update:#{s}")
+                end),
+                max_length: 5
+              )
+          ) do
+      needs? = simulate_needs?(perms, "widget", scopes_using_arg)
+
+      mentions_uses_arg? = Enum.any?(perms, &String.ends_with?(&1, ":uses_arg"))
+      assert needs? == mentions_uses_arg?
+    end
+  end
+end

--- a/test/ash_grant/resolve_argument_validation_test.exs
+++ b/test/ash_grant/resolve_argument_validation_test.exs
@@ -1,0 +1,168 @@
+defmodule AshGrant.ResolveArgumentValidationTest do
+  @moduledoc """
+  Compile-time validation tests for the `resolve_argument` DSL sugar.
+
+  Each test defines a deliberately invalid resource inside a `fn -> ... end`
+  and asserts that loading it raises a `Spark.Error.DslError` with a helpful
+  message. The resources are wrapped so they are only evaluated when the test
+  calls the function — this way a failed expectation surfaces as a regular
+  assertion failure rather than breaking test loading.
+  """
+  use ExUnit.Case, async: true
+
+  test "rejects :from_path that starts with a non-existent relationship" do
+    defn = fn ->
+      defmodule BadPathMissingRel do
+        @moduledoc false
+        use Ash.Resource,
+          domain: nil,
+          validate_domain_inclusion?: false,
+          data_layer: Ash.DataLayer.Ets,
+          extensions: [AshGrant]
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          scope(:has_ref, expr(^arg(:center_id) == ^actor(:org_id)))
+          resolve_argument(:center_id, from_path: [:nonexistent_rel, :center_id])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+        end
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+      end
+    end
+
+    assert_raise Spark.Error.DslError, ~r/has no[\s\S]*relationship :nonexistent_rel/, fn ->
+      defn.()
+    end
+  end
+
+  test "rejects :from_path whose leaf is a relationship rather than an attribute" do
+    defn = fn ->
+      defmodule BadPathLeafIsRel do
+        @moduledoc false
+        use Ash.Resource,
+          domain: nil,
+          validate_domain_inclusion?: false,
+          data_layer: Ash.DataLayer.Ets,
+          extensions: [AshGrant]
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          scope(:has_ref, expr(^arg(:parent) == ^actor(:id)))
+          resolve_argument(:parent, from_path: [:parent])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:parent_id, :uuid, allow_nil?: true)
+        end
+
+        relationships do
+          belongs_to(:parent, __MODULE__, define_attribute?: false, source_attribute: :parent_id)
+        end
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+      end
+    end
+
+    assert_raise Spark.Error.DslError, ~r/ends on a[\s\S]*relationship/, fn -> defn.() end
+  end
+
+  test "rejects :from_path whose leaf is neither a relationship nor an attribute" do
+    defn = fn ->
+      defmodule BadPathLeafMissing do
+        @moduledoc false
+        use Ash.Resource,
+          domain: nil,
+          validate_domain_inclusion?: false,
+          data_layer: Ash.DataLayer.Ets,
+          extensions: [AshGrant]
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          scope(:has_ref, expr(^arg(:nothing) == ^actor(:id)))
+          resolve_argument(:nothing, from_path: [:nothing_here])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+        end
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+      end
+    end
+
+    assert_raise Spark.Error.DslError, ~r/neither a[\s\S]*relationship nor an attribute/, fn ->
+      defn.()
+    end
+  end
+
+  test "rejects resolve_argument that is not referenced by any scope" do
+    defn = fn ->
+      defmodule DeadResolveArg do
+        @moduledoc false
+        use Ash.Resource,
+          domain: nil,
+          validate_domain_inclusion?: false,
+          data_layer: Ash.DataLayer.Ets,
+          extensions: [AshGrant]
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          scope(:own, expr(author_id == ^actor(:id)))
+          # No scope references ^arg(:center_id) — this is dead code.
+          resolve_argument(:center_id, from_path: [:id])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+          attribute(:author_id, :uuid, allow_nil?: true)
+        end
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+      end
+    end
+
+    assert_raise Spark.Error.DslError, ~r/no scope references/, fn -> defn.() end
+  end
+
+  test "rejects :for_actions that names a non-existent action" do
+    defn = fn ->
+      defmodule BadForActions do
+        @moduledoc false
+        use Ash.Resource,
+          domain: nil,
+          validate_domain_inclusion?: false,
+          data_layer: Ash.DataLayer.Ets,
+          extensions: [AshGrant]
+
+        ash_grant do
+          resolver(fn _, _ -> [] end)
+          scope(:has_ref, expr(^arg(:id) == ^actor(:id)))
+          resolve_argument(:id, from_path: [:id], for_actions: [:nonexistent_action])
+        end
+
+        attributes do
+          uuid_primary_key(:id)
+        end
+
+        actions do
+          defaults([:read, :destroy, create: :*, update: :*])
+        end
+      end
+    end
+
+    assert_raise Spark.Error.DslError, ~r/nonexistent_action/, fn -> defn.() end
+  end
+end

--- a/test/support/auth_pattern/domain.ex
+++ b/test/support/auth_pattern/domain.ex
@@ -5,5 +5,6 @@ defmodule AshGrant.Test.Auth.Domain do
   resources do
     resource(AshGrant.Test.Auth.Order)
     resource(AshGrant.Test.Auth.Refund)
+    resource(AshGrant.Test.Auth.RefundDsl)
   end
 end

--- a/test/support/auth_pattern/domain.ex
+++ b/test/support/auth_pattern/domain.ex
@@ -6,5 +6,6 @@ defmodule AshGrant.Test.Auth.Domain do
     resource(AshGrant.Test.Auth.Order)
     resource(AshGrant.Test.Auth.Refund)
     resource(AshGrant.Test.Auth.RefundDsl)
+    resource(AshGrant.Test.Auth.RefundDefaults)
   end
 end

--- a/test/support/resources/auth_pattern_refund_defaults.ex
+++ b/test/support/resources/auth_pattern_refund_defaults.ex
@@ -1,0 +1,70 @@
+defmodule AshGrant.Test.Auth.RefundDefaults do
+  @moduledoc false
+  # Minimal Refund variant that combines `default_policies true` with
+  # `resolve_argument`: no explicit policies block, no manual argument/change
+  # wiring on actions. The entire authorization setup lives in the
+  # `ash_grant` block.
+
+  use Ash.Resource,
+    domain: AshGrant.Test.Auth.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ets do
+    private?(true)
+  end
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    resource_name("refund_defaults")
+    default_policies(true)
+
+    scope(:always, true)
+    scope(:by_own_author, expr(author_id == ^actor(:id)))
+    scope(:at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids)))
+
+    resolve_argument(:center_id, from_path: [:order, :center_id])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:author_id, :uuid, public?: true, allow_nil?: false)
+    attribute(:amount, :integer, public?: true, allow_nil?: false)
+  end
+
+  relationships do
+    belongs_to :order, AshGrant.Test.Auth.Order do
+      public?(true)
+      allow_nil?(false)
+      attribute_writable?(true)
+    end
+  end
+
+  # No `policies do ... end` — default_policies generates them.
+  # No explicit argument/change declarations — resolve_argument injects them.
+
+  actions do
+    defaults([:read])
+
+    create :create do
+      accept([:author_id, :amount, :order_id])
+    end
+
+    update :update do
+      accept([:amount])
+      require_atomic?(false)
+    end
+
+    destroy :destroy do
+      require_atomic?(false)
+    end
+  end
+end

--- a/test/support/resources/auth_pattern_refund_dsl.ex
+++ b/test/support/resources/auth_pattern_refund_dsl.ex
@@ -1,0 +1,74 @@
+defmodule AshGrant.Test.Auth.RefundDsl do
+  @moduledoc false
+  # Same semantic as AshGrant.Test.Auth.Refund, but using the
+  # `resolve_argument` DSL sugar instead of a hand-rolled change module.
+
+  use Ash.Resource,
+    domain: AshGrant.Test.Auth.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ets do
+    private?(true)
+  end
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    resource_name("refund_dsl")
+
+    scope(:always, true)
+    scope(:by_own_author, expr(author_id == ^actor(:id)))
+    scope(:at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids)))
+
+    resolve_argument(:center_id, from_path: [:order, :center_id])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:author_id, :uuid, public?: true, allow_nil?: false)
+    attribute(:amount, :integer, public?: true, allow_nil?: false)
+  end
+
+  relationships do
+    belongs_to :order, AshGrant.Test.Auth.Order do
+      public?(true)
+      allow_nil?(false)
+      attribute_writable?(true)
+    end
+  end
+
+  policies do
+    policy action_type(:read) do
+      authorize_if(AshGrant.filter_check())
+    end
+
+    policy action_type([:create, :update, :destroy]) do
+      authorize_if(AshGrant.check())
+    end
+  end
+
+  actions do
+    defaults([:read])
+
+    create :create do
+      accept([:author_id, :amount, :order_id])
+    end
+
+    update :update do
+      accept([:amount])
+      require_atomic?(false)
+    end
+
+    destroy :destroy do
+      require_atomic?(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `resolve_argument` inside the `ash_grant` DSL block, auto-wiring an action argument + lazy change on every write action, with introspection-driven loading.

```elixir
ash_grant do
  scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
  scope :at_own_unit_and_small, [:at_own_unit], expr(total_amount <= 100)

  resolve_argument :center_id, from_path: [:order, :center_id]
end
```

The transformer walks every scope at compile time and records which arguments each scope references. At runtime the generated change loads the relationship **only when an in-play permission uses a scope that references the argument** — direct-attribute scopes like `:by_own_author` pay zero cost.

## Why

Relational scopes (`expr(order.center_id in ...)`) force the DB-query fallback path on write actions, which is fragile under composite inheritance (#83), function wrapping (#86), and FK-changing updates. The argument-based pattern keeps scope expressions in-memory-evaluable and moves the relationship traversal into the resource's own pipeline. #88 enabled `^arg(...)` in scopes; this PR makes the pattern ergonomic.

## Components

- `AshGrant.Dsl.ResolveArgument` — entity struct
- DSL entity registered in `lib/ash_grant/dsl.ex`
- `AshGrant.Info.resolve_arguments/1` — runtime introspection
- `AshGrant.ArgumentAnalyzer` — AST walker extracting `{:_arg, name}` refs
- `AshGrant.Transformers.AddArgumentResolvers` — compile-time wiring, path validation, dead-declaration detection
- `AshGrant.Changes.ResolveArgument` — runtime lazy loader handling create (FK → head record → walk rest) and update/destroy (load path on existing data)

## Test breadth

| Suite | Count | Purpose |
|---|---|---|
| `argument_analyzer_test.exs` | 16 | AST walker across all expression shapes |
| `resolve_argument_dsl_test.exs` | 10 | Full DSL → transformer → runtime pipeline |
| `resolve_argument_validation_test.exs` | 5 | Compile-time errors (bad paths, dead decls) |
| `resolve_argument_property_test.exs` | 5 properties | StreamData — analyzer vs oracle, permission matching |

Total: **943 tests, 101 properties, 0 failures.** `mix compile --warnings-as-errors` clean, `mix credo` shows no new issues.

## Compile-time validation

- Path intermediates must be `:belongs_to` relationships (not has_one/has_many)
- Path leaf must be an attribute (not another relationship)
- Each `resolve_argument` must be referenced by at least one scope (no dead declarations)
- `for_actions:` must reference existing create/update/destroy actions

## Relationship with `write:` scope option

The `write:` option on `scope` was designed to provide a simpler, in-memory-evaluable expression for write actions when the main filter uses relational traversal. With this DSL, that role is largely subsumed: the scope is already argument-based (no traversal), so `write:` is typically unnecessary for new code. Existing `write:` usage remains supported. Deprecation is a follow-up decision after the pattern sees more use.

## Guide

`guides/argument-based-scope.md` is rewritten to lead with the DSL sugar as the recommended API. Hand-rolled change-module version is kept as an "under the hood" section for surgical cases.

## Reference implementation

Both styles coexist in test support for 1:1 comparison:

- `test/support/resources/auth_pattern_refund_dsl.ex` — uses `resolve_argument`
- `test/support/resources/auth_pattern_refund.ex` — hand-rolled change module

🤖 Generated with [Claude Code](https://claude.com/claude-code)