### PR TITLE
feat: identifier-based introspection entry points

### DIFF
--- a/lib/ash_grant/behaviours/permission_resolver.ex
+++ b/lib/ash_grant/behaviours/permission_resolver.ex
@@ -152,4 +152,43 @@ defmodule AshGrant.PermissionResolver do
 
   """
   @callback resolve(actor(), context()) :: [permission()]
+
+  @doc """
+  Optional. Loads an actor given an identifier (e.g., primary key).
+
+  This callback powers identifier-based introspection entry points such as
+  `AshGrant.Introspect.explain_by_identifier/1` and
+  `AshGrant.Introspect.can_by_identifier/3`, where the caller (an admin
+  dashboard, LLM tool, `mix ash_grant.explain` task, etc.) only knows the
+  actor's ID — not the fully-hydrated struct.
+
+  Implementations should fetch the actor from the underlying data store
+  and return it in the same shape that `resolve/2` expects.
+
+  ## Return values
+
+  - `{:ok, actor}` - the loaded actor
+  - `:error` - when no actor exists for the given identifier
+
+  ## Example
+
+      defmodule MyApp.PermissionResolver do
+        @behaviour AshGrant.PermissionResolver
+
+        @impl true
+        def resolve(actor, _context), do: actor.permissions
+
+        @impl true
+        def load_actor(id) do
+          case MyApp.Accounts.get_user(id) do
+            nil -> :error
+            user -> {:ok, user}
+          end
+        end
+      end
+
+  """
+  @callback load_actor(id :: term()) :: {:ok, actor()} | :error
+
+  @optional_callbacks load_actor: 1
 end

--- a/lib/ash_grant/introspect.ex
+++ b/lib/ash_grant/introspect.ex
@@ -143,6 +143,144 @@ defmodule AshGrant.Introspect do
   end
 
   @doc """
