### PR TITLE
feat: mix ash_grant.explain task

### DIFF
--- a/lib/mix/tasks/ash_grant.explain.ex
+++ b/lib/mix/tasks/ash_grant.explain.ex
@@ -1,0 +1,199 @@
+defmodule Mix.Tasks.AshGrant.Explain do
+  @moduledoc """
+  Explains an AshGrant access decision from the command line.
+
+  Uses `AshGrant.Introspect.explain_by_identifier/1` under the hood, so
+  the resource's permission resolver must implement the optional
+  `load_actor/1` callback. If it doesn't, you'll see
+  `actor_loader_not_implemented`.
+
+  ## Usage
+
+      mix ash_grant.explain --actor USER_ID --resource RESOURCE_KEY --action ACTION [options]
+
+  ## Options
+
+    * `--actor`    - Required. Actor identifier (passed to `load_actor/1`).
+    * `--resource` - Required. Resource key (matches `resource_name`).
+    * `--action`   - Required. Action name (atom).
+    * `--format`   - `text` (default) or `json`.
+    * `--context`  - Optional JSON object forwarded to the resolver.
+
+  ## Examples
+
+      # Human-readable
+      mix ash_grant.explain --actor user_123 --resource post --action read
+
+      # Machine-readable for CI/LLM pipelines
+      mix ash_grant.explain --actor user_123 --resource post --action read --format json
+
+      # With context
+      mix ash_grant.explain --actor user_123 --resource post --action read \\
+        --context '{"reference_date":"2024-01-01"}'
+
+  ## Exit codes
+
+    * 0 - Explanation produced (regardless of allow/deny).
+    * 1 - Lookup failure (unknown resource, actor not found, missing loader).
+    * 2 - Usage error (missing required option, invalid value).
+  """
+
+  use Mix.Task
+
+  @shortdoc "Explain an AshGrant access decision for an actor/resource/action"
+
+  @switches [
+    actor: :string,
+    resource: :string,
+    action: :string,
+    format: :string,
+    context: :string
+  ]
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    case run_cli(args) do
+      {:ok, output, 0} ->
+        Mix.shell().info(output)
+
+      {:error, output, exit_code} ->
+        Mix.shell().error(output)
+        System.at_exit(fn _ -> exit({:shutdown, exit_code}) end)
+    end
+  end
+
+  @doc """
+  Pure entry point used by both `run/1` and the test suite.
+
+  Returns `{:ok | :error, output_string, exit_code}` so callers can
+  inspect the task's behaviour without intercepting Mix shell output.
+  """
+  @spec run_cli([String.t()]) ::
+          {:ok, String.t(), 0} | {:error, String.t(), 1 | 2}
+  def run_cli(args) do
+    with {:ok, opts} <- parse_args(args),
+         {:ok, call_opts} <- build_call_opts(opts),
+         {:ok, format} <- parse_format(opts) do
+      call_and_format(call_opts, format)
+    end
+  end
+
+  defp parse_args(args) do
+    {opts, _rest, invalid} = OptionParser.parse(args, strict: @switches)
+
+    if invalid == [] do
+      {:ok, opts}
+    else
+      names = Enum.map_join(invalid, ", ", fn {name, _} -> name end)
+      {:error, "Invalid options: #{names}", 2}
+    end
+  end
+
+  defp build_call_opts(opts) do
+    with {:ok, actor_id} <- fetch_required(opts, :actor),
+         {:ok, resource_key} <- fetch_required(opts, :resource),
+         {:ok, action_str} <- fetch_required(opts, :action),
+         {:ok, context} <- parse_context(opts) do
+      action = String.to_atom(action_str)
+
+      {:ok,
+       [
+         actor_id: actor_id,
+         resource_key: resource_key,
+         action: action,
+         context: context
+       ]}
+    end
+  end
+
+  defp fetch_required(opts, key) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} when value != "" -> {:ok, value}
+      _ -> {:error, "Missing required option: --#{key}", 2}
+    end
+  end
+
+  defp parse_context(opts) do
+    case Keyword.get(opts, :context) do
+      nil ->
+        {:ok, %{}}
+
+      json when is_binary(json) ->
+        case Jason.decode(json, keys: :atoms) do
+          {:ok, %{} = map} ->
+            {:ok, map}
+
+          {:ok, _other} ->
+            {:error, "--context must decode to a JSON object", 2}
+
+          {:error, err} ->
+            {:error, "--context is not valid JSON: #{inspect(err)}", 2}
+        end
+    end
+  end
+
+  defp parse_format(opts) do
+    case Keyword.get(opts, :format, "text") do
+      "text" -> {:ok, :text}
+      "json" -> {:ok, :json}
+      other -> {:error, "Unknown --format value: #{inspect(other)}", 2}
+    end
+  end
+
+  defp call_and_format(call_opts, format) do
+    case AshGrant.Introspect.explain_by_identifier(call_opts) do
+      {:ok, explanation} ->
+        {:ok, format_explanation(explanation, format), 0}
+
+      {:error, reason} ->
+        {:error, format_error(reason), 1}
+    end
+  end
+
+  defp format_explanation(explanation, :json) do
+    Jason.encode!(explanation)
+  end
+
+  defp format_explanation(explanation, :text) do
+    decision = explanation.decision |> to_string() |> String.upcase()
+    resource = inspect(explanation.resource)
+
+    lines = [
+      "Decision:     #{decision}",
+      "Resource:     #{resource}",
+      "Action:       #{inspect(explanation.action)}",
+      "Actor:        #{inspect(explanation.actor)}",
+      "Reason code:  #{explanation.reason_code}",
+      "Summary:      #{explanation.summary}"
+    ]
+
+    lines =
+      if is_binary(explanation.scope_filter_string) do
+        lines ++ ["Scope filter: #{explanation.scope_filter_string}"]
+      else
+        lines
+      end
+
+    matched =
+      case explanation.matching_permissions do
+        [] -> ["(no matching permissions)"]
+        perms -> Enum.map(perms, &"  - #{inspect(&1)}")
+      end
+
+    Enum.join(lines ++ ["Matching permissions:" | matched], "\n")
+  end
+
+  defp format_error(:unknown_resource),
+    do: "unknown_resource — no resource matched the given --resource key"
+
+  defp format_error(:actor_not_found),
+    do: "actor_not_found — resolver.load_actor/1 returned :error for the given --actor"
+
+  defp format_error(:actor_loader_not_implemented),
+    do:
+      "actor_loader_not_implemented — the resource's permission resolver does not implement load_actor/1"
+
+  defp format_error(other), do: "error: #{inspect(other)}"
+end

