### PR TITLE
docs: advanced patterns, migration guide, and coverage gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,12 @@ Post |> Ash.read!(actor: viewer)
 - **[Scopes](guides/scopes.md)** — Scope DSL, inheritance, combination rules, multi-tenancy, relational scopes, business examples
 - **[Scope Naming Convention](guides/scope-naming-convention.md)** — Predicate naming, sentence test, RBAC/ABAC patterns, AND/OR composition
 - **[Argument-Based Scope](guides/argument-based-scope.md)** — Multi-hop authorization via action arguments + resource-local lazy loading, avoids DB-query fallback
+- **[Advanced Patterns](guides/advanced-patterns.md)** — Real-world recipes combining `resolve_argument` and `scope_through` (multi-hop writes, parent-shared children, both together)
 - **[Field-Level Permissions](guides/field-level-permissions.md)** — Field groups, whitelist/blacklist modes, inheritance, masking
 - **[Checks & Policies](guides/checks-and-policies.md)** — Check types, CanPerform calculations, DSL configuration, default_policies
-- **[Debugging & Introspection](guides/debugging-and-introspection.md)** — explain/4, permission introspection, scope descriptions, read vs write evaluation
+- **[Debugging & Introspection](guides/debugging-and-introspection.md)** — explain/4, permission introspection, identifier-based lookups, expression stringification
 - **[Policy Testing](guides/policy-testing.md)** — DSL and YAML tests, mix tasks, export/import
+- **[Migration Guide](guides/migration.md)** — Moving off deprecated `write:`, `scope_resolver`, and `owner_field`
 
 ## Architecture
 

