### PR TITLE
deprecate: mark scope :write option as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Post |> Ash.read!(actor: viewer)
 - **[Argument-Based Scope](guides/argument-based-scope.md)** — Multi-hop authorization via action arguments + resource-local lazy loading, avoids DB-query fallback
 - **[Field-Level Permissions](guides/field-level-permissions.md)** — Field groups, whitelist/blacklist modes, inheritance, masking
 - **[Checks & Policies](guides/checks-and-policies.md)** — Check types, CanPerform calculations, DSL configuration, default_policies
-- **[Debugging & Introspection](guides/debugging-and-introspection.md)** — explain/4, permission introspection, write: option, scope descriptions
+- **[Debugging & Introspection](guides/debugging-and-introspection.md)** — explain/4, permission introspection, scope descriptions, read vs write evaluation
 - **[Policy Testing](guides/policy-testing.md)** — DSL and YAML tests, mix tasks, export/import
 
 ## Architecture

--- a/guides/argument-based-scope.md
+++ b/guides/argument-based-scope.md
@@ -218,13 +218,15 @@ affected actions.
 
 ### Relationship with the `write:` scope option
 
-The `write:` option on `scope` was designed to provide a simpler, in-memory-
-evaluable expression for write actions when the main filter uses relational
-traversal. With argument-based scopes + `resolve_argument`, the scope is
-already in-memory-evaluable and `write:` is typically not needed.
+The `write:` option on `scope` was an earlier escape hatch for the same
+problem this pattern solves: a simpler, in-memory-evaluable expression for
+write actions when the main filter traverses relationships.
 
-For new code, prefer this pattern over `write:`. `write:` remains supported
-for existing resources.
+With argument-based scopes + `resolve_argument`, the scope expression is
+already in-memory-evaluable and the relationship traversal lives in the
+change module. **`write:` is deprecated as of 0.14** — new code should use
+this pattern. Existing `write:` usage still compiles (with a deprecation
+warning) to give projects time to migrate.
 
 ## Hand-rolled version (under the hood)
 

--- a/guides/debugging-and-introspection.md
+++ b/guides/debugging-and-introspection.md
@@ -44,54 +44,39 @@ Scope Filter: true (no filtering)
 ───────────────────────────────────────────────────────────────────
 ```
 
-## Dual Read/Write Scope (`write:` Option)
+## Read vs write scope evaluation
 
-Scopes with `exists()` or dot-paths work automatically for both reads and writes via
-DB query fallback. The `write:` option is an optional override for explicit control:
+Scopes with `exists()` or dot-paths work for both reads and writes automatically:
 
-| `write:` value | Strategy | Behavior |
-|----------------|----------|----------|
-| _(omitted, no relationships)_ | In-memory | Evaluates filter in-memory (default) |
-| _(omitted, has relationships)_ | DB query | Queries DB with read scope (automatic) |
-| `write: expr(...)` | In-memory | Use this expression for writes (overrides DB query) |
-| `write: false` | Deny | Explicitly deny all writes with this scope |
-| `write: true` | Allow | Allow all writes with this scope (no filtering) |
+- **Read**: `FilterCheck` lowers the expression to SQL.
+- **Write**: `Check` evaluates it in memory where possible; for scopes with
+  relationship references it falls back to a DB query.
+
+For multi-hop write authorization (e.g., `refund.order.center_id in actor_units`),
+prefer argument-based scopes — they keep the scope expression in-memory-evaluable
+and push relationship traversal into the resource's own change pipeline:
 
 ```elixir
 ash_grant do
-  resolver MyApp.PermissionResolver
-
-  scope :always, true
-
-  # Relational scope — DB query fallback handles writes automatically
-  scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id)))
-
-  # Explicitly deny writes
-  scope :org_member, expr(exists(org.users, id == ^actor(:id))),
-    write: false
-
-  # Explicit in-memory override (avoids DB round-trip)
-  scope :same_org, expr(exists(org.users, id == ^actor(:id))),
-    write: expr(org_id == ^actor(:org_id))
-
-  # Simple scopes — in-memory evaluation, no write: needed
-  scope :own, expr(author_id == ^actor(:id))
+  scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+  resolve_argument :center_id, from_path: [:order, :center_id]
 end
 ```
 
-**Inheritance:** Child scopes inherit their parent's `write:` expression. If a parent
-has `write: false`, it propagates to all children:
-
-```elixir
-scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id))),
-  write: false
-scope :team_editor, [:team_member], expr(role == :editor)
-# team_editor inherits write: false — writes are denied
-```
+See the [Argument-Based Scope guide](argument-based-scope.md) for the full pattern.
 
 **Resolution functions:**
-- `AshGrant.Info.resolve_scope_filter/3` — always returns the read (filter) expression
-- `AshGrant.Info.resolve_write_scope_filter/3` — returns `write:` expression if set, otherwise falls back to `filter`
+- `AshGrant.Info.resolve_scope_filter/3` — resolved read filter (inheritance applied)
+- `AshGrant.Info.resolve_write_scope_filter/3` — resolved write filter (inheritance applied, `write:` option honored if present)
+
+### `write:` option (deprecated)
+
+The `write:` option was introduced as an escape hatch when the main `filter`
+could not be evaluated in memory on write actions. It is **deprecated as of
+0.14** — prefer argument-based scopes + `resolve_argument` for multi-hop
+cases, or use a separate scope name for read-only semantics.
+
+Using `write:` still works but emits a compile-time deprecation warning.
 
 ## Scope Descriptions
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -243,6 +243,8 @@ ash_grant do
 end
 ```
 
