### PR TITLE
docs: cross-link argument-based scope from all relevant guides

### DIFF
--- a/guides/authorization-patterns.md
+++ b/guides/authorization-patterns.md
@@ -288,8 +288,17 @@ end
 ```
 
 For **read** actions, these compile to SQL (EXISTS subquery or JOIN).
-For **write** actions, AshGrant automatically uses a DB query fallback to verify
-the record matches the scope.
+For **simple write** actions, AshGrant uses a DB query fallback to verify
+the record matches the scope — this covers most single-hop cases.
+
+For **multi-hop write authorization** (e.g., `refund → order → center_id`),
+composite scope inheritance, or scopes that wrap relationship references inside
+functions, prefer the **argument-based scope pattern**: declare scopes against
+action arguments (`^arg(:x)`) and let the resource populate the argument from
+its own relationships via `resolve_argument`. See the
+[Argument-Based Scope guide](argument-based-scope.md) for the full walkthrough
+of that pattern — it avoids the DB-query fallback's rough edges and pays zero
+cost for scopes that don't reference the argument.
 
 ### Method 3: `scope_through` — Parent-Child Propagation
 

--- a/guides/checks-and-policies.md
+++ b/guides/checks-and-policies.md
@@ -136,6 +136,11 @@ ash_grant do
   scope :always, true
   scope :own, expr(owner_id == ^actor(:id))
 
+  # Argument-based scope + argument resolver
+  # (for multi-hop authorization — see the Argument-Based Scope guide)
+  scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+  resolve_argument :center_id, from_path: [:order, :center_id]
+
   # UI visibility calculations
   can_perform_actions [:update, :destroy]
 end
@@ -149,6 +154,16 @@ end
 | `can_perform_actions` | list of atoms | Batch-generate `CanPerform` calculations (e.g., `[:update, :destroy]`) |
 | `resource_name` | string | Resource name for permission matching. Default: derived from module name (last segment, snake_cased). `MyApp.Blog.Post` → `"post"`, `MyApp.CustomerOrder` → `"customer_order"` |
 | `instance_key` | atom | Field to match instance permission IDs against. Defaults to `:id` (primary key). See [Instance Key](permissions.md#instance-key) |
+
+**Entities inside `ash_grant do ... end`**
+
+| Entity | Description |
+|--------|-------------|
+| `scope :name, filter` | Named scope — see [Scopes](scopes.md) |
+| `field_group :name, fields` | Field-level access group — see [Field-Level Permissions](field-level-permissions.md) |
+| `can_perform :action` | Per-record boolean calculation |
+| `scope_through :rel` | Propagate parent instance permissions to this resource |
+| `resolve_argument :name, from_path: [...]` | Auto-populate an action argument from a relationship for argument-based scopes — see [Argument-Based Scope](argument-based-scope.md) |
 
 ### Default Policies Options
 

--- a/guides/policy-testing.md
+++ b/guides/policy-testing.md
@@ -55,14 +55,36 @@ end
 | Macro | Description |
 |-------|-------------|
 | `assert_can(actor, action)` | Actor can perform action |
-| `assert_can(actor, action, record)` | Actor can access specific record |
+| `assert_can(actor, action, record)` | Actor can access specific record (bare map) |
+| `assert_can(actor, action, [record: ..., arguments: ...])` | Actor can access record with action arguments |
 | `assert_cannot(actor, action)` | Actor cannot perform action |
-| `assert_cannot(actor, action, record)` | Actor cannot access specific record |
+| `assert_cannot(actor, action, record)` | Actor cannot access specific record (bare map) |
+| `assert_cannot(actor, action, [record: ..., arguments: ...])` | Actor cannot access record with action arguments |
 
 Action can be specified as:
 - Atom: `:read` (shorthand for `action: :read`)
 - Keyword: `action: :approve` (specific action name)
 - Keyword: `action_type: :update` (all actions of type)
+
+### Testing argument-based scopes
+
+For scopes that reference `^arg(:name)` (see
+[Argument-Based Scope](argument-based-scope.md)), pass an `arguments:` map
+alongside `record:` using the keyword-list form:
+
+```elixir
+assert_can :manager, :update,
+  record: %{author_id: "u1"},
+  arguments: %{center_id: "center_A"}
+
+assert_cannot :manager, :update,
+  record: %{author_id: "u1"},
+  arguments: %{center_id: "outside_unit"}
+```
+
+The `arguments` map is forwarded to `Ash.Expr.fill_template` as `:args`, so
+the scope's `^arg(:center_id)` resolves to the supplied value before
+evaluation against the record.
 
 ## YAML Format
 
@@ -112,6 +134,32 @@ tests:
       record:
         author_id: "other_user"
 ```
+
+### YAML — `arguments:` field for argument-based scopes
+
+YAML tests can provide action arguments for scopes that use `^arg(:name)`:
+
+```yaml
+  - name: "manager can update refund in their unit"
+    assert_can:
+      actor: unit_manager
+      action: update
+      record:
+        author_id: "u1"
+      arguments:
+        center_id: "center_A"
+
+  - name: "manager cannot update refund outside their unit"
+    assert_cannot:
+      actor: unit_manager
+      action: update
+      record:
+        author_id: "u1"
+      arguments:
+        center_id: "center_Z"
+```
+
+See [Argument-Based Scope](argument-based-scope.md) for when to use this pattern.
 
 ## Mix Tasks
 

--- a/guides/scope-naming-convention.md
+++ b/guides/scope-naming-convention.md
@@ -71,6 +71,20 @@ The simple `:own` is kept for the common case of "my own record":
 scope :own, expr(user_id == ^actor(:id))
 ```
 
+> **When the scoped attribute is not on the record itself** — e.g., Refund
+> reaches `center_id` only through its `:order` relationship — write the
+> expression against an action argument rather than traversing the
+> relationship, and declare a `resolve_argument` to populate it:
+>
+> ```elixir
+> scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+> resolve_argument :center_id, from_path: [:order, :center_id]
+> ```
+>
+> The scope name stays `:at_own_unit` (the sentence test still passes:
+> "Actor can update refund at own unit"). See the
+> [Argument-Based Scope guide](argument-based-scope.md) for the full rationale.
+
 ### Rule 3: Resource state scopes — adjectives or participles
 
 For ABAC scopes based on record attributes, use names that describe the state:


### PR DESCRIPTION
## Summary

Audit of all `guides/*.md` files revealed that four described relational-scope usage without mentioning the argument-based alternative or linking to its dedicated guide. This threads the pattern through consistently.

### Updated

| Guide | Change |
|---|---|
| `authorization-patterns.md` | ReBAC section's "DB query fallback" paragraph now qualifies (simple cases) and points at argument-based for multi-hop / composite / function-wrapped |
| `checks-and-policies.md` | DSL Configuration example + table include `resolve_argument` as a first-class entity |
| `policy-testing.md` | Assertion-macro table documents `[record:, arguments:]` keyword-list form; new subsections show DSL call shape and YAML `arguments:` field |
| `scope-naming-convention.md` | Rule 2 callout explains that when the scoped attribute lives behind a relationship, the *shape* of the expression changes (use `^arg(:x)` + `resolve_argument`) while the naming still applies |

### Unchanged (not a miss)

- `field-level-permissions.md` — column-level access, orthogonal to scope evaluation
- `permissions.md` — permission string format, orthogonal

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 38 doctests, 101 properties, 965 tests, 0 failures (no behaviour change)
- [x] `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)