### PR TITLE
feat: add Jason encoders and Ash.Expr stringifier for JSON surface

### DIFF
--- a/lib/ash_grant/explanation.ex
+++ b/lib/ash_grant/explanation.ex
@@ -340,3 +340,43 @@ defmodule AshGrant.Explanation do
     |> IO.iodata_to_binary()
   end
 end
+
+defimpl Jason.Encoder, for: AshGrant.Explanation do
+  # The JSON surface is consumed by external tooling (ash_grant_phoenix,
+  # ash_grant_ai). It must never raise on terms that are valid Elixir but
+  # not valid JSON (module refs, Ash.Expr internals, captured functions in
+  # field_group defs, arbitrary actor structs). We transform to a JSON-safe
+  # map first, then delegate.
+  def encode(explanation, opts) do
+    explanation
+    |> to_json_safe()
+    |> Jason.Encode.map(opts)
+  end
+
+  defp to_json_safe(%AshGrant.Explanation{} = exp) do
+    %{
+      resource: inspect(exp.resource),
+      action: exp.action,
+      actor: inspect(exp.actor),
+      context: exp.context,
+      decision: exp.decision,
+      reason: exp.reason,
+      matching_permissions: exp.matching_permissions,
+      evaluated_permissions: exp.evaluated_permissions,
+      scope_filter_string: AshGrant.ExprStringify.to_string(exp.scope_filter),
+      field_groups: exp.field_groups,
+      field_group_defs: Enum.map(exp.field_group_defs, &field_group_to_map/1),
+      resolve_arguments: exp.resolve_arguments
+    }
+  end
+
+  # AshGrant.Dsl.FieldGroup carries an anonymous `:mask_with` function that
+  # Jason cannot encode. Strip it (and only it) — keep the rest intact.
+  defp field_group_to_map(%{__struct__: _} = fg) do
+    fg
+    |> Map.from_struct()
+    |> Map.delete(:mask_with)
+  end
+
+  defp field_group_to_map(other), do: other
+end

--- a/lib/ash_grant/expr_stringify.ex
+++ b/lib/ash_grant/expr_stringify.ex
@@ -1,0 +1,64 @@
+defmodule AshGrant.ExprStringify do
+  @moduledoc """
+  Converts `Ash.Expr` terms and scope filter values into human-readable,
+  LLM-friendly strings.
+
+  Ash's default `Inspect` for expressions is already quite readable, but it
+  uses internal reference tuples like `{:_actor, :id}` or `:_tenant`.
+  Downstream consumers (the `AshGrant.Explanation` JSON surface, future
+  Phoenix dashboard, and Ash AI tools) need strings that mirror the DSL
+  syntax users write in their resources — `^actor(:id)`, `^tenant()`,
+  `^context(:key)`.
+
+  This module is **read-only and best-effort**: the output is a display
+  string, never parsed back. Unknown terms fall back to `inspect/1` and the
+  function never raises.
+
+  ## Examples
+
+      iex> AshGrant.ExprStringify.to_string(true)
+      "true"
+
+      iex> expr = AshGrant.Info.resolve_scope_filter(MyApp.Post, :own, %{})
+      iex> AshGrant.ExprStringify.to_string(expr)
+      "author_id == ^actor(:id)"
+
+  ## Public API contract
+
+  This module is part of AshGrant's public introspection surface consumed by
+  `ash_grant_phoenix` and `ash_grant_ai`. Breaking changes are tracked in
+  CHANGELOG.
+  """
+
+  @doc """
+  Converts a scope filter value to a human-readable string.
+
+  Accepts:
+  - `true` / `false` / `nil`
+  - `Ash.Expr` terms (any struct inspected via Ash's protocol)
+  - Arbitrary Elixir terms (falls back to `inspect/1`)
+  """
+  @spec to_string(term()) :: String.t()
+  def to_string(true), do: "true"
+  def to_string(false), do: "false"
+  def to_string(nil), do: "nil"
+
+  def to_string(other) do
+    other
+    |> inspect(limit: :infinity, printable_limit: :infinity, structs: true)
+    |> humanize()
+  end
+
+  # Replace internal reference tuples with their DSL-facing form.
+  #
+  # Why regex instead of walking the AST: Ash's own Inspect protocol already
+  # handles nested operators, fragments, and refs readably. We just need to
+  # unwrap the ^actor/^tenant/^context references so the output mirrors the
+  # DSL. If Ash ever changes its inspect format, we tighten this here.
+  defp humanize(str) do
+    str
+    |> String.replace(~r/\{:_actor,\s*:([a-zA-Z_][a-zA-Z0-9_]*)\}/, "^actor(:\\1)")
+    |> String.replace(~r/\{:_context,\s*:([a-zA-Z_][a-zA-Z0-9_]*)\}/, "^context(:\\1)")
+    |> String.replace(":_tenant", "^tenant()")
+  end
+end

