### PR TITLE
docs: guide coverage — advanced patterns, migration, and gap fills

### DIFF
--- a/guides/checks-and-policies.md
+++ b/guides/checks-and-policies.md
@@ -144,9 +144,10 @@ At load time, `expression/2` runs **once** with the actor in context:
    the parent's `instance_key` differs from the relationship's
    destination attribute).
 5. Combine everything with `OR`. Shortcuts:
-   - Any scope resolves to `true` (`:always`, `:all`, `:global`) →
-     the calculation is literally `expr(true)` and collapses to a
-     `SELECT true`.
+   - Any scope resolves to `true` (`:always` — the recommended name; the
+     runtime also accepts `:all` and `:global` as synonyms for backward
+     compatibility) → the calculation is literally `expr(true)` and
+     collapses to a `SELECT true`.
    - No scopes, no instance IDs, no parent filters → `expr(false)`.
    - Actor is `nil` → `expr(false)` (no permissions evaluated).
 

--- a/guides/debugging-and-introspection.md
+++ b/guides/debugging-and-introspection.md
@@ -67,7 +67,7 @@ See the [Argument-Based Scope guide](argument-based-scope.md) for the full patte
 
 **Resolution functions:**
 - `AshGrant.Info.resolve_scope_filter/3` — resolved read filter (inheritance applied)
-- `AshGrant.Info.resolve_write_scope_filter/3` — resolved write filter (inheritance applied, `write:` option honored if present)
+- `AshGrant.Info.resolve_write_scope_filter/3` — resolved write filter (inheritance applied; respects the deprecated `write:` override for backward compatibility — see below)
 
 ### `write:` option (deprecated)
 

--- a/guides/scopes.md
+++ b/guides/scopes.md
@@ -19,9 +19,6 @@ ash_grant do
   # Inherited scope - combines parent with additional filter
   scope :own_draft, [:own], expr(status == :draft)
   # Result: author_id == actor.id AND status == :draft
-
-  # Relational scope - works for both reads and writes automatically
-  scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id)))
 end
 ```
 


### PR DESCRIPTION
## Summary

Closes coverage gaps surfaced by a DSL audit: adds two new guides and
fleshes out thin sections in existing ones. No library code changes.

### New guides

- **`guides/advanced-patterns.md`** — real-world recipes combining
  `resolve_argument` and `scope_through`:
  - multi-hop write authorization via argument-based scopes
  - parent-shared children through `scope_through`
  - the two together (e.g. `Comment → Post.author_id` writes, plus
    workspace-level reads)
  - troubleshooting (missing argument, atomic update errors, silent
    `scope_through`, pre/post-change FK semantics)
- **`guides/migration.md`** — step-by-step paths off the deprecated
  surfaces: `write:` → `resolve_argument`, `scope_resolver` → inline
  `scope` entities, `owner_field` → `scope :own`.

### Expanded coverage

- **`debugging-and-introspection.md`** — identifier-based Introspect
  (`explain_by_identifier/1`, `can_by_identifier/3`,
  `actor_permissions_by_id/2`), `load_actor/1` opt-in callback, error
  returns, `mix ash_grant.explain` exit codes, and `ExprStringify`.
- **`scopes.md`** — `^context(:key)` injection with DO/DON'T guidance
  over database-side functions for testability.
- **`checks-and-policies.md`** — CanPerform *Under the Hood*:
  `expression/2` shape, single-query SQL compilation (no N+1),
  `instance_key` and `scope_through` interaction, nil-actor
  short-circuit, template ref handling.
- **`field-level-permissions.md`** — `mask_with/2` signature,
  per-field branching, allow-wins + `%Ash.ForbiddenField{}`
  interaction, total-function guidance, JSON serialization behavior.

### Consistency cleanup

- Removed the `:team_member exists()` example from the Scope DSL intro
  in `scopes.md` — the same file flags relation-traversing scopes as
  anti-patterns on writes, and Relational Scopes already has a proper
  section.
- Tightened `:always / :all / :global` wording in the CanPerform
  shortcut list; flagged the `write:` reference next to
  `resolve_write_scope_filter/3` as deprecated.

### Registry

- `mix.exs`: new guides added to `docs: extras` in the Guides group.
- `README.md`: Guides index updated.

`AshGrant.AI` is intentionally excluded — to be documented once it
graduates out of testing.

## Test plan

- [ ] `mix compile --warnings-as-errors` passes
- [ ] `mix docs` renders the two new guides and the updated sections
- [ ] Spot-check internal links (`advanced-patterns.md` ↔
      `argument-based-scope.md` ↔ `migration.md`)
- [ ] No production code touched — no runtime test regressions possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)