### PR TITLE
feat: surface argument-based scopes in Explain + PolicyTest (DSL & YAML)

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -243,8 +243,9 @@ ash_grant do
 end
 ```
 
-For read actions, these compile to SQL (EXISTS subquery or JOIN). For write
-actions, AshGrant automatically uses a DB query fallback. For multi-hop
-write authorization, prefer the argument-based pattern — see the
-[Argument-Based Scope guide](argument-based-scope.md). The
+For read actions, these compile to SQL (EXISTS subquery or JOIN). For simple
+write actions, AshGrant uses a DB query fallback that handles most cases
+automatically. For multi-hop authorization, composite inheritance, or scopes
+that wrap relationship references inside functions, prefer the argument-based
+pattern — see the [Argument-Based Scope guide](argument-based-scope.md). The
 [Scopes guide](scopes.md) covers relational scopes in detail.

--- a/lib/ash_grant/explainer.ex
+++ b/lib/ash_grant/explainer.ex
@@ -7,7 +7,14 @@ defmodule AshGrant.Explainer do
   with full details about why access was allowed or denied.
   """
 
-  alias AshGrant.{Explanation, Info, Permission, PermissionInput, Permissionable}
+  alias AshGrant.{
+    ArgumentAnalyzer,
+    Explanation,
+    Info,
+    Permission,
+    PermissionInput,
+    Permissionable
+  }
 
   @doc """
   Explains an authorization decision for a resource and action.
@@ -46,6 +53,7 @@ defmodule AshGrant.Explainer do
     {decision, reason, matching_allows} = determine_decision(evaluated)
     scope_filter = resolve_explain_scope_filter(decision, matching_allows, resource, context)
     field_groups = extract_field_groups(matching_allows)
+    resolve_arguments = build_resolve_arguments(resource, action)
 
     %Explanation{
       resource: resource,
@@ -58,9 +66,33 @@ defmodule AshGrant.Explainer do
       evaluated_permissions: evaluated,
       scope_filter: scope_filter,
       field_groups: field_groups,
-      field_group_defs: Info.field_groups(resource)
+      field_group_defs: Info.field_groups(resource),
+      resolve_arguments: resolve_arguments
     }
   end
+
+  # Collect resolve_argument declarations active for this action, annotated with
+  # the scopes that actually reference the argument. Declarations that no scope
+  # uses — or that are scoped to other actions via :for_actions — are omitted.
+  defp build_resolve_arguments(resource, action) do
+    arg_to_scopes = ArgumentAnalyzer.arg_to_scopes(resource)
+
+    resource
+    |> Info.resolve_arguments()
+    |> Enum.filter(&applies_to_action?(&1, action))
+    |> Enum.map(fn decl ->
+      %{
+        name: decl.name,
+        from_path: decl.from_path,
+        for_actions: decl.for_actions,
+        scopes_needing: Enum.sort(Map.get(arg_to_scopes, decl.name, []))
+      }
+    end)
+    |> Enum.reject(&(&1.scopes_needing == []))
+  end
+
+  defp applies_to_action?(%{for_actions: nil}, _action), do: true
+  defp applies_to_action?(%{for_actions: list}, action), do: action in list
 
   defp resolve_action_type(resource, action) do
     case Ash.Resource.Info.action(resource, action) do

--- a/lib/ash_grant/explanation.ex
+++ b/lib/ash_grant/explanation.ex
@@ -18,6 +18,7 @@ defmodule AshGrant.Explanation do
   - `:scope_filter` - The resolved scope filter expression (for reads)
   - `:field_groups` - List of field group names the actor has access to (from 5-part permissions)
   - `:field_group_defs` - Field group definitions from the resource DSL
+  - `:resolve_arguments` - `resolve_argument` declarations active for this action, each annotated with the scope atoms that trigger the resolver at runtime (see `guides/argument-based-scope.md`)
 
   ## Example
 

--- a/lib/ash_grant/explanation.ex
+++ b/lib/ash_grant/explanation.ex
@@ -64,6 +64,13 @@ defmodule AshGrant.Explanation do
           field_group: String.t() | nil
         }
 
+  @type resolve_argument_entry :: %{
+          name: atom(),
+          from_path: [atom()],
+          for_actions: [atom()] | nil,
+          scopes_needing: [atom()]
+        }
+
   @type t :: %__MODULE__{
           resource: module(),
           action: atom(),
@@ -75,7 +82,8 @@ defmodule AshGrant.Explanation do
           evaluated_permissions: [evaluated_permission()],
           scope_filter: term() | nil,
           field_groups: [String.t()],
-          field_group_defs: [AshGrant.Dsl.FieldGroup.t()]
+          field_group_defs: [AshGrant.Dsl.FieldGroup.t()],
+          resolve_arguments: [resolve_argument_entry()]
         }
 
   defstruct [
@@ -89,7 +97,8 @@ defmodule AshGrant.Explanation do
     matching_permissions: [],
     evaluated_permissions: [],
     field_groups: [],
-    field_group_defs: []
+    field_group_defs: [],
+    resolve_arguments: []
   ]
 
   @doc """
@@ -123,6 +132,7 @@ defmodule AshGrant.Explanation do
       matching_section(explanation, color),
       if(verbose, do: evaluated_section(explanation, color), else: nil),
       scope_section(explanation, color),
+      resolve_arguments_section(explanation, color),
       field_group_section(explanation, color),
       footer(color)
     ]
@@ -275,6 +285,29 @@ defmodule AshGrant.Explanation do
     Field Groups:
       Actor's groups: #{maybe_color(actor_groups, :bright, color)}
     #{groups_info}
+    """
+  end
+
+  defp resolve_arguments_section(%{resolve_arguments: []} = _explanation, _color), do: nil
+
+  defp resolve_arguments_section(explanation, color) do
+    entries =
+      Enum.map_join(explanation.resolve_arguments, "\n", fn entry ->
+        path = entry.from_path |> Enum.map(&inspect/1) |> Enum.join(" → ")
+        scopes = entry.scopes_needing |> Enum.map_join(", ", &inspect/1)
+
+        scope_hint =
+          if scopes == "",
+            do: " (referenced by no scope — should not happen)",
+            else: " (triggers for scopes: #{scopes})"
+
+        "  • #{maybe_color(inspect(entry.name), :yellow, color)} ← #{path}#{scope_hint}"
+      end)
+
+    """
+
+    Argument Resolution (runtime load fires only when an in-play permission uses a listed scope):
+    #{entries}
     """
   end
 

--- a/lib/ash_grant/policy_test/assertions.ex
+++ b/lib/ash_grant/policy_test/assertions.ex
@@ -80,6 +80,15 @@ defmodule AshGrant.PolicyTest.Assertions do
   - An atom for action name shorthand: `:read`, `:update`
   - A keyword list with `:action` or `:action_type`
 
+  ## Third argument — record and/or arguments
+
+  The third argument may be:
+  - omitted — check permission only
+  - a bare map — treated as the record attributes
+  - a keyword list with `:record` and/or `:arguments` — the latter supplies
+    action-argument values for scopes that use `^arg(:name)` templates
+    (see `resolve_argument` and `guides/argument-based-scope.md`)
+
   ## Examples
 
       # Actor can perform :read action
@@ -93,6 +102,11 @@ defmodule AshGrant.PolicyTest.Assertions do
 
       # Actor can access record with specific attributes
       assert_can :reader, :read, %{status: :published}
+
+      # Argument-based scope — actor, record, AND action arguments
+      assert_can :manager, :update,
+        record: %{author_id: "u1"},
+        arguments: %{center_id: "center_A"}
   """
   defmacro assert_can(actor_name, action_spec) do
     quote do
@@ -119,6 +133,9 @@ defmodule AshGrant.PolicyTest.Assertions do
   @doc """
   Asserts that an actor cannot perform an action.
 
+  See `assert_can/3` for the accepted third-argument forms (bare record map
+  or `record:`/`arguments:` keyword list).
+
   ## Examples
 
       # Actor cannot perform :delete action
@@ -126,6 +143,11 @@ defmodule AshGrant.PolicyTest.Assertions do
 
       # Actor cannot access record with specific attributes
       assert_cannot :reader, :read, %{status: :draft}
+
+      # Argument-based scope — verify a value *outside* the actor's units is denied
+      assert_cannot :manager, :update,
+        record: %{author_id: "u1"},
+        arguments: %{center_id: "center_Z"}
   """
   defmacro assert_cannot(actor_name, action_spec) do
     quote do

--- a/lib/ash_grant/policy_test/assertions.ex
+++ b/lib/ash_grant/policy_test/assertions.ex
@@ -150,10 +150,11 @@ defmodule AshGrant.PolicyTest.Assertions do
   end
 
   @doc false
-  def do_assert_can(module, actor_name, action_spec, record) do
+  def do_assert_can(module, actor_name, action_spec, third) do
+    {record, arguments} = split_record_and_arguments(third)
     {actor, resource, action} = resolve_context(module, actor_name, action_spec)
 
-    case check_permission(resource, action, actor, record) do
+    case check_permission(resource, action, actor, record, arguments) do
       {:allow, _details} ->
         :ok
 
@@ -164,10 +165,11 @@ defmodule AshGrant.PolicyTest.Assertions do
   end
 
   @doc false
-  def do_assert_cannot(module, actor_name, action_spec, record) do
+  def do_assert_cannot(module, actor_name, action_spec, third) do
+    {record, arguments} = split_record_and_arguments(third)
     {actor, resource, action} = resolve_context(module, actor_name, action_spec)
 
-    case check_permission(resource, action, actor, record) do
+    case check_permission(resource, action, actor, record, arguments) do
       {:deny, _details} ->
         :ok
 
@@ -176,6 +178,25 @@ defmodule AshGrant.PolicyTest.Assertions do
           message: build_error_message(:assert_cannot, actor_name, action_spec, record, details)
     end
   end
+
+  # The third arg to assert_can/assert_cannot historically was a bare record
+  # map. Users may also pass a keyword list like `[record: %{...}, arguments:
+  # %{center_id: "..."}]` to supply both. Returns `{record, arguments}`.
+  defp split_record_and_arguments(nil), do: {nil, %{}}
+
+  defp split_record_and_arguments(kw) when is_list(kw) do
+    case Keyword.keyword?(kw) do
+      true ->
+        record = Keyword.get(kw, :record)
+        arguments = Keyword.get(kw, :arguments, %{}) || %{}
+        {record, arguments}
+
+      false ->
+        {nil, %{}}
+    end
+  end
+
+  defp split_record_and_arguments(record) when is_map(record), do: {record, %{}}
 
   @doc false
   def do_assert_fields_visible(module, actor_name, action_spec, fields) do
@@ -314,12 +335,12 @@ defmodule AshGrant.PolicyTest.Assertions do
     end
   end
 
-  defp check_permission(resource, action, actor, nil) do
+  defp check_permission(resource, action, actor, nil, _arguments) do
     # No record - just check if actor has permission for the action
     check_basic_permission(resource, action, actor)
   end
 
-  defp check_permission(resource, action, actor, record) when is_map(record) do
+  defp check_permission(resource, action, actor, record, arguments) when is_map(record) do
     # Record provided - check permission AND evaluate scope against record
     case check_basic_permission(resource, action, actor) do
       {:deny, _} = deny ->
@@ -327,7 +348,7 @@ defmodule AshGrant.PolicyTest.Assertions do
 
       {:allow, details} ->
         # Now check if the record matches the scope
-        check_scope_against_record(resource, action, actor, record, details)
+        check_scope_against_record(resource, action, actor, record, details, arguments)
     end
   end
 
@@ -358,7 +379,7 @@ defmodule AshGrant.PolicyTest.Assertions do
     end
   end
 
-  defp check_scope_against_record(resource, _action, actor, record, permission_details) do
+  defp check_scope_against_record(resource, _action, actor, record, permission_details, arguments) do
     scope_name = permission_details[:scope]
 
     if scope_name == nil or scope_name == "always" or scope_name == "all" or
@@ -371,7 +392,7 @@ defmodule AshGrant.PolicyTest.Assertions do
       context = %{actor: actor}
       filter = AshGrant.Info.resolve_scope_filter(resource, scope_atom, context)
 
-      case evaluate_filter_against_record(filter, record, actor, resource) do
+      case evaluate_filter_against_record(filter, record, actor, resource, arguments) do
         true ->
           {:allow, permission_details}
 
@@ -382,12 +403,22 @@ defmodule AshGrant.PolicyTest.Assertions do
   end
 
   @doc false
-  def evaluate_filter_against_record(filter, record, actor, resource \\ nil)
-  def evaluate_filter_against_record(true, _record, _actor, _resource), do: true
-  def evaluate_filter_against_record(false, _record, _actor, _resource), do: false
+  # Note: `arguments` is a map of action-argument values (or `%{}`) used to
+  # resolve `^arg(...)` templates in the filter. The old 4-arity version is
+  # preserved for back-compat; new callers should pass arguments.
+  def evaluate_filter_against_record(filter, record, actor, resource \\ nil, arguments \\ %{})
 
-  def evaluate_filter_against_record(filter, record, actor, resource) do
-    filled = Ash.Expr.fill_template(filter, actor: actor, context: %{})
+  def evaluate_filter_against_record(true, _record, _actor, _resource, _arguments), do: true
+
+  def evaluate_filter_against_record(false, _record, _actor, _resource, _arguments), do: false
+
+  def evaluate_filter_against_record(filter, record, actor, resource, arguments) do
+    filled =
+      Ash.Expr.fill_template(filter,
+        actor: actor,
+        context: %{},
+        args: arguments || %{}
+      )
 
     case Ash.Expr.eval(filled, record: record, resource: resource, actor: actor) do
       {:ok, true} -> true

--- a/lib/ash_grant/policy_test/dsl_generator.ex
+++ b/lib/ash_grant/policy_test/dsl_generator.ex
@@ -88,22 +88,15 @@ defmodule AshGrant.PolicyTest.DslGenerator do
   defp generate_assertion(test) do
     actor = ":#{test.actor}"
     action_spec = generate_action_spec(test)
-    record = generate_record(test[:record])
+    record = test[:record]
+    arguments = Map.get(test, :arguments, %{}) || %{}
 
     case test.type do
       :assert_can ->
-        if record do
-          "assert_can #{actor}, #{action_spec}, #{record}"
-        else
-          "assert_can #{actor}, #{action_spec}"
-        end
+        "assert_can #{actor}, #{action_spec}#{third_arg(record, arguments)}"
 
       :assert_cannot ->
-        if record do
-          "assert_cannot #{actor}, #{action_spec}, #{record}"
-        else
-          "assert_cannot #{actor}, #{action_spec}"
-        end
+        "assert_cannot #{actor}, #{action_spec}#{third_arg(record, arguments)}"
 
       :assert_fields_visible ->
         fields_list = generate_fields_list(test.fields)
@@ -114,6 +107,31 @@ defmodule AshGrant.PolicyTest.DslGenerator do
         "assert_fields_hidden #{actor}, #{action_spec}, #{fields_list}"
     end
   end
+
+  # Produce either `", %{...}"` (record only), `", [record: %{...}, arguments: %{...}]"`,
+  # `", [arguments: %{...}]"`, or empty string.
+  defp third_arg(nil, args) when args == %{}, do: ""
+
+  defp third_arg(record, args) when args == %{} do
+    ", " <> generate_record(record)
+  end
+
+  defp third_arg(record, args) do
+    parts =
+      []
+      |> maybe_add(:record, record, &generate_record/1)
+      |> maybe_add(:arguments, args, &generate_record/1)
+      |> Enum.reverse()
+      |> Enum.join(", ")
+
+    ", [" <> parts <> "]"
+  end
+
+  defp maybe_add(acc, _key, nil, _fmt), do: acc
+
+  defp maybe_add(acc, _key, empty, _fmt) when empty == %{}, do: acc
+
+  defp maybe_add(acc, key, value, fmt), do: ["#{key}: #{fmt.(value)}" | acc]
 
   defp generate_fields_list(fields) do
     inner = Enum.map_join(fields, ", ", &":#{&1}")

--- a/lib/ash_grant/policy_test/yaml_parser.ex
+++ b/lib/ash_grant/policy_test/yaml_parser.ex
@@ -58,6 +58,7 @@ defmodule AshGrant.PolicyTest.YamlParser do
           action: atom() | nil,
           action_type: atom() | nil,
           record: map() | nil,
+          arguments: map(),
           fields: [atom()] | nil
         }
 
