### PR TITLE
fix: forward changeset tenant in resolve_argument (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`resolve_argument` silently failed on CREATE for attribute-multitenant targets** (#99). `AshGrant.Changes.ResolveArgument` did not forward the changeset's tenant to `Ash.get!`/`Ash.load!`, so whenever any hop in `from_path` pointed to a resource with `multitenancy strategy: :attribute`, the fetch raised, the rescue returned `nil`, and the argument-based scope evaluated to `false` — denying the action. The change now passes `tenant: changeset.tenant` to both the create-path `safe_get/3` and the update/destroy-path `safe_load/3`.
+
 ## [0.14.0] - 2026-04-13
 
 This release is centred on a new **argument-based scope pattern** for

--- a/guides/argument-based-scope.md
+++ b/guides/argument-based-scope.md
@@ -210,6 +210,14 @@ the authorization fails with nil arguments.
 
 **Always pass `actor:` to `for_*/4` when using this pattern.**
 
+### Multi-tenancy
+
+`resolve_argument` forwards the changeset's `tenant` to the internal
+`Ash.get!`/`Ash.load!` calls. Paths that traverse resources with
+`multitenancy strategy: :attribute` resolve correctly as long as you call the
+action with `tenant:` set — the same tenant you would pass to any other
+multitenant action.
+
 ### `require_atomic? false` on update/destroy
 
 The generated change does not implement the atomic protocol. If your data

--- a/lib/ash_grant/changes/resolve_argument.ex
+++ b/lib/ash_grant/changes/resolve_argument.ex
@@ -33,6 +33,13 @@ defmodule AshGrant.Changes.ResolveArgument do
   referenced record was deleted), the change returns the changeset unchanged —
   the scope will then evaluate against a `nil` argument and typically fail
   closed (authorization denied).
+
+  ## Multi-tenancy
+
+  The changeset's `:tenant` is forwarded to the internal `Ash.get!`/`Ash.load!`
+  calls so that resources along `from_path` using attribute multitenancy can be
+  fetched correctly. Without this, those fetches would raise, be rescued, and
+  leave the argument unset — causing the scope to evaluate to `false`.
   """
 
   use Ash.Resource.Change
@@ -121,7 +128,7 @@ defmodule AshGrant.Changes.ResolveArgument do
     with %{source_attribute: source_attr, destination: destination} <-
            Ash.Resource.Info.relationship(cs.resource, first_rel),
          fk_value when not is_nil(fk_value) <- Changeset.get_attribute(cs, source_attr),
-         head when not is_nil(head) <- safe_get(destination, fk_value) do
+         head when not is_nil(head) <- safe_get(destination, fk_value, tenant_opts(cs)) do
       traverse(head, rest)
     else
       _ -> :skip
@@ -131,11 +138,18 @@ defmodule AshGrant.Changes.ResolveArgument do
   defp resolve_value(cs, path) do
     {rel_path, leaf} = split_relationship_path(cs.resource, path)
 
-    case safe_load(cs.data, build_load(rel_path)) do
+    case safe_load(cs.data, build_load(rel_path), tenant_opts(cs)) do
       {:ok, loaded} -> traverse_loaded(loaded, rel_path, leaf)
       :error -> :skip
     end
   end
+
+  # Forward the changeset's tenant so that target resources using attribute
+  # multitenancy can be fetched/loaded. Without this, `Ash.get!`/`Ash.load!`
+  # raise for attribute-multitenant resources and the change silently skips.
+  defp tenant_opts(%{tenant: nil}), do: []
+  defp tenant_opts(%{tenant: tenant}), do: [tenant: tenant]
+  defp tenant_opts(_), do: []
 
   # Walk down a path that's already loaded (for create case, we've already
   # loaded the first hop — traverse the rest).
@@ -199,16 +213,16 @@ defmodule AshGrant.Changes.ResolveArgument do
   defp build_load([rel]), do: rel
   defp build_load([rel | rest]), do: [{rel, build_load(rest)}]
 
-  defp safe_get(resource, id) do
-    Ash.get!(resource, id, authorize?: false)
+  defp safe_get(resource, id, extra_opts) do
+    Ash.get!(resource, id, Keyword.merge([authorize?: false], extra_opts))
   rescue
     _ -> nil
   end
 
-  defp safe_load(_data, nil), do: {:ok, nil}
+  defp safe_load(_data, nil, _extra_opts), do: {:ok, nil}
 
-  defp safe_load(data, load_spec) do
-    {:ok, Ash.load!(data, load_spec, authorize?: false)}
+  defp safe_load(data, load_spec, extra_opts) do
+    {:ok, Ash.load!(data, load_spec, Keyword.merge([authorize?: false], extra_opts))}
   rescue
     _ -> :error
   end

--- a/priv/test_repo/migrations/20260413000000_create_tenant_refund_tables.exs
+++ b/priv/test_repo/migrations/20260413000000_create_tenant_refund_tables.exs
@@ -1,0 +1,28 @@
+defmodule AshGrant.TestRepo.Migrations.CreateTenantRefundTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:tenant_orders, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:center_id, :uuid, null: false)
+      add(:tenant_id, :uuid, null: false)
+    end
+
+    create(index(:tenant_orders, [:tenant_id]))
+
+    create table(:tenant_refunds, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:amount, :integer, null: false)
+      add(:tenant_id, :uuid, null: false)
+
+      add(
+        :order_id,
+        references(:tenant_orders, type: :uuid, on_delete: :delete_all),
+        null: false
+      )
+    end
+
+    create(index(:tenant_refunds, [:tenant_id]))
+    create(index(:tenant_refunds, [:order_id]))
+  end
+end

--- a/test/ash_grant/resolve_argument_multitenancy_test.exs
+++ b/test/ash_grant/resolve_argument_multitenancy_test.exs
@@ -1,0 +1,97 @@
+defmodule AshGrant.ResolveArgumentMultitenancyTest do
+  @moduledoc """
+  Regression coverage for issue #99:
+
+  `resolve_argument` CREATE path silently failed when any hop in the
+  `from_path` pointed to an attribute-multitenant resource, because
+  `ResolveArgument.safe_get/2` called `Ash.get!` without forwarding the
+  changeset's tenant. The rescued raise left the argument nil, causing the
+  argument-based scope to evaluate to `false` and the action to be denied.
+  """
+  use AshGrant.DataCase, async: false
+
+  alias AshGrant.Test.{TenantOrder, TenantRefund}
+
+  defp actor(perms, extras) do
+    Map.merge(%{id: Ash.UUID.generate(), permissions: perms}, extras)
+  end
+
+  defp create_order!(tenant_id, center_id) do
+    TenantOrder
+    |> Ash.Changeset.for_create(:create, %{center_id: center_id}, tenant: tenant_id)
+    |> Ash.create!(tenant: tenant_id, authorize?: false)
+  end
+
+  describe "resolve_argument on a multitenant target (create path)" do
+    test "create succeeds when the argument-based scope matches" do
+      tenant = Ash.UUID.generate()
+      center = Ash.UUID.generate()
+      actor = actor(["tenant_refund:*:create:at_own_unit"], %{own_center_ids: [center]})
+
+      order = create_order!(tenant, center)
+
+      result =
+        TenantRefund
+        |> Ash.Changeset.for_create(
+          :create,
+          %{amount: 100, order_id: order.id},
+          actor: actor,
+          tenant: tenant
+        )
+        |> Ash.create(actor: actor, tenant: tenant)
+
+      assert {:ok, refund} = result
+      assert refund.tenant_id == tenant
+    end
+
+    test "create is forbidden when the relational scope does not match" do
+      tenant = Ash.UUID.generate()
+      order_center = Ash.UUID.generate()
+      other_center = Ash.UUID.generate()
+
+      # Actor only owns a center the order does NOT belong to.
+      actor = actor(["tenant_refund:*:create:at_own_unit"], %{own_center_ids: [other_center]})
+
+      order = create_order!(tenant, order_center)
+
+      result =
+        TenantRefund
+        |> Ash.Changeset.for_create(
+          :create,
+          %{amount: 100, order_id: order.id},
+          actor: actor,
+          tenant: tenant
+        )
+        |> Ash.create(actor: actor, tenant: tenant)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+  end
+
+  describe "resolve_argument on a multitenant target (update path)" do
+    test "update succeeds when the argument-based scope matches" do
+      tenant = Ash.UUID.generate()
+      center = Ash.UUID.generate()
+      actor = actor(["tenant_refund:*:update:at_own_unit"], %{own_center_ids: [center]})
+
+      order = create_order!(tenant, center)
+
+      refund =
+        TenantRefund
+        |> Ash.Changeset.for_create(
+          :create,
+          %{amount: 100, order_id: order.id},
+          tenant: tenant
+        )
+        |> Ash.create!(tenant: tenant, authorize?: false)
+
+      result =
+        refund
+        |> Ash.Changeset.for_update(:update, %{amount: 200}, actor: actor, tenant: tenant)
+        |> Ash.update(actor: actor, tenant: tenant)
+
+      assert {:ok, updated} = result
+      assert updated.amount == 200
+    end
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -33,6 +33,12 @@ defmodule AshGrant.Test.Domain do
     # Uses ^tenant() scope expression
     resource(AshGrant.Test.TenantPost)
 
+    # Attribute-multitenant resources exercising `resolve_argument` on a
+    # CREATE action whose target relationship is also attribute-multitenant
+    # (regression coverage for issue #99).
+    resource(AshGrant.Test.TenantOrder)
+    resource(AshGrant.Test.TenantRefund)
+
     # Instance permission read test resource
     resource(AshGrant.Test.SharedDoc)
 

--- a/test/support/resources/tenant_order.ex
+++ b/test/support/resources/tenant_order.ex
@@ -1,0 +1,42 @@
+defmodule AshGrant.Test.TenantOrder do
+  @moduledoc """
+  Attribute-multitenant Postgres resource used to reproduce the
+  `resolve_argument` CREATE-path tenant forwarding bug (issue #99).
+
+  Pairs with `AshGrant.Test.TenantRefund`, which declares
+  `resolve_argument :center_id, from_path: [:order, :center_id]` on an action
+  whose target (this resource) is attribute-multitenant.
+  """
+
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: AshPostgres.DataLayer
+
+  postgres do
+    table("tenant_orders")
+    repo(AshGrant.TestRepo)
+  end
+
+  multitenancy do
+    strategy(:attribute)
+    attribute(:tenant_id)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:center_id, :uuid, public?: true, allow_nil?: false)
+    attribute(:tenant_id, :uuid, public?: true, allow_nil?: false)
+  end
+
+  actions do
+    defaults([:read, :destroy])
+
+    create :create do
+      accept([:center_id])
+    end
+
+    update :update do
+      accept([:center_id])
+    end
+  end
+end

--- a/test/support/resources/tenant_refund.ex
+++ b/test/support/resources/tenant_refund.ex
@@ -1,0 +1,76 @@
+defmodule AshGrant.Test.TenantRefund do
+  @moduledoc """
+  Attribute-multitenant Postgres resource used to reproduce the
+  `resolve_argument` CREATE-path tenant forwarding bug (issue #99).
+
+  The `resolve_argument` declaration below triggered silent failure prior to
+  the fix: on :create, `ResolveArgument` called `Ash.get!` without
+  forwarding the changeset's tenant, so the target (a multitenant resource)
+  raised, was rescued, and the argument stayed nil — denying the action.
+  """
+
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: AshPostgres.DataLayer,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  postgres do
+    table("tenant_refunds")
+    repo(AshGrant.TestRepo)
+  end
+
+  multitenancy do
+    strategy(:attribute)
+    attribute(:tenant_id)
+  end
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil -> []
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    resource_name("tenant_refund")
+    default_policies(true)
+
+    scope(:always, true)
+    scope(:at_own_unit, expr(^arg(:center_id) in ^actor(:own_center_ids)))
+
+    resolve_argument(:center_id, from_path: [:order, :center_id])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:amount, :integer, public?: true, allow_nil?: false)
+    attribute(:tenant_id, :uuid, public?: true, allow_nil?: false)
+  end
+
+  relationships do
+    belongs_to :order, AshGrant.Test.TenantOrder do
+      public?(true)
+      allow_nil?(false)
+      attribute_writable?(true)
+    end
+  end
+
+  actions do
+    defaults([:read])
+
+    create :create do
+      accept([:amount, :order_id])
+    end
+
+    update :update do
+      accept([:amount])
+      require_atomic?(false)
+    end
+
+    destroy :destroy do
+      require_atomic?(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes #99: `resolve_argument` silently failed on CREATE when any hop in `from_path` pointed to an attribute-multitenant resource, because `Ash.get!`/`Ash.load!` were called without a `tenant:` option — they raised, the rescue returned `nil`, and the argument stayed unset, denying the action.
- `AshGrant.Changes.ResolveArgument` now forwards `changeset.tenant` to both the create-path `safe_get/3` and the update/destroy-path `safe_load/3`.
- Added regression coverage with two new postgres-backed resources (`TenantOrder`, `TenantRefund`) using `multitenancy strategy: :attribute`, plus a migration and a three-case test file (create allow, create deny, update allow). Verified the create-allow test fails with the fix reverted.
- Documented the tenant-forwarding contract in `@moduledoc` and added a "Multi-tenancy" gotcha in `guides/argument-based-scope.md`.
- CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 968 tests, 0 failures
- [x] `mix credo` — no new issues
- [x] `mix format --check-formatted` clean
- [x] New regression test fails without the fix and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)