### PR TITLE
test: assert write: option emits a deprecation warning

### DIFF
--- a/test/ash_grant/write_scope_deprecation_test.exs
+++ b/test/ash_grant/write_scope_deprecation_test.exs
@@ -1,0 +1,83 @@
+defmodule AshGrant.WriteScopeDeprecationTest do
+  @moduledoc """
+  Verifies that using the deprecated `write:` option on a scope emits a
+  compile-time deprecation warning pointing users at the argument-based
+  scope pattern.
+
+  This guards against the deprecation wiring silently regressing if Spark
+  changes how `deprecations:` entries are handled, or if the entry is
+  removed from `lib/ash_grant/dsl.ex`.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  test "using write: emits a deprecation warning mentioning resolve_argument" do
+    output =
+      capture_io(:stderr, fn ->
+        Code.compile_string("""
+        defmodule AshGrant.WriteScopeDeprecationTest.UsesWriteOption do
+          @moduledoc false
+          use Ash.Resource,
+            domain: nil,
+            validate_domain_inclusion?: false,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [AshGrant]
+
+          ash_grant do
+            resolver(fn _, _ -> [] end)
+            scope(:readonly, [], expr(author_id == ^actor(:id)), write: false)
+          end
+
+          attributes do
+            uuid_primary_key :id
+            attribute :author_id, :uuid, allow_nil?: true
+          end
+
+          actions do
+            defaults [:read]
+          end
+        end
+        """)
+      end)
+
+    assert output =~ "write",
+           "expected the write key to be flagged as deprecated; output was: #{output}"
+
+    assert output =~ "resolve_argument",
+           "expected the deprecation message to point at resolve_argument; output was: #{output}"
+  end
+
+  test "a scope without write: produces no deprecation warning" do
+    output =
+      capture_io(:stderr, fn ->
+        Code.compile_string("""
+        defmodule AshGrant.WriteScopeDeprecationTest.NoWriteOption do
+          @moduledoc false
+          use Ash.Resource,
+            domain: nil,
+            validate_domain_inclusion?: false,
+            data_layer: Ash.DataLayer.Ets,
+            extensions: [AshGrant]
+
+          ash_grant do
+            resolver fn _, _ -> [] end
+            scope :own, expr(author_id == ^actor(:id))
+          end
+
+          attributes do
+            uuid_primary_key :id
+            attribute :author_id, :uuid, allow_nil?: true
+          end
+
+          actions do
+            defaults [:read]
+          end
+        end
+        """)
+      end)
+
+    refute output =~ "write",
+           "expected no deprecation warning mentioning write:; output was: #{output}"
+  end
+end


### PR DESCRIPTION
## Summary

Fills a testing gap from #91. The deprecation wiring was previously verified only by manually grepping compile output; this adds two `ExUnit.CaptureIO`-based tests that capture :stderr while compiling small ash_grant resources:

- A scope declared with `write: false` must produce a warning that mentions both `write` and `resolve_argument`.
- A scope without `write:` must produce no such warning (false-positive guard).

Without these, a future Spark change to how `deprecations:` entries are reported — or an accidental removal of our entry — would silently regress the deprecation pathway.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 38 doctests, 101 properties, 953 tests, 0 failures (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)