@@ -174,9 +175,13 @@ defmodule AshGrant.PolicyTest.YamlParser do
       actor: atomize_key(assertion["actor"]),
       action: parse_action(assertion["action"]),
       action_type: parse_action(assertion["action_type"]),
-      record: parse_record(assertion["record"])
+      record: parse_record(assertion["record"]),
+      arguments: parse_arguments(assertion["arguments"])
     }
   end
+
+  defp parse_arguments(nil), do: %{}
+  defp parse_arguments(args) when is_map(args), do: atomize_map(args)
 
   defp parse_field_assertion(type, name, assertion) do
     fields =
@@ -191,6 +196,7 @@ defmodule AshGrant.PolicyTest.YamlParser do
       action: parse_action(assertion["action"]),
       action_type: nil,
       record: nil,
+      arguments: %{},
       fields: fields
     }
   end
@@ -253,13 +259,15 @@ defmodule AshGrant.PolicyTest.YamlParser do
         true -> raise "Test must have action or action_type: #{inspect(test)}"
       end
 
+    arguments = Map.get(test, :arguments, %{})
+
     try do
       case test.type do
         :assert_can ->
-          do_assert_can(resource, actor, action_spec, test.record)
+          do_assert_can(resource, actor, action_spec, test.record, arguments)
 
         :assert_cannot ->
