### PR TITLE
feat: add summary, reason_code, scope_filter_string to Explanation

### DIFF
--- a/lib/ash_grant/explainer.ex
+++ b/lib/ash_grant/explainer.ex
@@ -55,6 +55,19 @@ defmodule AshGrant.Explainer do
     field_groups = extract_field_groups(matching_allows)
     resolve_arguments = build_resolve_arguments(resource, action)
 
+    reason_code = reason_to_code(decision, reason)
+    scope_filter_string = stringify_scope_filter(scope_filter)
+
+    summary =
+      build_summary(
+        decision,
+        reason_code,
+        matching_allows,
+        evaluated,
+        action,
+        scope_filter_string
+      )
+
     %Explanation{
       resource: resource,
       action: action,
@@ -62,14 +75,51 @@ defmodule AshGrant.Explainer do
       context: context,
       decision: decision,
       reason: reason,
+      reason_code: reason_code,
+      summary: summary,
       matching_permissions: matching_allows,
       evaluated_permissions: evaluated,
       scope_filter: scope_filter,
+      scope_filter_string: scope_filter_string,
       field_groups: field_groups,
       field_group_defs: Info.field_groups(resource),
       resolve_arguments: resolve_arguments
     }
   end
+
+  defp reason_to_code(:allow, _reason), do: :allow_matched
+  defp reason_to_code(:deny, :denied_by_rule), do: :deny_rule_matched
+  defp reason_to_code(:deny, :no_matching_permissions), do: :no_matching_permission
+  defp reason_to_code(_, _), do: nil
+
+  defp stringify_scope_filter(nil), do: nil
+  defp stringify_scope_filter(filter), do: AshGrant.ExprStringify.to_string(filter)
+
+  defp build_summary(:allow, :allow_matched, matching_allows, _evaluated, _action, scope_str) do
+    [first | rest] = matching_allows
+    extra = if rest == [], do: "", else: " (and #{length(rest)} more)"
+    scope_part = allow_scope_phrase(scope_str)
+    "Allowed by '#{first.permission}'#{extra}.#{scope_part}"
+  end
+
+  defp build_summary(:deny, :deny_rule_matched, _matching, evaluated, _action, _scope_str) do
+    case Enum.find(evaluated, fn e -> e.matched && e.is_deny end) do
+      nil -> "Denied by a deny rule."
+      deny -> "Denied by '#{deny.permission}' (deny rule)."
+    end
+  end
+
+  defp build_summary(:deny, :no_matching_permission, _matching, _evaluated, action, _scope_str) do
+    "No matching permission for action #{inspect(action)}."
+  end
+
+  defp build_summary(_decision, _code, _matching, _evaluated, action, _scope_str) do
+    "No decision information available for action #{inspect(action)}."
+  end
+
+  defp allow_scope_phrase(nil), do: ""
+  defp allow_scope_phrase("true"), do: ""
+  defp allow_scope_phrase(str), do: " Scope filters by #{str}."
 
   # Collect resolve_argument declarations active for this action, annotated with
   # the scopes that actually reference the argument. Declarations that no scope

--- a/lib/ash_grant/explanation.ex
+++ b/lib/ash_grant/explanation.ex
@@ -19,6 +19,9 @@ defmodule AshGrant.Explanation do
   - `:field_groups` - List of field group names the actor has access to (from 5-part permissions)
   - `:field_group_defs` - Field group definitions from the resource DSL
   - `:resolve_arguments` - `resolve_argument` declarations active for this action, each annotated with the scope atoms that trigger the resolver at runtime (see `guides/argument-based-scope.md`)
+  - `:summary` - Human-readable one-line summary of the decision, suitable for UIs and LLM responses
+  - `:reason_code` - Structured reason code (`:allow_matched`, `:deny_rule_matched`, `:no_matching_permission`)
+  - `:scope_filter_string` - Stringified form of `:scope_filter` using `AshGrant.ExprStringify` (nil when no filter)
 
   ## Example
 
@@ -72,6 +75,9 @@ defmodule AshGrant.Explanation do
           scopes_needing: [atom()]
         }
 