--- a/lib/ash_grant/permission.ex
+++ b/lib/ash_grant/permission.ex
@@ -123,6 +123,7 @@ defmodule AshGrant.Permission do
           metadata: map() | nil
         }
 
+  @derive Jason.Encoder
   defstruct [
     :resource,
     :action,

--- a/lib/ash_grant/permission_input.ex
+++ b/lib/ash_grant/permission_input.ex
@@ -70,6 +70,7 @@ defmodule AshGrant.PermissionInput do
           metadata: map() | nil
         }
 
+  @derive Jason.Encoder
   @enforce_keys [:string]
   defstruct [:string, :description, :source, :metadata]
 

--- a/test/ash_grant/expr_stringify_test.exs
+++ b/test/ash_grant/expr_stringify_test.exs
@@ -1,0 +1,63 @@
+defmodule AshGrant.ExprStringifyTest do
+  @moduledoc """
+  Tests for ExprStringify — converting Ash.Expr terms to human/LLM-readable
+  strings.
+
+  These strings are surfaced in JSON output (Explanation.scope_filter_string)
+  and LLM tool responses, so the format must be predictable and use the DSL
+  syntax users wrote, not the internal reference tuples.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.ExprStringify
+
+  describe "to_string/1 — scalars" do
+    test "true → \"true\"" do
+      assert ExprStringify.to_string(true) == "true"
+    end
+
+    test "false → \"false\"" do
+      assert ExprStringify.to_string(false) == "false"
+    end
+
+    test "nil → \"nil\"" do
+      assert ExprStringify.to_string(nil) == "nil"
+    end
+  end
+
+  describe "to_string/1 — reference humanization" do
+    test "humanizes actor references to ^actor(:key)" do
+      expr = AshGrant.Info.resolve_scope_filter(AshGrant.Test.Post, :own, %{})
+      assert ExprStringify.to_string(expr) == "author_id == ^actor(:id)"
+    end
+
+    test "humanizes tenant reference to ^tenant()" do
+      expr =
+        AshGrant.Info.resolve_scope_filter(AshGrant.Test.TenantPost, :same_tenant, %{})
+
+      assert ExprStringify.to_string(expr) == "tenant_id == ^tenant()"
+    end
+
+    test "humanizes context references to ^context(:key)" do
+      ctx = %{reference_date: ~D[2024-01-01]}
+      expr = AshGrant.Info.resolve_scope_filter(AshGrant.Test.Post, :today_injectable, ctx)
+      result = ExprStringify.to_string(expr)
+
+      assert result =~ "^context(:reference_date)"
+      refute result =~ ":_context"
+    end
+  end
+
+  describe "to_string/1 — robustness" do
+    test "always returns a binary" do
+      expr = AshGrant.Info.resolve_scope_filter(AshGrant.Test.Post, :own, %{})
+      assert is_binary(ExprStringify.to_string(expr))
+    end
+
+    test "accepts unknown terms and does not raise" do
+      # Arbitrary term — should fall back to inspect-like output without crashing
+      assert is_binary(ExprStringify.to_string({:some, :tuple, [1, 2, 3]}))
+      assert is_binary(ExprStringify.to_string(%{arbitrary: "map"}))
+    end
+  end
+end

--- a/test/ash_grant/jason_encoder_test.exs
+++ b/test/ash_grant/jason_encoder_test.exs
@@ -1,0 +1,143 @@
+defmodule AshGrant.JasonEncoderTest do
+  @moduledoc """
+  Tests for JSON encoding of AshGrant public structs.
+
+  JSON-safe output is a hard requirement for the planned `ash_grant_ai`
+  package (LLM tool responses) and `ash_grant_phoenix` dashboard (JSON
+  export, API endpoints). Core contract: every public struct must encode
+  to valid JSON without raising, and must not leak module atoms or raw
+  Ash.Expr terms in the output.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.{Permission, PermissionInput}
+
+  describe "Jason.encode!/1 — Permission" do
+    test "encodes a basic RBAC permission" do
+      perm = Permission.parse!("post:*:read:own")
+      json = Jason.encode!(perm)
+      decoded = Jason.decode!(json)
+
+      assert decoded["resource"] == "post"
+      assert decoded["instance_id"] == "*"
+      assert decoded["action"] == "read"
+      assert decoded["scope"] == "own"
+      assert decoded["deny"] == false
+    end
+
+    test "encodes a deny permission" do
+      perm = Permission.parse!("!post:*:delete:always")
+      decoded = perm |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["deny"] == true
+      assert decoded["action"] == "delete"
+    end
+
+    test "encodes a 5-part permission with field_group" do
+      perm = Permission.parse!("employee:*:read:always:sensitive")
+      decoded = perm |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["field_group"] == "sensitive"
+    end
+
+    test "encodes an instance permission" do
+      perm = Permission.parse!("doc:doc_123:update:")
+      decoded = perm |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["instance_id"] == "doc_123"
+      assert decoded["action"] == "update"
+    end
+  end
+
+  describe "Jason.encode!/1 — PermissionInput" do
+    test "encodes with all metadata fields" do
+      input = %PermissionInput{
+        string: "post:*:update:own",
+        description: "Edit own posts",
+        source: "editor_role",
+        metadata: %{granted_at: "2024-01-15"}
+      }
+
+      decoded = input |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["string"] == "post:*:update:own"
+      assert decoded["description"] == "Edit own posts"
+      assert decoded["source"] == "editor_role"
+      assert decoded["metadata"] == %{"granted_at" => "2024-01-15"}
+    end
+
+    test "encodes with nil metadata fields" do
+      input = %PermissionInput{string: "post:*:read:always"}
+      decoded = input |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["string"] == "post:*:read:always"
+      assert decoded["description"] == nil
+      assert decoded["source"] == nil
+      assert decoded["metadata"] == nil
+    end
+  end
+
+  describe "Jason.encode!/1 — Explanation" do
+    setup do
+      # A minimal actor + resource combination that produces a non-trivial
+      # Explanation with a scope_filter we can assert on.
+      actor = %{id: 42, role: :editor}
+      explanation = AshGrant.explain(AshGrant.Test.Post, :update, actor)
+      {:ok, explanation: explanation}
+    end
+
+    test "encodes without raising", %{explanation: explanation} do
+      assert is_binary(Jason.encode!(explanation))
+    end
+
+    test "renders resource as a readable module name", %{explanation: explanation} do
+      decoded = explanation |> Jason.encode!() |> Jason.decode!()
+
+      assert is_binary(decoded["resource"])
+      assert decoded["resource"] =~ "Post"
+      refute decoded["resource"] == "Elixir.AshGrant.Test.Post"
+    end
+
+    test "renders decision and action as strings", %{explanation: explanation} do
+      decoded = explanation |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["decision"] in ["allow", "deny"]
+      assert decoded["action"] == "update"
+    end
+
+    test "stringifies scope_filter into scope_filter_string", %{explanation: explanation} do
+      decoded = explanation |> Jason.encode!() |> Jason.decode!()
+
+      # When the action is allowed by scope `:own`, filter should mention actor
+      if decoded["decision"] == "allow" do
+        assert is_binary(decoded["scope_filter_string"])
+        assert decoded["scope_filter_string"] =~ "^actor(:id)"
+      end
+    end
+
+    test "does not leak raw Ash.Expr structs into JSON", %{explanation: explanation} do
+      json = Jason.encode!(explanation)
+
+      # Raw Ash.Expr internals like :_actor / :_tenant / Ash.Query.* should
+      # never appear in the JSON surface — they're the signal of a leak.
+      refute json =~ ":_actor"
+      refute json =~ ":_tenant"
+      refute json =~ "Ash.Query.Call"
+      refute json =~ "Ash.Query.Ref"
+    end
+
+    test "renders actor as a readable string", %{explanation: explanation} do
+      decoded = explanation |> Jason.encode!() |> Jason.decode!()
+
+      # Actor is user-supplied and may contain arbitrary terms; we render it
+      # as an inspect-style string for debug traceability, not the raw map.
+      assert is_binary(decoded["actor"])
+    end
+
+    test "preserves matching_permissions as list of maps", %{explanation: explanation} do
+      decoded = explanation |> Jason.encode!() |> Jason.decode!()
+
+      assert is_list(decoded["matching_permissions"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Foundation PR (2/7) for the Public Introspection API — makes AshGrant's public structs safely JSON-encodable. Required by the two downstream consumers planned on top of core: `ash_grant_phoenix` (dashboard JSON export, potential REST/GraphQL surfaces) and `ash_grant_ai` (LLM tool responses must be JSON).

## Changes

### New: \`AshGrant.ExprStringify\`
Converts \`Ash.Expr\` terms and scope filter values to human/LLM-readable strings that mirror DSL syntax. Handles actor, tenant, and context references so output looks like what users wrote in their resources:

- \`{:_actor, :id}\` → \`^actor(:id)\`
- \`:_tenant\` → \`^tenant()\`
- \`{:_context, :key}\` → \`^context(:key)\`

Best-effort: falls back to \`inspect/1\` for unknown terms, never raises.

### \`@derive Jason.Encoder\`
- \`AshGrant.Permission\` — already JSON-shaped (strings/atoms/booleans/nil maps)
- \`AshGrant.PermissionInput\` — same

### Custom \`Jason.Encoder\` for \`AshGrant.Explanation\`
The struct holds terms that need transformation before JSON encoding:

- \`resource\` (module atom) → \`inspect/1\` string
- \`actor\` (user-supplied term) → \`inspect/1\` string — debug traceability without leaking struct internals
- \`scope_filter\` (Ash.Expr) → replaced by \`scope_filter_string\` via ExprStringify
- \`field_group_defs\` — strips the captured \`mask_with\` function (not encodable)

## Design notes

- **Why Jason, not native \`JSON\`**: Jason is already pulled in transitively by Ash/Spark (verified: \`jason 1.4.4\` in \`mix.lock\`). Using Elixir 1.18's native \`JSON\` module would force bumping \`~> 1.15\` → \`~> 1.18\` — a breaking change for users. Native migration can happen when Ash itself bumps its floor.
- **Why regex humanization in ExprStringify, not an AST walker**: Ash's own \`Inspect\` protocol already renders expressions readably. We only need to unwrap the internal reference tuples. If Ash's inspect format ever changes, we tighten the regex in one place.
- **Why \`inspect(actor)\` instead of the raw struct**: actors are arbitrary user terms (DB records, structs, nested data) that may not encode cleanly and may contain sensitive fields. An inspect-style string gives debug visibility without silently exposing internals.

## Test plan

- [x] \`mix test test/ash_grant/expr_stringify_test.exs\` — 8/8 pass
- [x] \`mix test test/ash_grant/jason_encoder_test.exs\` — 13/13 pass
- [x] \`mix test\` — full suite 992/992 pass
- [x] \`mix compile --warnings-as-errors\` — clean
- [x] \`mix credo\` — clean (pre-existing warning unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)