-          do_assert_cannot(resource, actor, action_spec, test.record)
+          do_assert_cannot(resource, actor, action_spec, test.record, arguments)
 
         :assert_fields_visible ->
           do_assert_fields_visible(resource, actor, action_spec, test.fields)
@@ -282,8 +290,8 @@ defmodule AshGrant.PolicyTest.YamlParser do
   end
 
   # Direct assertion implementation (without needing a module)
-  defp do_assert_can(resource, actor, action_spec, record) do
-    case check_permission(resource, actor, action_spec, record) do
+  defp do_assert_can(resource, actor, action_spec, record, arguments) do
+    case check_permission(resource, actor, action_spec, record, arguments) do
       {:allow, _} ->
         :ok
 
@@ -293,8 +301,8 @@ defmodule AshGrant.PolicyTest.YamlParser do
     end
   end
 
-  defp do_assert_cannot(resource, actor, action_spec, record) do
-    case check_permission(resource, actor, action_spec, record) do
+  defp do_assert_cannot(resource, actor, action_spec, record, arguments) do
+    case check_permission(resource, actor, action_spec, record, arguments) do
       {:deny, _} ->
         :ok
 
@@ -357,23 +365,24 @@ defmodule AshGrant.PolicyTest.YamlParser do
     end
   end
 