-For read actions, these compile to SQL (EXISTS subquery or JOIN). For write actions,
-AshGrant automatically uses a DB query fallback. See the [Scopes guide](scopes.md)
-for full details on relational scopes and the `write:` option.
+For read actions, these compile to SQL (EXISTS subquery or JOIN). For write
+actions, AshGrant automatically uses a DB query fallback. For multi-hop
+write authorization, prefer the argument-based pattern — see the
+[Argument-Based Scope guide](argument-based-scope.md). The
+[Scopes guide](scopes.md) covers relational scopes in detail.

--- a/guides/scopes.md
+++ b/guides/scopes.md
@@ -190,23 +190,30 @@ For **write** actions, `Check` automatically uses a **DB query fallback** when t
 scope contains relationship references — the read scope expression is used as a DB
 query to verify the record matches the scope.
 
-> **Optional: `write:` override**
->
-> You can use the `write:` option to explicitly control write behavior:
+### Recommended: argument-based scopes for multi-hop authorization
+
+For write-action authorization that reaches through relationships
+(e.g., `refund → order → center_id`), prefer an argument-based scope paired
+with `resolve_argument`. The scope stays in-memory-evaluable and the resource
+populates the argument from its own relationships:
 
 ```elixir
 ash_grant do
-  # Explicitly deny writes with this scope
-  scope :org_member, expr(exists(org.users, id == ^actor(:id))),
-    write: false
-
-  # Explicit in-memory expression (avoids DB round-trip)
-  scope :same_org, expr(exists(org.users, id == ^actor(:id))),
-    write: expr(org_id == ^actor(:org_id))
+  scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+  resolve_argument :center_id, from_path: [:order, :center_id]
 end
 ```
 