--- a/test/mix/tasks/ash_grant_explain_test.exs
+++ b/test/mix/tasks/ash_grant_explain_test.exs
@@ -1,0 +1,195 @@
+defmodule Mix.Tasks.AshGrant.ExplainTest do
+  @moduledoc """
+  Tests for the `mix ash_grant.explain` task.
+
+  The task itself is a thin wrapper that calls `run_cli/1`. We test the
+  wrapper function directly to avoid triggering `Mix.Task.run("app.start")`
+  and shell side effects — all assertions operate on the structured
+  `{status, output, exit_code}` tuple it returns.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.AshGrant.Explain
+
+  describe "run_cli/1 — happy paths" do
+    test "returns :ok with text output for an allowed action" do
+      assert {:ok, output, 0} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "read"
+               ])
+
+      assert is_binary(output)
+      assert output =~ "allow"
+      assert output =~ "id_loadable_post"
+      assert output =~ "read"
+    end
+
+    test "returns :ok with text output for a denied action" do
+      assert {:ok, output, 0} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "update"
+               ])
+
+      assert is_binary(output)
+      assert output =~ ~r/deny|denied/i
+    end
+
+    test "returns valid JSON when --format json is given" do
+      assert {:ok, output, 0} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "read",
+                 "--format",
+                 "json"
+               ])
+
+      assert {:ok, decoded} = Jason.decode(output)
+      assert decoded["decision"] == "allow"
+      assert decoded["action"] == "read"
+      assert is_binary(decoded["summary"])
+      assert decoded["reason_code"] == "allow_matched"
+    end
+
+    test "accepts --context as JSON and forwards it to the resolver" do
+      # Context has no effect for this actor's permissions, but parsing
+      # must succeed and the task must still return {:ok, ...}.
+      assert {:ok, _output, 0} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "read",
+                 "--context",
+                 ~s({"reference_date":"2024-01-01"})
+               ])
+    end
+  end
+
+  describe "run_cli/1 — error handling" do
+    test "returns :error with exit code 1 for an unknown resource" do
+      assert {:error, output, 1} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "definitely_not_a_resource",
+                 "--action",
+                 "read"
+               ])
+
+      assert output =~ "unknown_resource" or output =~ "not found"
+    end
+
+    test "returns :error with exit code 1 when the actor cannot be loaded" do
+      assert {:error, output, 1} =
+               Explain.run_cli([
+                 "--actor",
+                 "missing_user",
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "read"
+               ])
+
+      assert output =~ "actor_not_found" or output =~ ~r/actor.*not.*found/i
+    end
+
+    test "returns :error with exit code 1 when resolver has no load_actor/1" do
+      assert {:error, output, 1} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "no_load_actor_post",
+                 "--action",
+                 "read"
+               ])
+
+      assert output =~ "load_actor" or output =~ "not_implemented"
+    end
+
+    test "returns :error with exit code 2 when --actor is missing" do
+      assert {:error, output, 2} =
+               Explain.run_cli([
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "read"
+               ])
+
+      assert output =~ "--actor"
+    end
+
+    test "returns :error with exit code 2 when --resource is missing" do
+      assert {:error, output, 2} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--action",
+                 "read"
+               ])
+
+      assert output =~ "--resource"
+    end
+
+    test "returns :error with exit code 2 when --action is missing" do
+      assert {:error, output, 2} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "id_loadable_post"
+               ])
+
+      assert output =~ "--action"
+    end
+
+    test "returns :error with exit code 2 when --context is not valid JSON" do
+      assert {:error, output, 2} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "read",
+                 "--context",
+                 "not-json"
+               ])
+
+      assert output =~ ~r/context/i
+    end
+
+    test "returns :error with exit code 2 when --format is unknown" do
+      assert {:error, output, 2} =
+               Explain.run_cli([
+                 "--actor",
+                 "user_1",
+                 "--resource",
+                 "id_loadable_post",
+                 "--action",
+                 "read",
+                 "--format",
+                 "yaml"
+               ])
+
+      assert output =~ ~r/format/i
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `mix ash_grant.explain` — CLI wrapper around `Introspect.explain_by_identifier/1` so operators can debug live permission decisions from the shell.
- Expose a pure `run_cli/1` entry point that returns `{status, output, exit_code}` — tests exercise it directly without capturing Mix shell output.
- Supports `--format text` (default, human-readable) and `--format json` (for CI/LLM pipelines), plus `--context '<json>'` to forward a context map to the resolver.

## Usage
```
mix ash_grant.explain --actor user_123 --resource post --action read
mix ash_grant.explain --actor user_123 --resource post --action read --format json
mix ash_grant.explain --actor user_123 --resource post --action read \
  --context '{"reference_date":"2024-01-01"}'
```

## Exit codes
- `0` — explanation produced (allow or deny both succeed)
- `1` — lookup failure (`unknown_resource`, `actor_not_found`, `actor_loader_not_implemented`)
- `2` — usage error (missing option, invalid `--context` JSON, unknown `--format`)

## Context
PR6 of 7 in the Public Introspection API rollout. **Stacked on #107** — consumes `explain_by_identifier/1` from that PR.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (1045 tests, 0 failures; 12 new tests in `ash_grant_explain_test.exs`)
- [x] `mix credo` (no new findings after applying `Enum.map_join/3`)
- [x] `mix format --check-formatted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)