-  defp check_permission(resource, actor, {:action_type, type}, record) do
+  defp check_permission(resource, actor, {:action_type, type}, record, arguments) do
     actions = Ash.Resource.Info.actions(resource)
     matching = Enum.filter(actions, &(&1.type == type))
 
     if matching == [] do
       {:deny, %{reason: :no_matching_action_type}}
     else
-      find_first_allowed(matching, resource, actor, record)
+      find_first_allowed(matching, resource, actor, record, arguments)
     end
   end
 
-  defp check_permission(resource, actor, action, record) do
-    check_single_permission(resource, actor, action, record)
+  defp check_permission(resource, actor, action, record, arguments) do
+    check_single_permission(resource, actor, action, record, arguments)
   end
 
-  defp find_first_allowed(matching, resource, actor, record) do
-    results = Enum.map(matching, &check_single_permission(resource, actor, &1.name, record))
+  defp find_first_allowed(matching, resource, actor, record, arguments) do
+    results =
+      Enum.map(matching, &check_single_permission(resource, actor, &1.name, record, arguments))
 
     case Enum.find(results, fn {status, _} -> status == :allow end) do
       nil -> {:deny, %{reason: :no_permission}}
@@ -381,37 +390,40 @@ defmodule AshGrant.PolicyTest.YamlParser do
     end
   end
 