-> See the [Debugging & Introspection guide](debugging-and-introspection.md#dual-readwrite-scope-write-option) for full details on the `write:` option.
+See [Argument-Based Scope](argument-based-scope.md) for the full pattern.
+
+> **Deprecated: `write:` override**
+>
+> The `write:` option was introduced as an escape hatch when the main
+> `filter` could not be evaluated in memory on write actions. It is
+> deprecated as of 0.14 — prefer argument-based scopes + `resolve_argument`
+> for multi-hop cases, or use a separate scope name for read-only semantics.
+>
+> Using `write:` still works but emits a compile-time deprecation warning.
 
 ## Business Scope Examples
 

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -29,28 +29,32 @@ defmodule AshGrant.Dsl do
   | Option | Type | Description |
   |--------|------|-------------|
   | `inherits` | list of atoms | Parent scopes to inherit and combine with |
-  | `write` | expression, boolean, or nil | Write-specific expression. Falls back to `filter` if omitted. |
   | `description` | string | Human-readable description for explain/4 output |
+  | `write` | expression, boolean, or nil | **Deprecated.** Prefer argument-based scopes + `resolve_argument`. See below. |
 
-  ### Dual Read/Write Scope
+  ### Read vs write semantics
 
   The `filter` expression is used for read actions (converted to SQL via `FilterCheck`).
   For write actions, `Check` evaluates the scope — simple scopes use in-memory
   evaluation, while scopes with relationship references (`exists()` or dot-paths)
   automatically use a DB query to verify the scope.
 
-  The `write:` option is an optional override for explicit control:
+  For multi-hop authorization ("refund → order → center_id"), prefer
+  argument-based scopes together with `resolve_argument`:
 
-      # Explicitly deny writes
-      scope :readonly, expr(exists(org.users, id == ^actor(:id))),
-        write: false
+      scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+      resolve_argument :center_id, from_path: [:order, :center_id]
 
-      # Explicit in-memory expression (avoids DB round-trip)
-      scope :same_org, expr(exists(org.users, id == ^actor(:id))),
-        write: expr(org_id == ^actor(:org_id))
+  See `guides/argument-based-scope.md` for the full rationale and examples.
 
-  When `write:` is omitted, scopes with relationship references use a DB query
-  fallback; simple scopes use in-memory evaluation.
+  ### `write:` option (deprecated)
+
+  The `write:` option was introduced as an escape hatch for relational scopes
+  whose `filter` expression could not be evaluated in memory on write actions.
+  It is deprecated as of 0.14 — prefer argument-based scopes + `resolve_argument`,
+  or gate read-only semantics via separate scope names or the policy layer.
+
+  Using `write:` still works but emits a compile-time deprecation warning.
 
   ## CanPerform Entity
 
@@ -178,12 +182,16 @@ defmodule AshGrant.Dsl do
         # Relational scope — DB query fallback handles writes automatically
         scope :team_member, expr(exists(team.members, user_id == ^actor(:id)))
 
-        # Explicitly deny writes with this scope
-        scope :readonly, expr(exists(org.users, id == ^actor(:id))),
-          write: false
-
         # Description is optional - backward compatible
         scope :archived, expr(status == :archived)
+
+    For multi-hop authorization (e.g., "refund.order.center_id"), prefer
+    argument-based scopes paired with `resolve_argument`:
+
+        scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+        resolve_argument :center_id, from_path: [:order, :center_id]
+
+    The `write:` option is deprecated; see `guides/argument-based-scope.md`.
     """,
     examples: [
       "scope :always, true",
@@ -193,10 +201,16 @@ defmodule AshGrant.Dsl do
       ~s|scope :today, expr(fragment("DATE(inserted_at) = ?", ^context(:reference_date)))|,
       ~s|scope :own, expr(author_id == ^actor(:id)), description: "Records owned by the current user"|,
       "scope :team_member, expr(exists(team.members, user_id == ^actor(:id)))",
-      "scope :readonly, expr(exists(org.users, id == ^actor(:id))), write: false"
+      "scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))"
     ],
     target: AshGrant.Dsl.Scope,
     args: [:name, {:optional, :inherits}, :filter],
+    deprecations: [
+      write:
+        "`write:` is deprecated. Prefer argument-based scopes + `resolve_argument` " <>
+          "(see `guides/argument-based-scope.md`). For read-only semantics, define a " <>
+          "separate read-only scope or gate writes at the policy layer."
+    ],
     schema: [
       name: [
         type: :atom,
@@ -221,20 +235,15 @@ defmodule AshGrant.Dsl do
         type: {:or, [:boolean, :any]},
         required: false,
         doc: """
-        Optional override for write action evaluation. When omitted, scopes with
-        relationship references use a DB query fallback; simple scopes use in-memory
-        evaluation.
+        **Deprecated.** Prefer argument-based scopes + `resolve_argument`
+        (see `guides/argument-based-scope.md`).
 
-        Set to `false` to explicitly deny writes, or to an expression for explicit
-        in-memory evaluation (avoids DB round-trip).
+        Historical escape hatch: provides a write-side expression when the
+        main `filter` traverses relationships that cannot be evaluated in
+        memory. Set to `false` to deny writes, or to an expression that uses
+        only direct attributes.
 
-        ## Example
-
-            scope :readonly, expr(exists(org.users, id == ^actor(:id))),
-              write: false
-
-            scope :same_org, expr(exists(org.users, id == ^actor(:id))),
-              write: expr(org_id == ^actor(:org_id))
+        Still supported, but emits a compile-time deprecation warning.
         """
       ]
     ]
@@ -600,7 +609,7 @@ defmodule AshGrant.Dsl.Scope do
   - `:name` - The atom name of the scope (e.g., `:own`, `:published`)
   - `:inherits` - List of parent scope names to inherit from
   - `:filter` - The filter expression (`true` for no filtering, or an Ash.Expr)
-  - `:write` - Optional write-specific expression. Falls back to `:filter` if nil. Set to `false` to deny writes.
+  - `:write` - **Deprecated.** Optional write-specific expression. Prefer argument-based scopes with `resolve_argument`.
   - `:description` - Optional human-readable description for debugging/explain
   """
 


### PR DESCRIPTION
## Summary

Marks the `write:` option on `scope` as deprecated via Spark's `deprecations:` entity mechanism. Any usage emits a compile-time deprecation warning. The option continues to function; tests that exercise `write:` still pass.

```
warning: The write key is deprecated. will be deprecated in an upcoming release!
`write:` is deprecated. Prefer argument-based scopes + `resolve_argument`
(see `guides/argument-based-scope.md`). For read-only semantics, define a
separate read-only scope or gate writes at the policy layer.
```

## Why

`write:` was introduced as an escape hatch for relational scopes that could not be evaluated in memory on write actions. With `resolve_argument` now providing a first-class way to express multi-hop authorization with in-memory-evaluable scopes, `write:` is redundant for the common case and encourages brittle split-expression patterns. See `guides/argument-based-scope.md`.

## Doc updates

Every surface mentioning `write:` was updated to mark it deprecated and point at the argument-based pattern:

- `lib/ash_grant/dsl.ex` — `@moduledoc`, scope entity `describe` + examples, schema option doc, `%AshGrant.Dsl.Scope{}` struct typedoc
- `guides/scopes.md` — "Optional: write: override" replaced with a recommendation block + deprecation notice
- `guides/debugging-and-introspection.md` — "Dual Read/Write Scope" section rewritten as "Read vs write scope evaluation" pointing at `resolve_argument`
- `guides/getting-started.md` — relational-scope pointer updated
- `guides/argument-based-scope.md` — existing "Relationship with `write:`" section strengthened with 0.14 deprecation
- `README.md` — guide index entry no longer names `write:`

## Migration path

Existing code keeps compiling. The deprecation warning includes a pointer to the replacement pattern. After a grace period (likely one minor version), the option can be removed.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 38 doctests, 101 properties, 951 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] Existing `write_scope_test.exs` (31 tests) still passes
- [x] Deprecation warning verified to emit during compilation of test resources that use `write:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)