### PR TITLE
fix: route resolve_argument gate through the PermissionResolver (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`resolve_argument` was a silent no-op for non-plain-map actors** (#101). The `needs_resolution?/3` optimization read permissions straight off `actor.permissions` and returned `[]` for any actor that was not a literal map with a `:permissions` key. Real Ash resource structs carry no such field — permissions come from the configured `PermissionResolver` — so the change never ran in production, the argument stayed `nil`, and argument-based scopes always denied. `AshGrant.Changes.ResolveArgument` now routes through the resource's configured resolver (same source as `AshGrant.Check`/`FilterCheck`) and conservatively resolves the argument when the resolver is absent or raises, rather than skipping.
 - **`resolve_argument` silently failed on CREATE for attribute-multitenant targets** (#99). `AshGrant.Changes.ResolveArgument` did not forward the changeset's tenant to `Ash.get!`/`Ash.load!`, so whenever any hop in `from_path` pointed to a resource with `multitenancy strategy: :attribute`, the fetch raised, the rescue returned `nil`, and the argument-based scope evaluated to `false` — denying the action. The change now passes `tenant: changeset.tenant` to both the create-path `safe_get/3` and the update/destroy-path `safe_load/3`.
 
 ## [0.14.0] - 2026-04-13

--- a/lib/ash_grant/changes/resolve_argument.ex
+++ b/lib/ash_grant/changes/resolve_argument.ex
@@ -18,8 +18,15 @@ defmodule AshGrant.Changes.ResolveArgument do
 
   ## Runtime contract
 
-  If the actor is nil, or none of the actor's permissions use a scope in
+  If the actor is nil, or none of the actor's permissions (as returned by the
+  resource's configured `AshGrant.PermissionResolver`) use a scope in
   `:scopes_needing`, the change is a no-op — no DB load is performed.
+
+  If the resource has no resolver configured, or the resolver raises/returns
+  an unexpected shape, the change conservatively resolves the argument
+  rather than skipping — otherwise production actors (Ash resource structs
+  that carry no literal `:permissions` field) would silently bypass the
+  resolver.
 
   Otherwise, the change resolves the path:
 
@@ -54,7 +61,7 @@ defmodule AshGrant.Changes.ResolveArgument do
 
     actor = actor_from_context(ctx, changeset)
 
-    if needs_resolution?(actor, changeset.resource, scopes_needing) do
+    if needs_resolution?(actor, changeset.resource, scopes_needing, changeset) do
       case resolve_value(changeset, path) do
         {:ok, value} -> Changeset.set_argument(changeset, name, value)
         :skip -> changeset
@@ -76,17 +83,62 @@ defmodule AshGrant.Changes.ResolveArgument do
 
   defp actor_from_context(_, _), do: nil
 
-  defp needs_resolution?(nil, _resource, _scopes_needing), do: false
-  defp needs_resolution?(_actor, _resource, []), do: false
+  defp needs_resolution?(nil, _resource, _scopes_needing, _changeset), do: false
+  defp needs_resolution?(_actor, _resource, [], _changeset), do: false
 
-  defp needs_resolution?(actor, resource, scopes_needing) do
-    actor
-    |> permissions()
-    |> Enum.any?(&permission_uses_listed_scope?(&1, resource, scopes_needing))
+  defp needs_resolution?(actor, resource, scopes_needing, changeset) do
+    case actor_permissions(actor, resource, changeset) do
+      :unknown ->
+        # Conservative fallback: we couldn't introspect the actor's
+        # permissions (no resolver configured, or resolver raised). Resolve
+        # the argument rather than skipping — otherwise the scope evaluates
+        # against nil and denies valid actions.
+        true
+
+      perms when is_list(perms) ->
+        Enum.any?(perms, &permission_uses_listed_scope?(&1, resource, scopes_needing))
+    end
   end
 
-  defp permissions(%{permissions: perms}) when is_list(perms), do: perms
-  defp permissions(_), do: []
+  # Determine the actor's permissions using the resource's configured
+  # PermissionResolver — the same source `AshGrant.Check`/`FilterCheck` use at
+  # authorization time. Falling back to the literal `actor.permissions` field
+  # only works for plain-map actors (as in `AshGrant.PolicyTest`); real Ash
+  # resource structs carry no such field, so relying on it made the
+  # optimization a silent no-op in production (#101).
+  defp actor_permissions(actor, resource, changeset) do
+    case AshGrant.Info.resolver(resource) do
+      nil ->
+        literal_permissions(actor)
+
+      resolver ->
+        resolve_permissions(resolver, actor, resolver_context(actor, resource, changeset))
+    end
+  rescue
+    _ -> :unknown
+  end
+
+  defp resolver_context(actor, resource, changeset) do
+    %{
+      actor: actor,
+      resource: resource,
+      tenant: changeset.tenant,
+      action: changeset.action
+    }
+  end
+
+  defp resolve_permissions(resolver, actor, context) when is_function(resolver, 2) do
+    resolver.(actor, context)
+  end
+
+  defp resolve_permissions(resolver, actor, context) when is_atom(resolver) do
+    resolver.resolve(actor, context)
+  end
+
+  defp resolve_permissions(_, _, _), do: :unknown
+
+  defp literal_permissions(%{permissions: perms}) when is_list(perms), do: perms
+  defp literal_permissions(_), do: :unknown
 
   defp permission_uses_listed_scope?(perm_string, resource, scopes_needing) do
     case AshGrant.Permission.parse(perm_string) do

--- a/test/ash_grant/resolve_argument_struct_actor_test.exs
+++ b/test/ash_grant/resolve_argument_struct_actor_test.exs
@@ -1,0 +1,108 @@
+defmodule AshGrant.ResolveArgumentStructActorTest do
+  @moduledoc """
+  Regression coverage for issue #101:
+
+  `AshGrant.Changes.ResolveArgument.needs_resolution?/3` previously only
+  inspected `actor.permissions`. Production actors are Ash resource structs
+  without a literal `:permissions` field — permissions come from the
+  configured `PermissionResolver`. The old implementation silently treated
+  such actors as having no permissions, so the change never loaded the
+  relationship, `^arg(:name)` stayed nil, and the action was denied.
+
+  The fix routes through the resource's configured resolver, matching
+  `AshGrant.Check` / `FilterCheck`.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshGrant.Test.Auth.{Order, RefundStructActor}
+
+  # Simulates a production actor — an Ash resource / Ecto schema struct that
+  # carries domain attributes (role, org unit IDs) but no literal
+  # `:permissions` list. Permissions must come from the resolver.
+  defmodule Actor do
+    @moduledoc false
+    defstruct [:id, :role, :own_org_unit_ids]
+  end
+
+  setup do
+    RefundStructActor
+    |> Ash.read!(authorize?: false)
+    |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+
+    Order
+    |> Ash.read!(authorize?: false)
+    |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+
+    :ok
+  end
+
+  defp create_order!(center_id) do
+    Order
+    |> Ash.Changeset.for_create(:create, %{center_id: center_id})
+    |> Ash.create!(authorize?: false)
+  end
+
+  describe "struct actor (no literal :permissions field) drives resolve_argument via the resolver" do
+    test "create succeeds when the resolver-returned permission uses the argument-based scope" do
+      center = Ash.UUID.generate()
+      actor = %Actor{id: Ash.UUID.generate(), role: :center_manager, own_org_unit_ids: [center]}
+
+      order = create_order!(center)
+
+      result =
+        RefundStructActor
+        |> Ash.Changeset.for_create(
+          :create,
+          %{author_id: actor.id, order_id: order.id, amount: 50},
+          actor: actor
+        )
+        |> Ash.create(actor: actor)
+
+      assert {:ok, _} = result
+    end
+
+    test "create is forbidden when the resolver-returned permissions do not authorize the action" do
+      center = Ash.UUID.generate()
+      # `:author` role has an update permission, but no create permission —
+      # so create should be forbidden regardless of argument resolution.
+      actor = %Actor{id: Ash.UUID.generate(), role: :author, own_org_unit_ids: [center]}
+
+      order = create_order!(center)
+
+      result =
+        RefundStructActor
+        |> Ash.Changeset.for_create(
+          :create,
+          %{author_id: actor.id, order_id: order.id, amount: 50},
+          actor: actor
+        )
+        |> Ash.create(actor: actor)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "update skips the load when the in-play permissions do not reference the argument" do
+      # :author role only has update:by_own_author which doesn't reference
+      # ^arg(:center_id), so no DB load for :order should be triggered.
+      author_id = Ash.UUID.generate()
+      actor = %Actor{id: author_id, role: :author, own_org_unit_ids: []}
+
+      order = create_order!(Ash.UUID.generate())
+
+      refund =
+        RefundStructActor
+        |> Ash.Changeset.for_create(
+          :create,
+          %{author_id: author_id, order_id: order.id, amount: 10}
+        )
+        |> Ash.create!(authorize?: false)
+
+      cs = Ash.Changeset.for_update(refund, :update, %{amount: 20}, actor: actor)
+
+      # Argument was not populated — scope doesn't need it.
+      refute match?(%{center_id: v} when not is_nil(v), cs.arguments)
+
+      assert {:ok, _} = Ash.update(cs, actor: actor)
+    end
+  end
+end

--- a/test/support/auth_pattern/domain.ex
+++ b/test/support/auth_pattern/domain.ex
@@ -7,5 +7,6 @@ defmodule AshGrant.Test.Auth.Domain do
     resource(AshGrant.Test.Auth.Refund)
     resource(AshGrant.Test.Auth.RefundDsl)
     resource(AshGrant.Test.Auth.RefundDefaults)
+    resource(AshGrant.Test.Auth.RefundStructActor)
   end
 end

--- a/test/support/resources/auth_pattern_refund_struct_actor.ex
+++ b/test/support/resources/auth_pattern_refund_struct_actor.ex
@@ -1,0 +1,71 @@
+defmodule AshGrant.Test.Auth.RefundStructActor do
+  @moduledoc false
+  # Test resource for issue #101: when the actor is a struct with no
+  # `:permissions` field (as real production Ash resource actors typically
+  # are), `ResolveArgument` must still consult the resource's configured
+  # `PermissionResolver` to decide whether to resolve the argument.
+
+  use Ash.Resource,
+    domain: AshGrant.Test.Auth.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ets do
+    private?(true)
+  end
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        nil ->
+          []
+
+        %{role: :center_manager} ->
+          ["refund_struct_actor:*:create:at_own_unit", "refund_struct_actor:*:update:at_own_unit"]
+
+        %{role: :author} ->
+          ["refund_struct_actor:*:update:by_own_author"]
+
+        _ ->
+          []
+      end
+    end)
+
+    resource_name("refund_struct_actor")
+    default_policies(true)
+
+    scope(:always, true)
+    scope(:by_own_author, expr(author_id == ^actor(:id)))
+    scope(:at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids)))
+
+    resolve_argument(:center_id, from_path: [:order, :center_id])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:author_id, :uuid, public?: true, allow_nil?: false)
+    attribute(:amount, :integer, public?: true, allow_nil?: false)
+  end
+
+  relationships do
+    belongs_to :order, AshGrant.Test.Auth.Order do
+      public?(true)
+      allow_nil?(false)
+      attribute_writable?(true)
+    end
+  end
+
+  actions do
+    defaults([:read])
+
+    create :create do
+      accept([:author_id, :amount, :order_id])
+    end
+
+    update :update do
+      accept([:amount])
+      require_atomic?(false)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes #101: `AshGrant.Changes.ResolveArgument` read `actor.permissions` directly, so for any actor that wasn't a plain map with a literal `:permissions` key (i.e., every real production Ash resource struct) the optimization returned `[]`, the change silently became a no-op, and argument-based scopes always denied valid actions.
- `PolicyTest` actors are plain maps with `:permissions`, so the bug was invisible in tests — a false green signal noted in the issue.
- The change now consults `AshGrant.Info.resolver(resource)` — the same source `AshGrant.Check`/`FilterCheck` use at authorization time — and passes `%{actor, resource, tenant, action}` as context. If the resource has no resolver or the resolver raises, the change conservatively resolves the argument rather than skipping, preserving correctness.
- Companion to #99/#100 — together both fixes let `resolve_argument` replace hand-rolled resolvers in projects that use Ash resource structs as actors behind a `PermissionResolver`.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 971 tests, 0 failures
- [x] `mix format --check-formatted` clean
- [x] New regression test fails without the fix and passes with it (verified by temporarily reverting `needs_resolution?`)
- [x] New resource `AshGrant.Test.Auth.RefundStructActor` uses a role-based resolver and a struct actor with no `:permissions` field, mirroring the production shape described in the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)