### PR TITLE
feat: add resource registry and key-based lookup to Introspect

### DIFF
--- a/lib/ash_grant/introspect.ex
+++ b/lib/ash_grant/introspect.ex
@@ -59,6 +59,90 @@ defmodule AshGrant.Introspect do
         }
 
   @doc """
+  Lists Ash domains configured under `:ash_domains` across all started
+  applications.
+
+  AshGrant reuses the standard Ash convention (`config :my_app, ash_domains: [...]`)
+  rather than introducing its own configuration key. Any domain registered this
+  way is a candidate for resource discovery.
+
+  ## Examples
+
+      iex> AshGrant.Introspect.list_domains()
+      [MyApp.Blog, MyApp.Accounts]
+
+  """
+  @spec list_domains() :: [module()]
+  def list_domains do
+    for {app, _, _} <- Application.started_applications(),
+        domain <- Application.get_env(app, :ash_domains, []),
+        uniq: true,
+        do: domain
+  end
+
+  @doc """
+  Lists every resource that uses the `AshGrant` extension.
+
+  By default, domains are auto-discovered via `list_domains/0`. Pass
+  `:domains` to scope the lookup to a specific set (useful in tests and
+  multi-tenant setups).
+
+  ## Options
+
+  - `:domains` - Explicit list of Ash domain modules to inspect. When
+    omitted, uses `list_domains/0`.
+
+  ## Examples
+
+      iex> AshGrant.Introspect.list_resources()
+      [MyApp.Blog.Post, MyApp.Blog.Comment, ...]
+
+      iex> AshGrant.Introspect.list_resources(domains: [MyApp.Blog])
+      [MyApp.Blog.Post, MyApp.Blog.Comment]
+
+  """
+  @spec list_resources(keyword()) :: [module()]
+  def list_resources(opts \\ []) do
+    domains = Keyword.get_lazy(opts, :domains, &list_domains/0)
+
+    for domain <- domains,
+        resource <- Ash.Domain.Info.resources(domain),
+        uses_ash_grant?(resource),
+        uniq: true,
+        do: resource
+  end
+
+  @doc """
+  Resolves a resource key string to its module, if any registered resource
+  declares that name.
+
+  Matching is case-sensitive and uses `AshGrant.Info.resource_name/1`
+  (either the explicit `resource_name "..."` DSL value or the auto-derived
+  default). This enables external tools to accept resource names as strings
+  without knowing Elixir module references.
+
+  ## Examples
+
+      iex> AshGrant.Introspect.find_resource_by_key("blog")
+      {:ok, MyApp.Blog.Post}
+
+      iex> AshGrant.Introspect.find_resource_by_key("unknown")
+      :error
+
+  """
+  @spec find_resource_by_key(String.t()) :: {:ok, module()} | :error
+  def find_resource_by_key(""), do: :error
+
+  def find_resource_by_key(key) when is_binary(key) do
+    list_resources()
+    |> Enum.find(fn resource -> Info.resource_name(resource) == key end)
+    |> case do
+      nil -> :error
+      resource -> {:ok, resource}
+    end
+  end
+
+  @doc """
   Returns all permissions for a resource with their status for a given actor.
 
   Useful for Admin UI to display what a user can or cannot do.
@@ -379,6 +463,12 @@ defmodule AshGrant.Introspect do
   end
 
   # Private functions
+
+  defp uses_ash_grant?(resource) do
+    AshGrant in Spark.extensions(resource)
+  rescue
+    _ -> false
+  end
 
   defp get_resource_actions(resource) do
     Ash.Resource.Info.actions(resource)

--- a/test/ash_grant/introspect_registry_test.exs
+++ b/test/ash_grant/introspect_registry_test.exs
@@ -1,0 +1,91 @@
+defmodule AshGrant.IntrospectRegistryTest do
+  @moduledoc """
+  Tests for Introspect resource registry: domain/resource discovery and
+  key-based lookup.
+
+  These functions are the foundation for external consumers
+  (`ash_grant_phoenix`, `ash_grant_ai`) that need to enumerate resources
+  or resolve a string key to a resource module without the caller knowing
+  the module reference up-front.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.Introspect
+
+  describe "list_domains/0" do
+    test "returns domains configured via :ash_domains in started applications" do
+      domains = Introspect.list_domains()
+
+      # Test environment sets `config :ash_grant, ash_domains: [AshGrant.Test.Domain]`
+      assert AshGrant.Test.Domain in domains
+    end
+
+    test "returns a unique list" do
+      domains = Introspect.list_domains()
+      assert domains == Enum.uniq(domains)
+    end
+  end
+
+  describe "list_resources/1" do
+    test "returns resources from auto-discovered domains" do
+      resources = Introspect.list_resources()
+
+      # Sampling of resources registered under AshGrant.Test.Domain
+      assert AshGrant.Test.Post in resources
+      assert AshGrant.Test.Employee in resources
+      assert AshGrant.Test.SharedDoc in resources
+    end
+
+    test "every returned resource uses the AshGrant extension" do
+      resources = Introspect.list_resources()
+
+      Enum.each(resources, fn resource ->
+        assert AshGrant in Spark.extensions(resource),
+               "expected #{inspect(resource)} to use AshGrant extension"
+      end)
+    end
+
+    test "accepts an explicit :domains option to restrict scope" do
+      resources = Introspect.list_resources(domains: [AshGrant.Test.GrantDomain])
+
+      # GrantDomain holds the Domain* resources and nothing else
+      assert AshGrant.Test.DomainInheritedPost in resources
+      refute AshGrant.Test.Post in resources
+    end
+
+    test "returns an empty list when no matching domains are given" do
+      assert [] == Introspect.list_resources(domains: [])
+    end
+
+    test "returns a unique list" do
+      resources = Introspect.list_resources()
+      assert resources == Enum.uniq(resources)
+    end
+  end
+
+  describe "find_resource_by_key/1" do
+    test "resolves an explicit resource_name to its module" do
+      # AshGrant.Test.Employee declares `resource_name("employee")`
+      assert {:ok, AshGrant.Test.Employee} =
+               Introspect.find_resource_by_key("employee")
+    end
+
+    test "resolves an auto-derived resource_name to its module" do
+      # AshGrant.Test.Post has no explicit resource_name; derived as "post"
+      assert {:ok, AshGrant.Test.Post} = Introspect.find_resource_by_key("post")
+    end
+
+    test "returns :error when no resource matches the key" do
+      assert :error = Introspect.find_resource_by_key("definitely_not_a_resource")
+    end
+
+    test "returns :error for an empty string" do
+      assert :error = Introspect.find_resource_by_key("")
+    end
+
+    test "matches are case-sensitive" do
+      # "Employee" (capitalized) should not match "employee"
+      assert :error = Introspect.find_resource_by_key("Employee")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Foundation PR (1/7) for a Public Introspection API that will be shared by three downstream consumers: IEx debugging, a future `ash_grant_phoenix` LiveView dashboard, and a future `ash_grant_ai` package exposing these as Ash AI tools.