-  defp check_single_permission(resource, actor, action, nil) do
+  defp check_single_permission(resource, actor, action, nil, _arguments) do
     AshGrant.Introspect.can?(resource, action, actor)
   end
 
-  defp check_single_permission(resource, actor, action, record) do
+  defp check_single_permission(resource, actor, action, record, arguments) do
     case AshGrant.Introspect.can?(resource, action, actor) do
-      {:deny, _} = deny -> deny
-      {:allow, details} -> verify_scope_against_record(resource, actor, record, details)
+      {:deny, _} = deny ->
+        deny
+
+      {:allow, details} ->
+        verify_scope_against_record(resource, actor, record, details, arguments)
     end
   end
 
-  defp verify_scope_against_record(_resource, _actor, _record, %{scope: nil} = details) do
+  defp verify_scope_against_record(_resource, _actor, _record, %{scope: nil} = details, _args) do
     {:allow, details}
   end
 
-  defp verify_scope_against_record(resource, actor, record, details) do
+  defp verify_scope_against_record(resource, actor, record, details, arguments) do
     scope_name = details[:scope]
 
     if scope_name == nil or scope_name == "always" or scope_name == "all" or
          scope_name == "global" do
       {:allow, details}
     else
-      evaluate_scope_for_record(resource, actor, record, details, scope_name)
+      evaluate_scope_for_record(resource, actor, record, details, scope_name, arguments)
     end
   end
 