--- a/guides/advanced-patterns.md
+++ b/guides/advanced-patterns.md
@@ -1,0 +1,325 @@
+# Advanced Patterns
+
+Scopes with `^actor(:id)` or plain attribute comparisons cover most
+applications. Real projects eventually hit authorization questions that
+require information the record doesn't hold directly:
+
+- *"Can this user refund this order, given that the authority lives on the
+  order's organizational unit — not on the refund itself?"*
+- *"A workspace is shared with a user; can they see comments on posts in
+  that workspace, without re-granting comments individually?"*
+- *"Above applies, but with an extra attribute filter (`status == :open`)
+  layered on the parent-shared ones."*
+
+Two entities handle these, and most real apps end up needing both:
+
+- **`resolve_argument`** — the record computes a value from its own
+  relationships and exposes it as an action argument, so scopes can
+  compare against `^arg(:name)` in-memory.
+- **`scope_through`** — parent-resource instance permissions
+  (`"workspace:ws_abc:read:"`) automatically propagate to a child via a
+  `belongs_to` relationship.
+
+This guide pulls them together with end-to-end recipes. For the full
+rationale and internals of `resolve_argument`, see the
+[Argument-Based Scope](argument-based-scope.md) guide.
+
+> **Prerequisite:** Familiarity with [Scopes](scopes.md) and
+> [Permissions](permissions.md).
+
+## When to reach for which
+
+| Situation | Use |
+|---|---|
+| Authorization value is an FK on the record (`center_id`) | Direct attribute scope: `expr(center_id in ^actor(:own_units))` |
+| Authorization value lives on a related record (`order.center_id`), write action | `resolve_argument` |
+| Authorization value lives on a related record, read-only | Relational scope (`expr(order.center_id in ...)`) is fine — lowers to SQL |
+| Parent record is *individually shared* with an actor (Google-Docs-style) and children should follow | `scope_through` |
+| Both: parent is shared *and* the child has an additional condition | `scope_through` + RBAC scope (combined via OR) |
+| Both: value is relation-derived *and* parent is shared | `resolve_argument` + `scope_through` |
+
+## Recipe 1: Multi-hop write authorization with `resolve_argument`
+
+**Problem.** A `Refund` has `belongs_to :order`. An actor can refund an
+order only when the order's `center_id` is one of the units they manage.
+Using `expr(order.center_id in ^actor(:own_org_unit_ids))` works on reads
+but forces the write-side DB-query fallback and has rough edges with
+composite scopes and FK-changing updates.
+
+**Solution.** Declare the scope against an argument, and let the resource
+populate the argument from its own `:order` relationship.
+
+```elixir
+defmodule MyApp.Orders.Refund do
+  use Ash.Resource,
+    domain: MyApp.Orders,
+    data_layer: AshPostgres.DataLayer,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    resolver MyApp.PermissionResolver
+    default_policies true
+
+    scope :always, true
+    scope :by_own_author, expr(author_id == ^actor(:id))
+
+    # Argument-based scope — no relationship traversal in the expression
+    scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+
+    # Populates :center_id from the record's own :order FK before auth runs.
+    # The injected change is lazy: it only loads :order when an in-play
+    # permission uses a scope that references ^arg(:center_id).
+    resolve_argument :center_id, from_path: [:order, :center_id]
+  end
+
+  relationships do
+    belongs_to :order, MyApp.Orders.Order, allow_nil?: false
+  end
+
+  actions do
+    defaults [:read, :destroy]
+    create :create, do: accept [:author_id, :total_amount, :order_id]
+
+    update :update do
+      accept [:total_amount]
+      require_atomic? false   # the injected change is non-atomic
+    end
+  end
+end
+```
+
+### What you get
+
+- `:by_own_author` evaluates in memory — the lazy change sees the actor
+  does not need `^arg(:center_id)` and skips the DB load entirely.
+- `:at_own_unit` evaluates in memory against a resource-computed value —
+  the caller cannot tamper with `:center_id` because the resource reads
+  it off its own FK.
+- Composite scopes work cleanly:
+
+  ```elixir
+  scope :at_own_unit_and_small, [:at_own_unit], expr(total_amount <= 100)
+  ```
+
+- Multi-hop is the same declaration shape:
+
+  ```elixir
+  resolve_argument :organization_id,
+    from_path: [:order, :customer, :organization_id]
+  ```
+
+### Caller requirements
+
+- **Always pass `actor:`** to `for_update/4`, `for_create/4`,
+  `for_destroy/4`. The change needs the actor to introspect permissions.
+- **Set `require_atomic? false`** on affected update/destroy actions if
+  your data layer defaults to atomic updates.
+
+## Recipe 2: Parent-shared children with `scope_through`
+
+**Problem.** Users hold per-workspace instance permissions
+(`"workspace:ws_abc123:read:"`). Posts live under workspaces via
+`belongs_to :workspace`. We want that single workspace grant to cover
+every post in the workspace — without copying the grant onto each post.
+
+**Solution.** Declare `scope_through :workspace` on the child. AshGrant
+propagates the parent's instance permissions through the FK automatically
+for reads, writes, and `CanPerform` calculations.
+
+```elixir
+defmodule MyApp.Workspaces.Post do
+  use Ash.Resource,
+    domain: MyApp.Workspaces,
+    data_layer: AshPostgres.DataLayer,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    resolver MyApp.PermissionResolver
+    default_policies true
+
+    scope :always, true
+    scope :own, expr(author_id == ^actor(:id))
+
+    # Propagate Workspace instance permissions through :workspace FK
+    scope_through :workspace
+  end
+
+  relationships do
+    belongs_to :workspace, MyApp.Workspaces.Workspace, allow_nil?: false
+  end
+end
+```
+
+With permissions `["workspace:ws_abc:read:", "post:*:read:own"]`:
+
+- **Reads** — filter becomes
+  `(author_id == ^actor(:id)) OR (workspace_id IN ["ws_abc"])`.
+- **Writes** — `check/1` succeeds when either the RBAC scope matches or
+  the parent instance is in the actor's set.
+- **`can_read?` calculation** — same OR filter, compiled to SQL.
+
+### Narrowing to specific actions
+
+```elixir
+scope_through :workspace, actions: [:read, :update]
+```
+
+Only `:read` and `:update` propagate; `:destroy` falls back to RBAC only.
+
+### When the parent uses a custom `instance_key`
+
+If the parent resource declares `instance_key :external_id` and the
+child's FK doesn't match the parent's destination attribute, AshGrant
+emits an `exists()` subquery through the relationship automatically —
+the child declaration doesn't change.
+
+## Recipe 3: Combining `scope_through` with RBAC scopes
+
+A user may hold both:
+
+```
+["workspace:ws_abc:read:", "post:*:read:own"]
+```
+
+No extra wiring needed. Recipe 2's declaration already produces:
+
+```
+(workspace_id IN ["ws_abc"]) OR (author_id == ^actor(:id))
+```
+
+Parent-instance filters and RBAC scope filters combine with **OR** — an
+actor sees posts reachable via *any* of their grants.
+
+### Adding a conditional layer
+
+Want the parent grant to allow reads only while the post is `status ==
+:open`? Do not put that condition on `scope_through` — it's boolean
+propagation, not a filter. Instead:
+
+1. Keep `scope_through :workspace` for unconditional reach, **or**
+2. Drop `scope_through` and model the parent-share with an RBAC scope
+   that joins back through the relationship:
+
+   ```elixir
+   scope :in_shared_workspace_and_open,
+     expr(status == :open and
+          exists(workspace.shares, user_id == ^actor(:id)))
+   ```
+
+   Permission: `"post:*:read:in_shared_workspace_and_open"`.
+
+Option 2 keeps everything at the RBAC-scope layer — one concept, one
+combination rule (multiple permissions = OR). Option 1 is simpler when
+the share is genuinely unconditional.
+
+## Recipe 4: `resolve_argument` + `scope_through` together
+
+**Problem.** A `Comment` belongs to a `Post`. The post in turn belongs
+to a `Workspace`. We want two kinds of access:
+
+1. Workspace-level sharing — a user holding
+   `"workspace:ws_abc:read:"` can read every comment under every post in
+   that workspace.
+2. Content-level authorization on writes — a user can delete a comment
+   only when the *post's* author is the current user
+   (`comment → post.author_id`).
+
+**Solution.** `scope_through` handles (1); `resolve_argument` handles
+(2).
+
+```elixir
+defmodule MyApp.Workspaces.Comment do
+  use Ash.Resource,
+    domain: MyApp.Workspaces,
+    data_layer: AshPostgres.DataLayer,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    resolver MyApp.PermissionResolver
+    default_policies true
+
+    scope :always, true
+    scope :own, expr(author_id == ^actor(:id))
+
+    # Writing requires the post's author to match
+    scope :on_own_post, expr(^arg(:post_author_id) == ^actor(:id))
+
+    # Multi-hop: comment → post.author_id
+    resolve_argument :post_author_id, from_path: [:post, :author_id]
+
+    # Parent-share: any workspace share covers every comment under it
+    scope_through :post, actions: [:read]
+  end
+
+  relationships do
+    belongs_to :post, MyApp.Workspaces.Post, allow_nil?: false
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    update :update do
+      accept [:body]
+      require_atomic? false
+    end
+  end
+end
+```
+
+With permissions
+`["workspace:ws_abc:read:", "comment:*:destroy:on_own_post"]`:
+
+- Read: combined `OR` filter covers workspace-shared posts' comments
+  plus the actor's own (if they had an `:own` grant).
+- Destroy: `check/1` evaluates `^arg(:post_author_id) == ^actor(:id)`;
+  the injected change loads `:post` only when the actor holds a
+  destroy-scope that needs `^arg(:post_author_id)`.
+
+## Troubleshooting
+
+### "Argument ... is not set" on write
+
+The lazy change short-circuits when the actor is `nil` or holds no
+scope referencing the argument. Check:
+
+1. Did you pass `actor:` to `for_update/4` / `for_create/4`?
+2. Does at least one of the actor's permissions for this action use a
+   scope that references `^arg(<name>)`?
+
+### Atomic update errors
+
+`resolve_argument` injects a non-atomic change. Set
+`require_atomic? false` on the affected update/destroy actions.
+
+### `scope_through` has no effect
+
+Common causes:
+
+- The relationship is not `belongs_to`. `scope_through` only works
+  through `belongs_to` (child points at parent).
+- The `actions:` filter excludes the action you're testing.
+- The actor has no parent instance permissions. `scope_through` only
+  propagates **instance** permissions (`"workspace:ws_abc:read:"`),
+  not RBAC permissions (`"workspace:*:read:always"`).
+
+### Post-change FK on update
+
+If your update changes the FK, `resolve_argument` reads the **original**
+FK from `changeset.data`. That's usually what you want (authorize based
+on the *current* state before the change), but if you need post-change
+semantics you must resolve manually (see the
+[hand-rolled version](argument-based-scope.md#hand-rolled-version-under-the-hood))
+and read from `changeset.attributes` instead.
+
+## See also
+
+- [Argument-Based Scope](argument-based-scope.md) — deep dive on
+  `resolve_argument`, multi-hop paths, tamper resistance.
+- [Permissions](permissions.md#scope-through-parent-child-propagation)
+  — `scope_through` reference.
+- [Scopes](scopes.md) — scope inheritance and combination rules.
+- [Migration Guide](migration.md) — moving off deprecated `write:` and
+  `scope_resolver`.

--- a/guides/checks-and-policies.md
+++ b/guides/checks-and-policies.md
@@ -124,6 +124,67 @@ members =
 The calculation handles RBAC scopes, instance permissions, deny-wins, and
 multi-scope OR combination — all identical to `FilterCheck`.
 
+#### Under the Hood
+
+`CanPerform` implements Ash's calculation `expression/2` callback, which
+means each loaded calculation becomes a SQL expression on the same
+query — **one round-trip, no N+1**, no per-record resolver calls.
+
+At load time, `expression/2` runs **once** with the actor in context:
+
+1. Call the configured `PermissionResolver` to get the actor's
+   permission strings.
+2. Get matching RBAC scopes via `AshGrant.Evaluator.get_all_scopes/4`,
+   resolve each to its filter expression, and combine with `OR`.
+3. Get matching instance IDs and build
+   `expr(id in ^instance_ids)` — or `^ref(instance_key) in ^instance_ids`
+   if the resource declares a non-default `instance_key`.
+4. For each `scope_through`, add
+   `expr(fk in ^parent_instance_ids)` (or an `exists()` subquery when
+   the parent's `instance_key` differs from the relationship's
+   destination attribute).
+5. Combine everything with `OR`. Shortcuts:
+   - Any scope resolves to `true` (`:always`, `:all`, `:global`) →
+     the calculation is literally `expr(true)` and collapses to a
+     `SELECT true`.
+   - No scopes, no instance IDs, no parent filters → `expr(false)`.
+   - Actor is `nil` → `expr(false)` (no permissions evaluated).
+
+Template references in scope expressions (`^actor(:id)`, `^tenant()`,
+`^context(:key)`) stay as templates in the returned expression — Ash
+fills them during query execution using the actor and tenant on the
+query, the same way it does for `FilterCheck`.
+
+Because the whole calculation is one expression, the database evaluates
+it in the same query that loads the records. Loading
+`[:can_update?, :can_destroy?, :can_publish?]` on 500 rows is still one
+SQL statement.
+
+#### Custom Resource Name
+
+When a resource uses `resource_name "custom"` (permissions match
+`"custom:*:..."` rather than the module-derived default), the DSL
+sugar picks that up automatically. Pass `:resource_name` explicitly only
+if you've bypassed the DSL and are writing an explicit calculation
+declaration:
+
+```elixir
+calculations do
+  calculate :can_update?, :boolean,
+    {AshGrant.Calculation.CanPerform,
+      action: "update",
+      resource: __MODULE__,
+      resource_name: "legacy_post"}
+end
+```
+
+#### Actor Context
+
+The actor comes from `context.actor` — the same actor you pass to
+`Ash.read!/2`. Without an actor the calculation short-circuits to
+`false`; unauthenticated queries do not need special handling at the
+call site.
+
 ## DSL Configuration
 
 ```elixir

--- a/guides/debugging-and-introspection.md
+++ b/guides/debugging-and-introspection.md
@@ -168,3 +168,140 @@ All functions accept a `:context` option for passing additional resolver context
 ```elixir
 AshGrant.Introspect.actor_permissions(Post, user, context: %{tenant: tenant_id})
 ```
+
+## Identifier-Based Introspection
+
+The functions above all take a hydrated actor struct. External tools —
+admin dashboards, CLI commands, LLM agents, webhook handlers — often
+have only an **actor ID** plus string keys for the resource and action.
+The identifier-based variants take strings/IDs and do the lookup work
+themselves.
+
+**Provisional (v0.15):** signatures may tighten in a minor release. See
+[Public API Contract](public-api-contract.md) for stability tiers.
+
+### Opt in: implement `load_actor/1` on your resolver
+
+The identifier-based functions call your resolver module's optional
+`load_actor/1` callback to turn an ID into an actor. Implementing it is
+how a resolver declares it can be driven by ID:
+
+```elixir
+defmodule MyApp.PermissionResolver do
+  @behaviour AshGrant.PermissionResolver
+
+  @impl true
+  def resolve(actor, _context), do: actor.permissions
+
+  @impl true
+  def load_actor(user_id) do
+    case MyApp.Accounts.get_user(user_id) do
+      nil -> :error
+      user -> {:ok, user}
+    end
+  end
+end
+```
+
+Existing resolvers without `load_actor/1` keep working — the
+identifier-based functions return
+`{:error, :actor_loader_not_implemented}` and the rest of the API is
+unchanged.
+
+### `explain_by_identifier/1`
+
+Resolves the resource by key, loads the actor, and delegates to
+`AshGrant.explain/4`:
+
+```elixir
+AshGrant.Introspect.explain_by_identifier(
+  actor_id: "user_1",
+  resource_key: "post",    # matches AshGrant.Info.resource_name/1
+  action: :read,
+  context: %{tenant: "acme"}  # optional
+)
+# => {:ok, %AshGrant.Explanation{decision: :allow, ...}}
+```
+
+### `can_by_identifier/3`
+
+```elixir
+AshGrant.Introspect.can_by_identifier("user_1", "post", :read)
+# => {:allow, %{scope: "always", instance_ids: nil, field_groups: []}}
+
+AshGrant.Introspect.can_by_identifier("user_1", "post", :destroy)
+# => {:deny, %{reason: :no_permission}}
+```
+
+### `actor_permissions_by_id/2`
+
+```elixir
+AshGrant.Introspect.actor_permissions_by_id("user_1", "post")
+# => {:ok, [%{action: "read", allowed: true, ...}, ...]}
+```
+
+### Error returns
+
+All three never raise for predictable lookup failures. They return:
+
+| Return | Meaning |
+|---|---|
+| `{:error, :unknown_resource}` | No registered resource has `resource_key` as its `resource_name` |
+| `{:error, :actor_loader_not_implemented}` | Resolver is an anonymous function, or the module doesn't export `load_actor/1` |
+| `{:error, :actor_not_found}` | Resolver's `load_actor/1` returned `:error` |
+
+### CLI: `mix ash_grant.explain`
+
+A thin wrapper around `explain_by_identifier/1` for shell scripts and
+CI checks:
+
+```
+mix ash_grant.explain --actor USER_ID --resource RESOURCE_KEY --action ACTION \
+  [--format text|json] [--context '<json>']
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Explanation produced (allow or deny both exit 0) |
+| `1` | Lookup failure (unknown resource / actor loader / actor not found) |
+| `2` | Usage error (bad flag, malformed `--context`) |
+
+## Stringifying Scope Expressions
+
+**Provisional (v0.15).**
+
+Ash's default expression inspect is readable but uses internal
+references like `{:_actor, :id}` instead of the DSL-facing
+`^actor(:id)`. `AshGrant.ExprStringify.to_string/1` produces the
+human-facing form — the same form users write in their `ash_grant do`
+blocks.
+
+```elixir
+expr = AshGrant.Info.resolve_scope_filter(MyApp.Post, :own, %{})
+AshGrant.ExprStringify.to_string(expr)
+# => "author_id == ^actor(:id)"
+
+AshGrant.ExprStringify.to_string(true)   # => "true"
+AshGrant.ExprStringify.to_string(nil)    # => "nil"
+```
+
+Mappings:
+
+| Internal term | Stringified |
+|---|---|
+| `{:_actor, :id}` | `^actor(:id)` |
+| `{:_context, :reference_date}` | `^context(:reference_date)` |
+| `:_tenant` | `^tenant()` |
+
+Contract:
+
+- Always returns a binary.
+- Never raises — unknown terms fall back to `inspect/1`.
+- Display-only. The output is *not* round-trippable back into an
+  expression.
+
+The same function populates `Explanation.scope_filter_string`, so JSON
+consumers (LLM tools, dashboards) always receive a printable form
+without having to carry the raw AST.

--- a/guides/field-level-permissions.md
+++ b/guides/field-level-permissions.md
@@ -116,7 +116,9 @@ An actor with `confidential` permission can see everything that `sensitive` and 
 
 ## Field Masking
 
-Instead of hiding fields entirely, you can show masked values:
+Instead of hiding fields entirely, you can show masked values. The
+`mask:` option lists fields to mask at that group's level; `mask_with:`
+is the function that produces the displayed value.
 
 ```elixir
 field_group :sensitive, [:phone, :address],
@@ -127,12 +129,93 @@ field_group :sensitive, [:phone, :address],
   end
 ```
 
-**Masking rules:**
-- Masking is **not inherited** — a higher-level group sees original values
-- **Allow-wins**: if an actor has both a masking group and a non-masking group for the same field, the field is unmasked
-- Actors with 4-part permissions (no field_group) see all fields unmasked
+### `mask_with/2` signature
 
-**Example behavior:**
+`mask_with` is a 2-arity function called once per masked field, per
+record:
+
+```elixir
+@spec mask_with(value :: term(), field :: atom()) :: term()
+```
+
+- `value` — the attribute's current value on the record. May be `nil`.
+- `field` — the attribute name as an atom. Useful for one function that
+  masks multiple fields differently.
+
+The return value replaces the attribute in the emitted record. It does
+**not** have to be the same type as the input — returning a string
+`"***"` for a numeric field is fine. The consumer should treat a
+masked response as display-only.
+
+```elixir
+# Per-field logic via the second argument
+mask_with: fn
+  value, :phone when is_binary(value) ->
+    "***-****-" <> String.slice(value, -4..-1)
+
+  value, :email when is_binary(value) ->
+    [_, domain] = String.split(value, "@", parts: 2)
+    "***@" <> domain
+
+  _value, _field ->
+    "***"
+end
+```
+
+### Masking rules
+
+- **Not inherited.** Masking attaches to the group that declared it. A
+  child group inheriting from a masked parent does *not* inherit the
+  masking. An actor at the higher-level group sees raw values.
+- **Allow-wins across groups.** If an actor holds two field groups and
+  any one of them grants unmasked access to a field, that field is *not*
+  masked. You don't have to reason about permission order — explicit
+  unmasked access always wins.
+- **4-part permissions skip masking entirely.** An actor with
+  `"employee:*:read:always"` (no field_group) sees raw values, the same
+  way they see all fields.
+
+### Interaction with `%Ash.ForbiddenField{}`
+
+Masking runs in a read-time `after_action` hook, *before* Ash's native
+`restrict_field_access` step. If a field is outside the actor's field
+groups entirely, it becomes `%Ash.ForbiddenField{}` during restriction
+— masking does not touch those. `mask_with` never receives a
+`%Ash.ForbiddenField{}` and never runs on fields the actor cannot see.
+
+This means three levels exist:
+
+| Actor access to field | Result |
+|---|---|
+| Not in any granted field group | `%Ash.ForbiddenField{}` |
+| In a masked group only | `mask_with.(value, field)` — a displayable stand-in |
+| In any unmasked group | raw value |
+
+### Error handling
+
+`mask_with` is called inside the query's `after_action` pipeline. If the
+function raises, the read fails — the same way any other `after_action`
+raise would. Keep the function total:
+
+- Handle `nil` values explicitly if the column is nullable.
+- Handle unexpected types defensively — return a generic mask rather
+  than letting a pattern-match failure crash the read.
+- Avoid DB calls inside `mask_with` — it runs per record and bypasses
+  any batching.
+
+```elixir
+# DO: total and fast
+mask_with: fn
+  nil, _field -> nil
+  value, _field when is_binary(value) -> String.replace(value, ~r/./, "*")
+  _value, _field -> "***"
+end
+
+# DON'T: partial — raises on nil or non-binary values
+mask_with: fn value, _ -> String.replace(value, ~r/./, "*") end
+```
+
+### Example behavior
 
 | Actor Permission | phone | salary |
 |-----------------|-------|--------|
@@ -140,3 +223,10 @@ field_group :sensitive, [:phone, :address],
 | `...:sensitive` (with masking) | `"*************"` | `%Ash.ForbiddenField{}` |
 | `...:confidential` | `"010-1234-5678"` | `80000` |
 | `...` (4-part, no field_group) | `"010-1234-5678"` | `80000` |
+
+### Masking functions and JSON
+
+When an `AshGrant.Explanation` that references a masked field group is
+serialized via `Jason.encode!/1`, the `mask_with` function value is
+**stripped** — functions aren't JSON-representable. The rest of the
+field group (name, fields, masked field names) round-trips cleanly.

--- a/guides/migration.md
+++ b/guides/migration.md
@@ -1,0 +1,233 @@
+# Migration Guide
+
+This guide covers migrations away from deprecated AshGrant APIs. Each
+section explains **why** the old API is deprecated, what replaces it,
+and the mechanical steps to upgrade existing code.
+
+## `write:` scope option → `resolve_argument`
+
+**Deprecated in 0.14.** Still compiles; emits a compile-time
+deprecation warning.
+
+### Why it exists
+
+When a scope's read-side expression traversed a relationship
+(`expr(order.center_id in ...)`), the write-side couldn't evaluate in
+memory. `write:` was an escape hatch: "use *this* simpler expression
+when checking a write."
+
+```elixir
+# Before
+scope :at_own_unit,
+  expr(order.center_id in ^actor(:own_org_unit_ids)),
+  write: expr(center_id in ^actor(:own_org_unit_ids))
+```
+
+This worked, but had two problems:
+
+1. Two independent expressions for one logical rule — easy to drift.
+2. Composite scopes (`[:at_own_unit]`) didn't compose `write:` cleanly,
+   causing subtle inheritance bugs (see CHANGELOG 0.14 #83, #86).
+
+### What replaces it
+
+`resolve_argument` + an argument-based scope expression. The scope
+becomes in-memory-evaluable **for both read and write**, and the
+resource populates the argument from its own FK lazily.
+
+```elixir
+# After
+ash_grant do
+  scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+
+  resolve_argument :center_id, from_path: [:order, :center_id]
+end
+```
+
+One expression, no composite edge cases, zero cost for scopes that don't
+need the value (see the
+[Argument-Based Scope guide](argument-based-scope.md) for why).
+
+### Migration steps
+
+1. For each scope with a `write:` override, identify the FK path from
+   the record to the authorizing value. Usually this mirrors the `write:`
+   expression's attribute name (`center_id`) and the read expression's
+   relationship path (`order.center_id`).
+2. Rewrite the scope to compare `^arg(<name>)` instead of traversing
+   the relationship:
+
+   ```elixir
+   scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))
+   ```
+
+3. Add a `resolve_argument` entity declaring the FK path:
+
+   ```elixir
+   resolve_argument :center_id, from_path: [:order, :center_id]
+   ```
+
+4. Ensure affected update/destroy actions have `require_atomic? false`
+   — the injected change is non-atomic.
+5. Ensure all callers pass `actor:` to `for_update/4`, `for_create/4`,
+   `for_destroy/4`. The lazy change needs the actor to introspect
+   permissions.
+6. Drop the `write:` option.
+
+### When you actually want different read/write semantics
+
+Occasionally `write:` was used not as an escape hatch but to intentionally
+diverge read and write rules ("users can *see* published posts but only
+*edit* their own"). That's not what `write:` was for — model it as two
+separate scopes:
+
+```elixir
+# Before — semantic misuse of write:
+scope :readable_published,
+  expr(status == :published),
+  write: expr(author_id == ^actor(:id))
+
+# After — two scopes, permissions mapped per-action
+scope :published, expr(status == :published)
+scope :own, expr(author_id == ^actor(:id))
+```
+
+Then grant `"post:*:read:published"` and `"post:*:update:own"`
+separately. Per-action permissions are how AshGrant already expresses
+this.
+
+## `scope_resolver` → inline `scope` entities
+
+**Deprecated since 0.7.** Still loads as a fallback for scopes not
+defined inline.
+
+### Why it exists
+
+Early AshGrant used a `scope_resolver` module behaviour — you wrote a
+module that mapped scope names to filter expressions at runtime:
+
+```elixir
+# Before
+defmodule MyApp.PostScopeResolver do
+  @behaviour AshGrant.ScopeResolver
+
+  @impl true
+  def resolve(:own, ctx), do: expr(author_id == ^actor(:id))
+  def resolve(:published, _ctx), do: expr(status == :published)
+end
+
+ash_grant do
+  resolver MyApp.PermissionResolver
+  scope_resolver MyApp.PostScopeResolver
+end
+```
+
+This worked, but inverted where scope logic lived: compile-time
+expressions were authored in a separate runtime module, invisible to
+the DSL introspection layer (`AshGrant.Info.scopes/1`,
+`Introspect.available_permissions/1`, `explain/4`). Tooling couldn't
+see the scopes.
+
+### What replaces it
+
+The inline `scope` entity inside the `ash_grant` block:
+
+```elixir
+# After
+ash_grant do
+  resolver MyApp.PermissionResolver
+
+  scope :own, expr(author_id == ^actor(:id))
+  scope :published, expr(status == :published)
+end
+```
+
+Same filter expressions — just authored where the DSL can see them.
+Every introspection, debugging, and testing surface now works against
+them.
+
+### Migration steps
+
+1. For each scope your resolver module returns, add an equivalent
+   `scope :name, expr(...)` entity inside `ash_grant do ... end`.
+2. Translate any `ctx` the resolver module used:
+   - `ctx.actor` → `^actor(:field)` inside `expr()`
+   - `ctx.tenant` → `^tenant()`
+   - Other values passed by the caller → `^context(:key)` (set at query
+     time via `Ash.Query.set_context/2` or
+     `Ash.Changeset.set_context/2`; see
+     [Scopes: Context Injection](scopes.md#context-injection-context)).
+3. Remove the `scope_resolver` option from `ash_grant do`.
+4. Delete the resolver module (or keep it for any scopes you couldn't
+   express inline — see the next section).
+
+### Mixed mode during transition
+
+If you can't migrate every scope at once, both can coexist. Inline scopes
+take priority; any scope name not found inline falls back to
+`scope_resolver`. An error is raised if a scope is in neither. That's
+the safe state to run in while migrating one scope at a time.
+
+```elixir
+ash_grant do
+  resolver MyApp.PermissionResolver
+  scope_resolver MyApp.PostScopeResolver   # still here, falls back
+
+  scope :own, expr(author_id == ^actor(:id))
+  scope :published, expr(status == :published)
+  # :legacy_scope still comes from the resolver module
+end
+```
+
+### Why you can't skip migrating
+
+The deprecated surface is maintained for backward compatibility but
+does not participate in:
+
+- `AshGrant.Introspect.available_permissions/1`
+- `AshGrant.explain/4`'s matching/evaluated permission lists
+- Policy testing assertions that reference scope metadata
+- Admin dashboard and LLM tool surfaces
+
+Any scope that stays in `scope_resolver` is invisible to those surfaces.
+
+## `owner_field` option → `scope :own`
+
+**Deprecated.** Scheduled for removal in 1.0.
+
+### Why it exists
+
+`owner_field :author_id` was a shorthand for "authorize writes where
+`author_id == actor.id`." It ran ahead of the scope system and
+pre-dated inline `expr()` scopes.
+
+### What replaces it
+
+A plain `:own` scope. Same behavior, participates in the introspection
+surface, and composes with other scopes through inheritance.
+
+```elixir
+# Before
+ash_grant do
+  resolver MyApp.PermissionResolver
+  owner_field :author_id
+end
+
+# After
+ash_grant do
+  resolver MyApp.PermissionResolver
+  scope :own, expr(author_id == ^actor(:id))
+end
+```
+
+Update resolvers to emit `"post:*:update:own"` (or whatever action)
+instead of relying on the implicit `owner_field` check.
+
+## See also
+
+- [Scopes](scopes.md) — the inline `scope` DSL
+- [Argument-Based Scope](argument-based-scope.md) — the `resolve_argument`
+  pattern in depth
+- [Advanced Patterns](advanced-patterns.md) — real-world recipes
+  combining `resolve_argument` and `scope_through`
+- [CHANGELOG](../CHANGELOG.md) — exact release each deprecation landed in

--- a/guides/scopes.md
+++ b/guides/scopes.md
@@ -172,6 +172,60 @@ Post |> Ash.read!(actor: actor)
 - Scope inheritance works with tenant scopes (e.g., `[:same_tenant]`)
 - Both `filter_check` (reads) and `check` (writes) properly evaluate tenant scopes
 
+## Context Injection (`^context`)
+
+When a scope depends on a value that isn't on the actor, isn't the
+tenant, and isn't a database function — a reference date for a
+"recent" filter, a per-request threshold, a feature flag — inject it
+through `^context(:key)`:
+
+```elixir
+ash_grant do
+  scope :recent, expr(inserted_at > ^context(:cutoff))
+  scope :within_limit, expr(amount <= ^context(:max_amount))
+end
+```
+
+Callers set the value at query or changeset time:
+
+```elixir
+# Read
+Post
+|> Ash.Query.for_read(:read)
+|> Ash.Query.set_context(%{cutoff: DateTime.add(DateTime.utc_now(), -7, :day)})
+|> Ash.read!(actor: actor)
+
+# Write
+post
+|> Ash.Changeset.for_update(:update, %{amount: 500})
+|> Ash.Changeset.set_context(%{max_amount: 1_000})
+|> Ash.update!(actor: actor)
+```
+
+### Why `^context` over database functions
+
+Scope filters that embed database-side time or config calls are hard to
+test — every assertion has to mock the clock or the DB session. Pulling
+those values out to the caller makes scopes pure.
+
+```elixir
+# Avoid: only testable by freezing DB time
+scope :today, expr(fragment("DATE(inserted_at) = CURRENT_DATE"))
+
+# Prefer: caller supplies the reference date
+scope :on_date, expr(fragment("DATE(inserted_at) = ?", ^context(:reference_date)))
+```
+
+Policy tests can then assert different behaviors just by varying
+`context:` in the test harness — no clock manipulation required.
+
+### `^context` inside policies (not just scopes)
+
+`^context` is an Ash expression template — anywhere Ash accepts an
+expression, you can reference it. AshGrant scopes are one call site;
+`authorize_if expr(...)` in a `policies do` block is another. Both see
+the same injected value.
+
 ## Relational Scopes (`exists()` and Dot-Paths)
 
 You can use `exists()` and dot-path references in scope expressions for relationship-based filtering.

--- a/mix.exs
+++ b/mix.exs
@@ -88,10 +88,12 @@ defmodule AshGrant.MixProject do
         "guides/field-level-permissions.md": [title: "Field-Level Permissions"],
         "guides/scope-naming-convention.md": [title: "Scope Naming Convention"],
         "guides/argument-based-scope.md": [title: "Argument-Based Scope"],
+        "guides/advanced-patterns.md": [title: "Advanced Patterns"],
         "guides/checks-and-policies.md": [title: "Checks & Policies"],
         "guides/debugging-and-introspection.md": [title: "Debugging & Introspection"],
         "guides/public-api-contract.md": [title: "Public API Contract"],
         "guides/policy-testing.md": [title: "Policy Testing"],
+        "guides/migration.md": [title: "Migration Guide"],
         "CHANGELOG.md": [title: "Changelog"],
         LICENSE: [title: "License"]
       ],


### PR DESCRIPTION
Adds two new guides and fills in previously undocumented or thin areas surfaced by a coverage audit.

New guides:
- advanced-patterns.md: real-world recipes combining resolve_argument and scope_through (multi-hop writes, parent-shared children, resolve_argument + scope_through together, troubleshooting).
- migration.md: step-by-step migration paths off deprecated write:, scope_resolver, and owner_field.

Expanded coverage:
- debugging-and-introspection.md: identifier-based Introspect (explain_by_identifier, can_by_identifier, actor_permissions_by_id), load_actor/1 opt-in callback, mix ash_grant.explain exit codes, and ExprStringify section.
- scopes.md: ^context(:key) injection with DO/DON'T guidance over database-side functions for testability.
- checks-and-policies.md: CanPerform "Under the Hood" explaining expression/2, single-query compilation (no N+1), instance_key and scope_through interaction, nil-actor short-circuit.
- field-level-permissions.md: mask_with/2 signature, per-field branching, allow-wins interaction with %Ash.ForbiddenField{}, total function guidance, JSON serialization behavior.

README and mix.exs updated to register the new guides in ExDoc extras.