### PR TITLE
release: v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.1] - 2026-04-13
+
+Two fixes that make `resolve_argument` (introduced in 0.14.0) actually
+usable outside `AshGrant.PolicyTest` — both bugs rendered the DSL sugar
+a silent no-op in production. Also bumps the hard Ash floor to 3.19 for
+compatibility-CI parity.
 
 ### Fixed
 
 - **`resolve_argument` was a silent no-op for non-plain-map actors** (#101). The `needs_resolution?/3` optimization read permissions straight off `actor.permissions` and returned `[]` for any actor that was not a literal map with a `:permissions` key. Real Ash resource structs carry no such field — permissions come from the configured `PermissionResolver` — so the change never ran in production, the argument stayed `nil`, and argument-based scopes always denied. `AshGrant.Changes.ResolveArgument` now routes through the resource's configured resolver (same source as `AshGrant.Check`/`FilterCheck`) and conservatively resolves the argument when the resolver is absent or raises, rather than skipping.
 - **`resolve_argument` silently failed on CREATE for attribute-multitenant targets** (#99). `AshGrant.Changes.ResolveArgument` did not forward the changeset's tenant to `Ash.get!`/`Ash.load!`, so whenever any hop in `from_path` pointed to a resource with `multitenancy strategy: :attribute`, the fetch raised, the rescue returned `nil`, and the argument-based scope evaluated to `false` — denying the action. The change now passes `tenant: changeset.tenant` to both the create-path `safe_get/3` and the update/destroy-path `safe_load/3`.
+
+### Changed
+
+- **Ash floor bumped from `~> 3.7` to `~> 3.19`** (#98). Aligns the declared minimum with the version the compatibility CI matrix already exercises.
+
+### Documentation
+
+- ExDoc now surfaces the `scope-naming-convention.md` and `argument-based-scope.md` guides in its extras list (previously authored but unlinked in `mix.exs`).
+- `AshGrant.ArgumentAnalyzer` `@moduledoc` no longer references a removed helper on `AshGrant.Check`.
 
 ## [0.14.0] - 2026-04-13
 

--- a/lib/ash_grant/argument_analyzer.ex
+++ b/lib/ash_grant/argument_analyzer.ex
@@ -8,8 +8,7 @@ defmodule AshGrant.ArgumentAnalyzer do
   `AshGrant.Transformers.AddArgumentResolvers` transformer uses to wire up
   `AshGrant.Changes.ResolveArgument` only where the argument is actually needed.
 
-  The walker understands the same AST shapes as
-  `AshGrant.Check.contains_relationship_reference?/1`:
+  The walker understands the following AST shapes:
 
     * `%Ash.Query.BooleanExpression{}`, `%Ash.Query.Not{}`
     * `%Ash.Query.Call{args: [...]}`

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.14.0"
+  @version "0.14.1"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do
@@ -86,6 +86,8 @@ defmodule AshGrant.MixProject do
         "guides/permissions.md": [title: "Permissions"],
         "guides/scopes.md": [title: "Scopes"],
         "guides/field-level-permissions.md": [title: "Field-Level Permissions"],
+        "guides/scope-naming-convention.md": [title: "Scope Naming Convention"],
+        "guides/argument-based-scope.md": [title: "Argument-Based Scope"],
         "guides/checks-and-policies.md": [title: "Checks & Policies"],
         "guides/debugging-and-introspection.md": [title: "Debugging & Introspection"],
         "guides/policy-testing.md": [title: "Policy Testing"],


### PR DESCRIPTION
## Summary
- Bump version to 0.14.1
- Update CHANGELOG.md
- Register two guides (`argument-based-scope.md`, `scope-naming-convention.md`) in the ExDoc extras list
- Minor `@moduledoc` cleanup on `AshGrant.ArgumentAnalyzer`

### What's new in v0.14.1

**Fixed**
- `resolve_argument` was a silent no-op for non-plain-map actors (#101, fixed in #102). The permission-gate optimization read `actor.permissions` literally, so production Ash-struct actors (which get permissions from a `PermissionResolver`, not a literal field) bypassed the gate silently. Now routes through `AshGrant.Info.resolver/1` — same source as `AshGrant.Check`/`FilterCheck`.
- `resolve_argument` silently failed on CREATE for attribute-multitenant targets (#99, fixed in #100). The internal `Ash.get!`/`Ash.load!` calls didn't forward `changeset.tenant`, so any hop in `from_path` pointing at an attribute-multitenant resource raised, was rescued, and left the argument `nil`. Tenant is now threaded through to both paths.

**Changed**
- Ash floor bumped from `~> 3.7` to `~> 3.19` (#98) to match the matrix the compatibility CI already exercises.

**Documentation**
- Two guides authored in the 0.14.0 window are now actually surfaced in generated ExDoc.
- `AshGrant.ArgumentAnalyzer` @moduledoc no longer references a removed helper.

## Post-merge
```
git checkout main && git pull
git tag v0.14.1
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)