-  defp evaluate_scope_for_record(resource, actor, record, details, scope_name) do
+  defp evaluate_scope_for_record(resource, actor, record, details, scope_name, arguments) do
     scope_atom = if is_binary(scope_name), do: String.to_atom(scope_name), else: scope_name
     filter = AshGrant.Info.resolve_scope_filter(resource, scope_atom, %{actor: actor})
 
-    if Assertions.evaluate_filter_against_record(filter, record, actor, resource) do
+    if Assertions.evaluate_filter_against_record(filter, record, actor, resource, arguments) do
       {:allow, details}
     else
       {:deny, %{reason: :scope_mismatch}}

--- a/lib/ash_grant/policy_test/yaml_parser.ex
+++ b/lib/ash_grant/policy_test/yaml_parser.ex
@@ -40,6 +40,20 @@ defmodule AshGrant.PolicyTest.YamlParser do
             record:
               status: draft
 
+  ### Argument-based scopes
+
+  Scopes can reference action arguments via `^arg(:name)`. To exercise those
+  in a YAML test, supply an `arguments:` map alongside `record:`:
+
+      - name: "manager can update refund in their unit"
+        assert_can:
+          actor: unit_manager
+          action: update
+          record:
+            author_id: "u1"
+          arguments:
+            center_id: "center_A"
+
   ## Usage
 
       # Parse YAML file