+  Explains an access decision using string/ID inputs.
+
+  Resolves `resource_key` to a resource module via `find_resource_by_key/1`,
+  then loads the actor by calling `load_actor/1` on the resource's
+  permission resolver module, and finally delegates to
+  `AshGrant.explain/4`.
+
+  This is the primary entry point for external tools (admin dashboards,
+  LLM agents, `mix ash_grant.explain`) that only know string identifiers.
+
+  ## Options (keyword list)
+
+  - `:actor_id` - Required. Identifier to pass to `resolver.load_actor/1`.
+  - `:resource_key` - Required. Resource name (matches `AshGrant.Info.resource_name/1`).
+  - `:action` - Required. Action name as an atom.
+  - `:context` - Optional. Additional context map passed to the resolver.
+
+  ## Returns
+
+  - `{:ok, AshGrant.Explanation.t()}`
+  - `{:error, :unknown_resource}` - no resource matched `resource_key`
+  - `{:error, :actor_loader_not_implemented}` - resolver cannot load actors
+    by ID (either it's an anonymous function or the module doesn't export
+    the optional `load_actor/1` callback)
+  - `{:error, :actor_not_found}` - resolver's `load_actor/1` returned `:error`
+
+  ## Examples
+
+      iex> AshGrant.Introspect.explain_by_identifier(
+      ...>   actor_id: "user_1",
+      ...>   resource_key: "post",
+      ...>   action: :read
+      ...> )
+      {:ok, %AshGrant.Explanation{decision: :allow, ...}}
+
+  """
+  @spec explain_by_identifier(keyword()) ::
+          {:ok, AshGrant.Explanation.t()}
+          | {:error, :unknown_resource | :actor_loader_not_implemented | :actor_not_found}
+  def explain_by_identifier(opts) when is_list(opts) do
+    actor_id = Keyword.fetch!(opts, :actor_id)
+    resource_key = Keyword.fetch!(opts, :resource_key)
+    action = Keyword.fetch!(opts, :action)
+    context = Keyword.get(opts, :context, %{})
+
+    with {:ok, resource} <- resolve_resource(resource_key),
+         {:ok, actor} <- load_actor_for(resource, actor_id) do
+      {:ok, AshGrant.explain(resource, action, actor, context)}
+    end
+  end
+
+  @doc """
+  Identifier-based variant of `can?/4`.
+
+  Same resolution flow as `explain_by_identifier/1` (resource key →
+  module, actor id → actor), then delegates to `can?/4`.
+
+  ## Options
+
+  - `:context` - Optional. Additional context map passed to the resolver.
+
+  ## Returns
+
+  - `{:allow, map()}` / `{:deny, map()}` - same shape as `can?/4`
+  - `{:error, :unknown_resource | :actor_loader_not_implemented | :actor_not_found}`
+
+  ## Examples
+
+      iex> AshGrant.Introspect.can_by_identifier("user_1", "post", :read)
+      {:allow, %{scope: "always", instance_ids: nil, field_groups: []}}
+
+  """
+  @spec can_by_identifier(term(), String.t(), atom(), keyword()) ::
+          {:allow, map()}
+          | {:deny, map()}
+          | {:error, :unknown_resource | :actor_loader_not_implemented | :actor_not_found}
+  def can_by_identifier(actor_id, resource_key, action, opts \\ []) do
+    with {:ok, resource} <- resolve_resource(resource_key),
+         {:ok, actor} <- load_actor_for(resource, actor_id) do
+      can?(resource, action, actor, opts)
+    end
+  end
+
+  @doc """
+  Identifier-based variant of `actor_permissions/3`.
+
+  ## Options
+
+  - `:context` - Optional. Additional context map passed to the resolver.
+
+  ## Returns
+
+  - `{:ok, [permission_status()]}`
+  - `{:error, :unknown_resource | :actor_loader_not_implemented | :actor_not_found}`
+
+  ## Examples
+
+      iex> AshGrant.Introspect.actor_permissions_by_id("user_1", "post")
+      {:ok, [%{action: "read", allowed: true, ...}, ...]}
+
+  """
+  @spec actor_permissions_by_id(term(), String.t(), keyword()) ::
+          {:ok, [permission_status()]}
+          | {:error, :unknown_resource | :actor_loader_not_implemented | :actor_not_found}
+  def actor_permissions_by_id(actor_id, resource_key, opts \\ []) do
+    with {:ok, resource} <- resolve_resource(resource_key),
+         {:ok, actor} <- load_actor_for(resource, actor_id) do
+      {:ok, actor_permissions(resource, actor, opts)}
+    end
+  end
+
+  defp resolve_resource(resource_key) do
+    case find_resource_by_key(resource_key) do
+      {:ok, resource} -> {:ok, resource}
+      :error -> {:error, :unknown_resource}
+    end
+  end
+
+  defp load_actor_for(resource, actor_id) do
+    case Info.resolver(resource) do
+      resolver when is_atom(resolver) and not is_nil(resolver) ->
+        Code.ensure_loaded(resolver)
+
+        if function_exported?(resolver, :load_actor, 1) do
+          case resolver.load_actor(actor_id) do
+            {:ok, actor} -> {:ok, actor}
+            :error -> {:error, :actor_not_found}
+          end
+        else
+          {:error, :actor_loader_not_implemented}
+        end
+
+      _ ->
+        {:error, :actor_loader_not_implemented}
+    end
+  end
+
+  @doc """
   Returns all permissions for a resource with their status for a given actor.
 
   Useful for Admin UI to display what a user can or cannot do.