+  @type reason_code ::
+          :allow_matched | :deny_rule_matched | :no_matching_permission | nil
+
   @type t :: %__MODULE__{
           resource: module(),
           action: atom(),
@@ -79,9 +85,12 @@ defmodule AshGrant.Explanation do
           context: map() | nil,
           decision: :allow | :deny,
           reason: atom() | nil,
+          reason_code: reason_code(),
+          summary: String.t() | nil,
           matching_permissions: [evaluated_permission()],
           evaluated_permissions: [evaluated_permission()],
           scope_filter: term() | nil,
+          scope_filter_string: String.t() | nil,
           field_groups: [String.t()],
           field_group_defs: [AshGrant.Dsl.FieldGroup.t()],
           resolve_arguments: [resolve_argument_entry()]
@@ -94,7 +103,10 @@ defmodule AshGrant.Explanation do
     :context,
     :decision,
     :reason,
+    :reason_code,
+    :summary,
     :scope_filter,
+    :scope_filter_string,
     matching_permissions: [],
     evaluated_permissions: [],
     field_groups: [],
@@ -361,9 +373,11 @@ defimpl Jason.Encoder, for: AshGrant.Explanation do
       context: exp.context,
       decision: exp.decision,
       reason: exp.reason,
+      reason_code: exp.reason_code,
+      summary: exp.summary,
       matching_permissions: exp.matching_permissions,
       evaluated_permissions: exp.evaluated_permissions,
-      scope_filter_string: AshGrant.ExprStringify.to_string(exp.scope_filter),
+      scope_filter_string: exp.scope_filter_string,
       field_groups: exp.field_groups,
       field_group_defs: Enum.map(exp.field_group_defs, &field_group_to_map/1),
       resolve_arguments: exp.resolve_arguments

--- a/test/ash_grant/explanation_summary_test.exs
+++ b/test/ash_grant/explanation_summary_test.exs
@@ -1,0 +1,128 @@
+defmodule AshGrant.ExplanationSummaryTest do
+  @moduledoc """
+  Tests for Explanation's human/LLM-readable fields: `summary`,
+  `reason_code`, and `scope_filter_string`.
+
+  These fields are the first thing downstream consumers (Phoenix
+  dashboard, AI agents) read. They must be:
+  - always populated (no nil summary for a valid evaluation)
+  - structured enough to branch on programmatically (`reason_code`)
+  - readable enough to show verbatim in a UI or LLM response (`summary`)
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.Test.Post
+
+  describe "reason_code" do
+    test "is :allow_matched when an allow permission grants access" do
+      actor = %{id: "user_1", permissions: ["post:*:read:always"]}
+      %{reason_code: code} = AshGrant.explain(Post, :read, actor)
+      assert code == :allow_matched
+    end
+
+    test "is :deny_rule_matched when a deny permission wins" do
+      actor = %{
+        id: "user_1",
+        permissions: ["post:*:*:always", "!post:*:destroy:always"]
+      }
+
+      %{reason_code: code} = AshGrant.explain(Post, :destroy, actor)
+      assert code == :deny_rule_matched
+    end
+
+    test "is :no_matching_permission when no rule matches" do
+      actor = %{id: "user_1", permissions: []}
+      %{reason_code: code} = AshGrant.explain(Post, :read, actor)
+      assert code == :no_matching_permission
+    end
+
+    test "is :no_matching_permission when actor is nil" do
+      %{reason_code: code} = AshGrant.explain(Post, :read, nil)
+      assert code == :no_matching_permission
+    end
+  end
+
+  describe "summary" do
+    test "for allow, mentions the matched permission string" do
+      actor = %{id: "user_1", permissions: ["post:*:read:always"]}
+      %{summary: summary} = AshGrant.explain(Post, :read, actor)
+
+      assert is_binary(summary)
+      assert summary =~ "post:*:read:always"
+      assert summary =~ ~r/allow/i
+    end
+
+    test "for deny by rule, mentions the deny permission" do
+      actor = %{
+        id: "user_1",
+        permissions: ["post:*:*:always", "!post:*:destroy:always"]
+      }
+
+      %{summary: summary} = AshGrant.explain(Post, :destroy, actor)
+
+      assert is_binary(summary)
+      assert summary =~ "!post:*:destroy:always"
+      assert summary =~ ~r/den(y|ied)/i
+    end
+
+    test "for no match, states that no permission matched" do
+      actor = %{id: "user_1", permissions: []}
+      %{summary: summary} = AshGrant.explain(Post, :read, actor)
+
+      assert is_binary(summary)
+      assert summary =~ ~r/no.*match|no.*permission/i
+    end
+
+    test "is always a non-empty string" do
+      cases = [
+        {nil, :read},
+        {%{id: "user_1", permissions: []}, :read},
+        {%{id: "user_1", permissions: ["post:*:read:always"]}, :read},
+        {%{id: "user_1", permissions: ["post:*:*:always", "!post:*:destroy:always"]}, :destroy}
+      ]
+
+      for {actor, action} <- cases do
+        %{summary: summary} = AshGrant.explain(Post, action, actor)
+        assert is_binary(summary) and byte_size(summary) > 0
+      end
+    end
+  end
+
+  describe "scope_filter_string" do
+    test "is populated when allow applies a scope" do
+      actor = %{id: "user_1", permissions: ["post:*:update:own"]}
+      %{scope_filter_string: str} = AshGrant.explain(Post, :update, actor)
+
+      assert is_binary(str)
+      assert str =~ "^actor(:id)"
+      refute str =~ ":_actor"
+    end
+
+    test "mirrors ExprStringify output of scope_filter" do
+      actor = %{id: "user_1", permissions: ["post:*:update:own"]}
+      exp = AshGrant.explain(Post, :update, actor)
+
+      assert exp.scope_filter_string == AshGrant.ExprStringify.to_string(exp.scope_filter)
+    end
+
+    test "is nil when decision is deny" do
+      %{scope_filter_string: str} = AshGrant.explain(Post, :read, nil)
+      assert str == nil
+    end
+  end
+
+  describe "Jason encoding integration" do
+    test "JSON output includes summary and reason_code as strings" do
+      actor = %{id: "user_1", permissions: ["post:*:read:always"]}
+
+      decoded =
+        Post
+        |> AshGrant.explain(:read, actor)
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      assert is_binary(decoded["summary"])
+      assert decoded["reason_code"] == "allow_matched"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Foundation PR (3/7) for the Public Introspection API. Adds the three fields that LLM agents and UI dashboards read first when answering \"can X do Y?\":

- **\`summary\`** — one-line, human-readable description of the decision
- **\`reason_code\`** — structured atom for programmatic branching
- **\`scope_filter_string\`** — ExprStringify form of the scope filter

> **Based on:** #105 — this PR is stacked on \`feat/json-encoders-and-expr-stringify\` because it extends the JSON encoder added there. Merge #105 first.

## Summary format

| reason_code | Example \`summary\` |
|---|---|
| \`:allow_matched\` | \"Allowed by 'post:*:read:own'. Scope filters by author_id == ^actor(:id).\" |
| \`:deny_rule_matched\` | \"Denied by '!post:*:destroy:always' (deny rule).\" |
| \`:no_matching_permission\` | \"No matching permission for action :read.\" |

The pattern is fixed and predictable, so agents can parse it structurally (\"Allowed by 'X'\", \"Denied by 'X'\") while humans can read it directly.

## Design notes

- **Why \`reason_code\` alongside existing \`reason\`**: The existing \`reason\` field is \`nil\` for allow cases and uses pluralized atoms like \`:no_matching_permissions\`. To avoid a breaking change, \`reason_code\` is added as a parallel field with a narrower, always-present enum. External consumers should prefer \`reason_code\`.
- **Why \`scope_filter_string\` on the struct, not computed in the encoder**: Keeps IEx inspection and JSON output consistent, and avoids recomputation. The Jason encoder (from #105) now just passes it through.
- **Why a formatted sentence summary instead of a template string**: LLM agents benefit from complete sentences they can paraphrase or quote verbatim. \`reason_code\` is there for when they need to branch without reading prose.

## Test plan

- [x] \`mix test test/ash_grant/explanation_summary_test.exs\` — 12/12 pass
- [x] \`mix test\` — full suite 1004/1004 pass
- [x] \`mix compile --warnings-as-errors\` — clean
- [x] \`mix format --check-formatted\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)