--- a/test/ash_grant/explain_resolve_argument_test.exs
+++ b/test/ash_grant/explain_resolve_argument_test.exs
@@ -1,0 +1,75 @@
+defmodule AshGrant.ExplainResolveArgumentTest do
+  @moduledoc """
+  Tests that `AshGrant.Explainer` surfaces `resolve_argument` declarations so
+  users can see — from a single `explain/4` output — how `^arg(...)` values in
+  scope expressions are populated at runtime.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.Test.Auth.RefundDsl
+  alias AshGrant.Test.BulkItem
+
+  describe "Explainer populates :resolve_arguments" do
+    test "resource with resolve_argument lists the declaration annotated with scopes" do
+      actor = %{
+        id: Ash.UUID.generate(),
+        permissions: ["refund_dsl:*:update:at_own_unit"],
+        own_org_unit_ids: [Ash.UUID.generate()]
+      }
+
+      explanation = AshGrant.Explainer.explain(RefundDsl, :update, actor)
+
+      assert [entry] = explanation.resolve_arguments
+      assert entry.name == :center_id
+      assert entry.from_path == [:order, :center_id]
+      assert entry.scopes_needing == [:at_own_unit]
+    end
+
+    test "resource without any resolve_argument returns an empty list" do
+      explanation = AshGrant.Explainer.explain(BulkItem, :update, nil)
+      assert explanation.resolve_arguments == []
+    end
+
+    test "entry is included regardless of whether the actor actually uses it" do
+      # The Explanation is a *structural* description of how the resource is
+      # wired, so `resolve_arguments` shouldn't depend on which permissions the
+      # actor happens to hold. An operator debugging a misconfiguration should
+      # be able to see the declaration even when no current actor references it.
+      actor = %{id: Ash.UUID.generate(), permissions: [], own_org_unit_ids: []}
+
+      explanation = AshGrant.Explainer.explain(RefundDsl, :update, actor)
+
+      assert [entry] = explanation.resolve_arguments
+      assert entry.name == :center_id
+    end
+  end
+
+  describe "Explanation.to_string renders Argument Resolution section" do
+    test "section appears when resolve_arguments is non-empty" do
+      actor = %{
+        id: Ash.UUID.generate(),
+        permissions: ["refund_dsl:*:update:at_own_unit"],
+        own_org_unit_ids: [Ash.UUID.generate()]
+      }
+
+      output =
+        RefundDsl
+        |> AshGrant.Explainer.explain(:update, actor)
+        |> AshGrant.Explanation.to_string(color: false)
+
+      assert output =~ "Argument Resolution"
+      assert output =~ ":center_id"
+      assert output =~ ":order"
+      assert output =~ ":at_own_unit"
+    end
+
+    test "section is omitted when the resource has no resolve_argument declarations" do
+      output =
+        BulkItem
+        |> AshGrant.Explainer.explain(:update, nil)
+        |> AshGrant.Explanation.to_string(color: false)
+
+      refute output =~ "Argument Resolution"
+    end
+  end
+end

--- a/test/ash_grant/policy_test/argument_based_scope_test.exs
+++ b/test/ash_grant/policy_test/argument_based_scope_test.exs
@@ -1,0 +1,128 @@
+defmodule AshGrant.PolicyTest.ArgumentBasedScopeTest do
+  @moduledoc """
+  Tests that `AshGrant.PolicyTest` covers argument-based scopes through both
+  the DSL (`assert_can`/`assert_cannot` with `arguments:`) and the YAML
+  format (an `arguments:` field on a test).
+
+  The DSL path has its own assertions module; the YAML path has an
+  internal duplicate inside `YamlParser`. Both must forward the
+  `arguments` map to `Ash.Expr.fill_template` via `args:` for `^arg(...)`
+  templates to resolve during scope evaluation.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.PolicyTest.{Assertions, YamlParser}
+
+  @yaml_fixture "test/fixtures/policy_tests/argument_based_scope.yaml"
+
+  describe "DSL assertions — keyword-list third arg" do
+    test "assert_can passes when arguments satisfy the argument-based scope" do
+      filter =
+        AshGrant.Info.resolve_scope_filter(
+          AshGrant.Test.Auth.RefundDsl,
+          :at_own_unit,
+          %{}
+        )
+
+      actor = %{id: "u1", own_org_unit_ids: ["center_A"]}
+      record = %{author_id: "u1"}
+      arguments = %{center_id: "center_A"}
+
+      assert Assertions.evaluate_filter_against_record(
+               filter,
+               record,
+               actor,
+               AshGrant.Test.Auth.RefundDsl,
+               arguments
+             )
+    end
+
+    test "assert_cannot is correct when argument does not match actor's units" do
+      filter =
+        AshGrant.Info.resolve_scope_filter(
+          AshGrant.Test.Auth.RefundDsl,
+          :at_own_unit,
+          %{}
+        )
+
+      actor = %{id: "u1", own_org_unit_ids: ["center_A"]}
+      record = %{author_id: "u1"}
+      arguments = %{center_id: "center_Z"}
+
+      refute Assertions.evaluate_filter_against_record(
+               filter,
+               record,
+               actor,
+               AshGrant.Test.Auth.RefundDsl,
+               arguments
+             )
+    end
+
+    test "default arguments (empty map) still works for scopes that don't use ^arg(...)" do
+      filter =
+        AshGrant.Info.resolve_scope_filter(
+          AshGrant.Test.Auth.RefundDsl,
+          :by_own_author,
+          %{}
+        )
+
+      actor = %{id: "u1"}
+      record = %{author_id: "u1"}
+
+      # 4-arity form (no arguments) must keep working for legacy callers.
+      assert Assertions.evaluate_filter_against_record(
+               filter,
+               record,
+               actor,
+               AshGrant.Test.Auth.RefundDsl
+             )
+    end
+  end
+
+  describe "YAML parser — parses and forwards :arguments" do
+    test "parse_file picks up the arguments field on a test" do
+      {:ok, parsed} = YamlParser.parse_file(@yaml_fixture)
+
+      manager_test =
+        Enum.find(parsed.tests, &(&1.name =~ "manager can update"))
+
+      # YamlParser intentionally keeps mixed-case/quoted strings (UUIDs etc.)
+      # as strings; only lowercase-alphanum tokens atomize.
+      assert manager_test.arguments == %{center_id: "center_A"}
+    end
+
+    test "tests without arguments get an empty map" do
+      {:ok, parsed} = YamlParser.parse_file(@yaml_fixture)
+
+      author_test = Enum.find(parsed.tests, &(&1.name =~ "author can update own"))
+
+      assert author_test.arguments == %{}
+    end
+
+    test "running the fixture passes every assertion" do
+      {:ok, results} = YamlParser.run_yaml_tests(@yaml_fixture)
+
+      failed = Enum.reject(results, & &1.passed)
+
+      assert failed == [],
+             "expected every test in #{@yaml_fixture} to pass, but these failed:\n" <>
+               Enum.map_join(failed, "\n", &"  - #{&1.test_name}: #{&1.message}")
+    end
+  end
+
+  describe "DslGenerator — converts YAML arguments to DSL" do
+    test "generated DSL uses the keyword-list third-arg form when arguments are set" do
+      parsed = YamlParser.parse_file!(@yaml_fixture)
+      code = AshGrant.PolicyTest.DslGenerator.generate_from_parsed(parsed, @yaml_fixture)
+
+      # The manager test had both record: and arguments:, so expect the
+      # keyword-list form.
+      assert code =~ "arguments: %{center_id:"
+      assert code =~ "record:"
+
+      # The author test had only record:, so the simple 3-arg form should
+      # still be used.
+      assert code =~ ~r/assert_can :author_user, :update, %\{author_id:/
+    end
+  end
+end

--- a/test/fixtures/policy_tests/argument_based_scope.yaml
+++ b/test/fixtures/policy_tests/argument_based_scope.yaml
@@ -1,0 +1,48 @@
+resource: AshGrant.Test.Auth.RefundDsl
+
+actors:
+  unit_manager_A:
+    id: user_a
+    permissions:
+      - refund_dsl:*:update:at_own_unit
+    own_org_unit_ids:
+      - center_A
+      - center_B
+
+  author_user:
+    id: author_001
+    permissions:
+      - refund_dsl:*:update:by_own_author
+
+tests:
+  - name: "manager can update refund whose order center_id is in their units"
+    assert_can:
+      actor: unit_manager_A
+      action: update
+      record:
+        author_id: user_a
+      arguments:
+        center_id: center_A
+
+  - name: "manager cannot update refund whose order is in a different center"
+    assert_cannot:
+      actor: unit_manager_A
+      action: update
+      record:
+        author_id: user_a
+      arguments:
+        center_id: center_X
+
+  - name: "author can update own refund without any argument"
+    assert_can:
+      actor: author_user
+      action: update
+      record:
+        author_id: author_001
+
+  - name: "author cannot update another user's refund"
+    assert_cannot:
+      actor: author_user
+      action: update
+      record:
+        author_id: someone_else


### PR DESCRIPTION
## Summary

Rounds out the argument-based scope work so that both the introspection surface (`AshGrant.explain/4`) and the policy testing surfaces (DSL assertions + YAML fixtures + `DslGenerator`) understand `^arg(...)` templates and the `resolve_argument` declarations that populate them.

## What changed

### Explain module
- `AshGrant.Explanation` gains `:resolve_arguments` — a list of `%{name, from_path, for_actions, scopes_needing}` entries computed from the resource's declarations, annotated with the scope atoms that would trigger each resolver.
- `Explanation.to_string/2` renders a new "Argument Resolution" section (shown only when non-empty), so operators see *where* each `^arg(:x)` value comes from at runtime.
- Entries scoped via `:for_actions` are filtered for unrelated actions.

### PolicyTest (DSL)
- `assert_can`/`assert_cannot` now accept a keyword-list third argument:
  ```elixir
  assert_can :manager, :update,
    record: %{author_id: "u1"},
    arguments: %{center_id: "center_A"}
  ```
- Old forms keep working — bare map → record; no third arg → legacy.
- `arguments` flows through `check_permission/5 → check_scope_against_record/6 → evaluate_filter_against_record/5`, which passes them to `Ash.Expr.fill_template/2` via `:args`.

### PolicyTest (YAML)
- `YamlParser` parses an optional `arguments:` field on each test.
- Internal YAML runner propagates arguments through its own duplicate check chain.
- `DslGenerator` emits the keyword-list form when arguments are present, simple bare-map form otherwise — YAML→DSL conversion preserves behaviour.

## New files
- `test/fixtures/policy_tests/argument_based_scope.yaml` — reference fixture
- `test/ash_grant/explain_resolve_argument_test.exs` — 5 tests
- `test/ash_grant/policy_test/argument_based_scope_test.exs` — 7 tests

## Test plan
- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 38 doctests, 101 properties, 965 tests, 0 failures (12 new)
- [x] `mix format --check-formatted` clean
- [x] Existing DSL/YAML tests untouched (back-compat preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)