--- a/test/ash_grant/introspect_by_identifier_test.exs
+++ b/test/ash_grant/introspect_by_identifier_test.exs
@@ -1,0 +1,164 @@
+defmodule AshGrant.IntrospectByIdentifierTest do
+  @moduledoc """
+  Tests for identifier-based introspection entry points.
+
+  These functions let external consumers (admin dashboards, LLM tools,
+  `mix ash_grant.explain` task) drive AshGrant using only string/ID
+  inputs — no module references, no fully-hydrated actor structs. The
+  core flow is:
+
+      resource_key (string) → resource module (via find_resource_by_key)
+      actor_id (term)       → actor struct (via resolver.load_actor/1)
+      then delegate to explain/3, can?/4, actor_permissions/3.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.{Explanation, Introspect}
+
+  describe "explain_by_identifier/1" do
+    test "returns {:ok, Explanation} when resolver loads the actor and allows action" do
+      assert {:ok, %Explanation{} = exp} =
+               Introspect.explain_by_identifier(
+                 actor_id: "user_1",
+                 resource_key: "id_loadable_post",
+                 action: :read
+               )
+
+      assert exp.decision == :allow
+      assert exp.action == :read
+      # Actor was hydrated from the resolver — not a raw ID
+      assert is_map(exp.actor)
+      assert exp.actor.id == "user_1"
+    end
+
+    test "returns {:ok, Explanation} with scope_filter when scope applies" do
+      assert {:ok, exp} =
+               Introspect.explain_by_identifier(
+                 actor_id: "user_2",
+                 resource_key: "id_loadable_post",
+                 action: :update
+               )
+
+      assert exp.decision == :allow
+      assert is_binary(exp.scope_filter_string)
+      assert exp.scope_filter_string =~ "^actor(:id)"
+    end
+
+    test "accepts an optional :context keyword" do
+      assert {:ok, exp} =
+               Introspect.explain_by_identifier(
+                 actor_id: "user_1",
+                 resource_key: "id_loadable_post",
+                 action: :read,
+                 context: %{source: "admin_ui"}
+               )
+
+      assert exp.decision == :allow
+    end
+
+    test "returns {:error, :unknown_resource} when resource_key has no match" do
+      assert {:error, :unknown_resource} =
+               Introspect.explain_by_identifier(
+                 actor_id: "user_1",
+                 resource_key: "definitely_not_a_resource",
+                 action: :read
+               )
+    end
+
+    test "returns {:error, :actor_not_found} when load_actor/1 returns :error" do
+      assert {:error, :actor_not_found} =
+               Introspect.explain_by_identifier(
+                 actor_id: "missing_user",
+                 resource_key: "id_loadable_post",
+                 action: :read
+               )
+    end
+
+    test "returns {:error, :actor_loader_not_implemented} when resolver module lacks load_actor/1" do
+      assert {:error, :actor_loader_not_implemented} =
+               Introspect.explain_by_identifier(
+                 actor_id: "user_1",
+                 resource_key: "no_load_actor_post",
+                 action: :read
+               )
+    end
+
+    test "returns {:error, :actor_loader_not_implemented} when resolver is an anonymous function" do
+      # AshGrant.Test.Post uses an inline fn resolver, which cannot define
+      # a load_actor/1 callback.
+      assert {:error, :actor_loader_not_implemented} =
+               Introspect.explain_by_identifier(
+                 actor_id: "user_1",
+                 resource_key: "post",
+                 action: :read
+               )
+    end
+  end
+
+  describe "can_by_identifier/3" do
+    test "returns {:allow, details} when actor is loaded and action is allowed" do
+      assert {:allow, details} =
+               Introspect.can_by_identifier("user_1", "id_loadable_post", :read)
+
+      assert details.scope == "always"
+    end
+
+    test "returns {:deny, %{reason: :no_permission}} when actor has no matching permission" do
+      # user_1 has only "post:*:read:always" — update is not granted
+      assert {:deny, %{reason: :no_permission}} =
+               Introspect.can_by_identifier("user_1", "id_loadable_post", :update)
+    end
+
+    test "returns {:error, :unknown_resource} for an unknown resource key" do
+      assert {:error, :unknown_resource} =
+               Introspect.can_by_identifier("user_1", "definitely_not_a_resource", :read)
+    end
+
+    test "returns {:error, :actor_not_found} when actor id does not resolve" do
+      assert {:error, :actor_not_found} =
+               Introspect.can_by_identifier("missing_user", "id_loadable_post", :read)
+    end
+
+    test "returns {:error, :actor_loader_not_implemented} when resolver can't load actors" do
+      assert {:error, :actor_loader_not_implemented} =
+               Introspect.can_by_identifier("user_1", "no_load_actor_post", :read)
+    end
+
+    test "accepts a keyword context option" do
+      assert {:allow, _details} =
+               Introspect.can_by_identifier("user_1", "id_loadable_post", :read,
+                 context: %{source: "admin_ui"}
+               )
+    end
+  end
+
+  describe "actor_permissions_by_id/2" do
+    test "returns {:ok, statuses} listing each action with allow/deny" do
+      assert {:ok, statuses} =
+               Introspect.actor_permissions_by_id("user_1", "id_loadable_post")
+
+      assert is_list(statuses)
+      assert Enum.all?(statuses, &is_map/1)
+      assert Enum.all?(statuses, &Map.has_key?(&1, :action))
+      assert Enum.all?(statuses, &Map.has_key?(&1, :allowed))
+
+      read_status = Enum.find(statuses, &(&1.action == "read"))
+      assert read_status.allowed == true
+    end
+
+    test "returns {:error, :unknown_resource} for an unknown resource_key" do
+      assert {:error, :unknown_resource} =
+               Introspect.actor_permissions_by_id("user_1", "definitely_not_a_resource")
+    end
+
+    test "returns {:error, :actor_not_found} when the actor id does not resolve" do
+      assert {:error, :actor_not_found} =
+               Introspect.actor_permissions_by_id("missing_user", "id_loadable_post")
+    end
+
+    test "returns {:error, :actor_loader_not_implemented} when resolver can't load actors" do
+      assert {:error, :actor_loader_not_implemented} =
+               Introspect.actor_permissions_by_id("user_1", "no_load_actor_post")
+    end
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -67,5 +67,10 @@ defmodule AshGrant.Test.Domain do
 
     # Generic action test resource (action_input tenant extraction)
     resource(AshGrant.Test.ServiceRequest)
+
+    # Identifier-based introspection test resources (module resolver with
+    # and without the optional `load_actor/1` callback)
+    resource(AshGrant.Test.IdLoadablePost)
+    resource(AshGrant.Test.NoLoadActorPost)
   end
 end

--- a/test/support/resolvers/id_loadable_resolver.ex
+++ b/test/support/resolvers/id_loadable_resolver.ex
@@ -1,0 +1,48 @@
+defmodule AshGrant.Test.IdLoadableResolver do
+  @moduledoc false
+  @behaviour AshGrant.PermissionResolver
+
+  @users %{
+    "user_1" => %{
+      id: "user_1",
+      role: :editor,
+      permissions: ["id_loadable_post:*:read:always"]
+    },
+    "user_2" => %{
+      id: "user_2",
+      role: :editor,
+      permissions: ["id_loadable_post:*:update:own", "id_loadable_post:*:read:always"]
+    }
+  }
+
+  @impl true
+  def resolve(actor, _context) do
+    case actor do
+      nil -> []
+      %{permissions: perms} -> perms
+      _ -> []
+    end
+  end
+
+  @impl true
+  def load_actor(id) do
+    case Map.fetch(@users, id) do
+      {:ok, actor} -> {:ok, actor}
+      :error -> :error
+    end
+  end
+end
+
+defmodule AshGrant.Test.NoLoadActorResolver do
+  @moduledoc false
+  @behaviour AshGrant.PermissionResolver
+
+  @impl true
+  def resolve(actor, _context) do
+    case actor do
+      nil -> []
+      %{permissions: perms} -> perms
+      _ -> []
+    end
+  end
+end

--- a/test/support/resources/id_loadable_post.ex
+++ b/test/support/resources/id_loadable_post.ex
@@ -1,0 +1,84 @@
+defmodule AshGrant.Test.IdLoadablePost do
+  @moduledoc """
+  Test resource whose permission resolver is a module (not an anonymous
+  function) and implements the optional `load_actor/1` callback.
+
+  Used to exercise `AshGrant.Introspect.explain_by_identifier/1` and
+  related identifier-based entry points.
+  """
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    resolver(AshGrant.Test.IdLoadableResolver)
+    resource_name("id_loadable_post")
+
+    scope(:always, true)
+    scope(:own, expr(author_id == ^actor(:id)))
+  end
+
+  policies do
+    policy action_type(:read) do
+      authorize_if(AshGrant.filter_check())
+    end
+
+    policy action_type([:create, :update, :destroy]) do
+      authorize_if(AshGrant.check())
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+    attribute(:author_id, :string, public?: true)
+  end
+
+  actions do
+    defaults([:read, :destroy, :create, :update])
+  end
+end
+
+defmodule AshGrant.Test.NoLoadActorPost do
+  @moduledoc """
+  Test resource whose permission resolver is a module but does NOT
+  implement the optional `load_actor/1` callback.
+
+  Used to verify identifier-based introspection returns
+  `{:error, :actor_loader_not_implemented}` when the resolver can't load
+  actors by ID.
+  """
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    resolver(AshGrant.Test.NoLoadActorResolver)
+    resource_name("no_load_actor_post")
+
+    scope(:always, true)
+  end
+
+  policies do
+    policy action_type(:read) do
+      authorize_if(AshGrant.filter_check())
+    end
+
+    policy action_type([:create, :update, :destroy]) do
+      authorize_if(AshGrant.check())
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true, allow_nil?: false)
+  end
+
+  actions do
+    defaults([:read, :destroy, :create, :update])
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Introspect.explain_by_identifier/1`, `can_by_identifier/3`, and `actor_permissions_by_id/2` — string/ID-driven entry points for admin dashboards, LLM agents, and `mix ash_grant.explain`.
- Add optional `load_actor/1` callback to `AshGrant.PermissionResolver` to let resolvers hydrate an actor from an ID.
- Structured error returns (`:unknown_resource`, `:actor_loader_not_implemented`, `:actor_not_found`) let consumers branch without catching exceptions.

## Context
Part of the Public Introspection API rollout (PR4 of 7). Consumers share one core: IEx debugging, `ash_grant_phoenix` dashboard, `ash_grant_ai` tool surface.

The `load_actor/1` callback is optional — existing resolvers (including anonymous-function resolvers) continue to work; they simply can't drive the identifier-based entry points.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (1033 tests, 0 failures; 17 new tests in `introspect_by_identifier_test.exs`)
- [x] `mix credo` (no new findings)
- [x] `mix format --check-formatted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)