Adds three helpers to `AshGrant.Introspect`:

- **`list_domains/0`** — auto-discovers Ash domains from the standard `:ash_domains` config across all started applications. **No AshGrant-specific configuration key is introduced** — reuses the Ash convention so users don't have to register domains twice.
- **`list_resources/1`** — returns every resource using the `AshGrant` extension, with an optional `:domains` override for scoped lookups.
- **`find_resource_by_key/1`** — resolves a `resource_name` string (explicit or auto-derived) back to its module. Case-sensitive.

Together these let external tools accept resource names as strings and enumerate AshGrant-enabled resources without the caller knowing Elixir module references up-front.

## Design notes

- **Zero-config discovery** — considered adding `config :ash_grant, :domains` but rejected. AshGrant is a DSL extension that activates per-resource; requiring a parallel domain registry would duplicate the Ash convention that users already maintain (`config :my_app, ash_domains: [...]`).
- **Filtering via `Spark.extensions/1`** — a resource is included iff `AshGrant in Spark.extensions(resource)`. Guarded with `rescue` so non-Spark modules in a domain don't crash enumeration.
- **Test-first (TDD)** — 12 tests written before implementation, covering auto-discovery, `:domains` override, empty-list edge cases, uniqueness, AshGrant-only filtering, explicit/derived resource_name matching, unknown-key handling, and case-sensitivity.

## Test plan

- [x] `mix test test/ash_grant/introspect_registry_test.exs` — 12/12 pass
- [x] `mix test` — full suite 983/983 pass
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo` — clean (pre-existing warning unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)