### PR TITLE
docs: tip — prefer direct FK column over relationship traversal when the check is about the FK itself

### DIFF
--- a/guides/scopes.md
+++ b/guides/scopes.md
@@ -190,6 +190,23 @@ For **write** actions, `Check` automatically uses a **DB query fallback** when t
 scope contains relationship references — the read scope expression is used as a DB
 query to verify the record matches the scope.
 
+> **Tip: use the foreign key column directly when the check is really about it.**
+>
+> Expressions like `expr(not is_nil(team.id))` reach through a belongs_to
+> relationship to check something the record already knows — its own FK column:
+>
+> ```elixir
+> # ❌ Traverses the relationship; forces the DB-query fallback on writes.
+> scope :has_team, expr(not is_nil(team.id))
+>
+> # ✅ Direct FK — evaluates in memory, no DB round-trip.
+> scope :has_team, expr(not is_nil(team_id))
+> ```
+>
+> Use the relationship form only when you genuinely need a value stored on the
+> related record (and for multi-hop cases, prefer the argument-based pattern
+> below).
+
 ### Recommended: argument-based scopes for multi-hop authorization
 
 For write-action authorization that reaches through relationships


### PR DESCRIPTION
## Summary

Small follow-up promised when closing #86 as not planned.

Surfaces a footgun that is easy to miss: `expr(not is_nil(team.id))` reaches through a belongs_to relationship to check something the record already knows via its own `team_id` column. The direct-attribute form evaluates in memory (no DB-query fallback), is faster, and sidesteps the function-wrapped relational-ref limitations discussed in #86.

```elixir
# ❌ Traverses the relationship; forces the DB-query fallback on writes.
scope :has_team, expr(not is_nil(team.id))

# ✅ Direct FK — evaluates in memory, no DB round-trip.
scope :has_team, expr(not is_nil(team_id))
```

Added as a `> Tip:` block in `guides/scopes.md`, right before the "Recommended: argument-based scopes" section.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 38 doctests, 101 properties, 965 tests, 0 failures (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)