### PR TITLE
feat: remove scope inheritance, add do-block form for scope options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking
+
+- **Scope inheritance removed.** `inherits` (and the old 3-argument positional form `scope :name, [:parent], filter`) is no longer supported. Write each scope as a standalone expression; combine conditions with `and`:
+
+  ```elixir
+  # Before
+  scope :own, expr(author_id == ^actor(:id))
+  scope :own_draft, [:own], expr(status == :draft)
+  # or: scope :own_draft, expr(status == :draft), inherits: [:own]
+
+  # After
+  scope :own, expr(author_id == ^actor(:id))
+  scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
+  ```
+
+  Domain-defined scopes still merge into resources that share the domain — only scope-to-scope `inherits` is gone. The `AshGrant.Dsl.Scope` struct no longer has an `:inherits` field.
+
+### Added
+
+- `scope` now supports a do-block form for setting `description` and any other scope option:
+
+  ```elixir
+  scope :own, expr(author_id == ^actor(:id)) do
+    description "Records owned by the current user"
+  end
+  ```
+
 ## [0.14.1] - 2026-04-13
 
 Two fixes that make `resolve_argument` (introduced in 0.14.0) actually

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Permissions resolve to native Ash filters and policy checks, with deny-wins sema
 
 **Authorization:**
 - **Domain-level DSL** — shared resolver and scopes inherited by all resources in a domain
-- **Scope DSL** with `expr()` — row-level filters, scope inheritance, `^tenant()` support
+- **Scope DSL** with `expr()` — row-level filters, `^tenant()` support
 - **Argument-based scopes** with `resolve_argument` — multi-hop authorization via action arguments populated from the resource's own relationships, with lazy loading
 - **Field groups** — column-level read access with inheritance and masking
 - **Instance permissions** — per-record sharing with optional scope conditions
@@ -103,7 +103,7 @@ Post |> Ash.read!(actor: viewer)
 
 - **[Getting Started](guides/getting-started.md)** — Module-based resolvers, explicit policies, domain-level DSL, resolver patterns
 - **[Permissions](guides/permissions.md)** — Permission format, wildcards, RBAC, instance permissions, instance_key, scope_through, deny-wins
-- **[Scopes](guides/scopes.md)** — Scope DSL, inheritance, combination rules, multi-tenancy, relational scopes, business examples
+- **[Scopes](guides/scopes.md)** — Scope DSL, combination rules, multi-tenancy, relational scopes, business examples
 - **[Scope Naming Convention](guides/scope-naming-convention.md)** — Predicate naming, sentence test, RBAC/ABAC patterns, AND/OR composition
 - **[Argument-Based Scope](guides/argument-based-scope.md)** — Multi-hop authorization via action arguments + resource-local lazy loading, avoids DB-query fallback
 - **[Advanced Patterns](guides/advanced-patterns.md)** — Real-world recipes combining `resolve_argument` and `scope_through` (multi-hop writes, parent-shared children, both together)

--- a/guides/advanced-patterns.md
+++ b/guides/advanced-patterns.md
@@ -96,10 +96,11 @@ end
 - `:at_own_unit` evaluates in memory against a resource-computed value —
   the caller cannot tamper with `:center_id` because the resource reads
   it off its own FK.
-- Composite scopes work cleanly:
+- Composite scopes are written directly with `and`:
 
   ```elixir
-  scope :at_own_unit_and_small, [:at_own_unit], expr(total_amount <= 100)
+  scope :at_own_unit_and_small,
+    expr(^arg(:center_id) in ^actor(:own_org_unit_ids) and total_amount <= 100)
   ```
 
 - Multi-hop is the same declaration shape:

--- a/guides/authorization-patterns.md
+++ b/guides/authorization-patterns.md
@@ -176,18 +176,21 @@ ash_grant do
   scope :same_tenant, expr(tenant_id == ^actor(:tenant_id))
 
   # Own + draft status = "my drafts only"
-  scope :own_draft, [:own], expr(status == :draft)
+  scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
 
   # Same tenant + active = "active records in my tenant"
-  scope :tenant_active, [:same_tenant], expr(status == :active)
+  scope :tenant_active,
+    expr(tenant_id == ^actor(:tenant_id) and status == :active)
 
   # Same tenant + own = "my records in my tenant"
-  scope :tenant_own, [:same_tenant], expr(created_by_id == ^actor(:id))
+  scope :tenant_own,
+    expr(tenant_id == ^actor(:tenant_id) and created_by_id == ^actor(:id))
 end
 ```
 
-> **Remember:** Scope inheritance = AND (restricts access). Multiple permissions = OR
-> (expands access). See the [Scopes guide](scopes.md#scope-combination-rules) for details.
+> **Remember:** Combining conditions in one scope = AND (restricts access).
+> Multiple permissions on the same action = OR (expands access). See the
+> [Scopes guide](scopes.md#scope-combination-rules) for details.
 
 ### Example: Amount-Based Authorization
 
@@ -402,7 +405,7 @@ ash_grant do
   scope :always, true
   scope :same_tenant, expr(tenant_id == ^tenant())
   scope :own, expr(author_id == ^actor(:id))
-  scope :own_in_tenant, [:same_tenant], expr(author_id == ^actor(:id))
+  scope :own_in_tenant, expr(tenant_id == ^tenant() and author_id == ^actor(:id))
 end
 ```
 
@@ -533,7 +536,8 @@ ash_grant do
   # ABAC scopes
   scope :same_tenant, expr(tenant_id == ^actor(:tenant_id))
   scope :active, expr(status == :active)
-  scope :tenant_own, [:same_tenant], expr(author_id == ^actor(:id))
+  scope :tenant_own,
+    expr(tenant_id == ^actor(:tenant_id) and author_id == ^actor(:id))
 
   # ReBAC
   scope :team_member, expr(exists(team.memberships, user_id == ^actor(:id)))

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -160,15 +160,17 @@ end
 | resolver | Yes | Yes | **Resource wins** |
 | resolver | No | Yes | Domain's resolver used |
 | scope (same name) | Yes | Yes | **Resource wins** (override) |
-| scope | No | Yes | Domain scope inherited |
+| scope | No | Yes | Domain scope is available on the resource |
 
-Resource scopes can inherit from domain-defined parent scopes:
+Domain scopes become available on resources that share the domain, alongside
+resource-defined scopes. Scope inheritance between scopes is not supported —
+write the combined expression directly:
 
 ```elixir
-# Domain defines :own scope
-# Resource adds :own_draft that inherits from domain's :own
+# Domain defines :own scope (author_id == ^actor(:id))
+# Resource adds its own combined scope
 ash_grant do
-  scope :own_draft, [:own], expr(status == :draft)
+  scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
 end
 ```
 

--- a/guides/migration.md
+++ b/guides/migration.md
@@ -4,6 +4,39 @@ This guide covers migrations away from deprecated AshGrant APIs. Each
 section explains **why** the old API is deprecated, what replaces it,
 and the mechanical steps to upgrade existing code.
 
+## Scope inheritance — removed
+
+**Removed in the next release.** Scopes no longer support `inherits`. Write the
+combined filter directly with `and`.
+
+### Why
+
+Scope inheritance added hidden coupling (a child's behaviour depended on parent
+filters that might live in a different module — e.g. the domain), and its
+interactions with `write:` and argument-based scopes were subtle. Inlining the
+expression is mechanically trivial, reads plainly, and is easier to debug in
+`AshGrant.explain/4`.
+
+### What replaces it
+
+Write each scope as a single expression. Combine with `and`:
+
+```elixir
+# Before
+scope :own, expr(author_id == ^actor(:id))
+scope :own_draft, [:own], expr(status == :draft)
+# or:
+scope :own_draft, expr(status == :draft), inherits: [:own]
+
+# After
+scope :own, expr(author_id == ^actor(:id))
+scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
+```
+
+Domain-defined scopes are still merged into resources that share the domain
+(so a resource can still reference a scope defined on the domain by name in a
+permission string). Only scope-to-scope `inherits` is gone.
+
 ## `write:` scope option → `resolve_argument`
 
 **Deprecated in 0.14.** Still compiles; emits a compile-time

--- a/guides/scope-naming-convention.md
+++ b/guides/scope-naming-convention.md
@@ -110,21 +110,25 @@ scope :draft_or_pending, expr(status in [:draft, :pending_review])
 
 More examples: `:cancellable` > `:scheduled_and_future`, `:archivable` > `:completed_or_expired`.
 
-### Rule 4: AND composition — `_and_` connector with scope inheritance
+### Rule 4: AND composition — `_and_` connector, combined inline
 
-When a scope requires multiple conditions to ALL be true, use scope inheritance
-and name with `_and_`:
+When a scope requires multiple conditions to ALL be true, write them directly
+with `and` and name the scope with `_and_`:
 
 ```elixir
 scope :own, expr(author_id == ^actor(:id))
-scope :own_and_draft, [:own], expr(status == :draft)
+scope :own_and_draft, expr(author_id == ^actor(:id) and status == :draft)
 # Result: author_id == actor.id AND status == :draft
 # "Actor can update post own and draft"
 ```
 
 ```elixir
 scope :at_own_unit, expr(org_unit_id in ^actor(:own_org_unit_ids))
-scope :at_own_unit_and_upcoming, [:at_own_unit], expr(status == :scheduled and start_at > now())
+scope :at_own_unit_and_upcoming,
+  expr(
+    org_unit_id in ^actor(:own_org_unit_ids) and
+      status == :scheduled and start_at > now()
+  )
 # "Actor can cancel schedule at own unit and upcoming"
 ```
 
@@ -233,7 +237,11 @@ ash_grant do
   scope :always, true
   scope :at_own_unit, expr(org_unit_id in ^actor(:own_org_unit_ids))
   scope :upcoming, expr(status == :scheduled and start_at > now())
-  scope :at_own_unit_and_upcoming, [:at_own_unit], expr(status == :scheduled and start_at > now())
+  scope :at_own_unit_and_upcoming,
+    expr(
+      org_unit_id in ^actor(:own_org_unit_ids) and
+        status == :scheduled and start_at > now()
+    )
 end
 ```
 

--- a/guides/scopes.md
+++ b/guides/scopes.md
@@ -16,21 +16,32 @@ ash_grant do
   scope :own, expr(author_id == ^actor(:id))
   scope :published, expr(status == :published)
 
-  # Inherited scope - combines parent with additional filter
-  scope :own_draft, [:own], expr(status == :draft)
-  # Result: author_id == actor.id AND status == :draft
+  # Combined scope - write the combined filter directly (no inheritance)
+  scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
 end
 ```
 
-## Scope Inheritance
+Each scope is standalone. If you need a combination of conditions, write them
+directly with `and`.
 
-Scopes can inherit from parent scopes:
+## Describing Scopes
+
+Every scope can carry a human-readable `description` that shows up in
+`AshGrant.explain/4` output and introspection helpers. Provide it via a keyword
+option or inside a do-block:
 
 ```elixir
-scope :base, expr(tenant_id == ^actor(:tenant_id))
-scope :active, [:base], expr(status == :active)
-# Result: tenant_id == actor.tenant_id AND status == :active
+# Keyword form
+scope :own, expr(author_id == ^actor(:id)),
+  description: "Records owned by the current user"
+
+# Do-block form
+scope :own, expr(author_id == ^actor(:id)) do
+  description "Records owned by the current user"
+end
 ```
+
+Fetch a description via `AshGrant.Info.scope_description/2`.
 
 ## Scope Combination Rules
 
@@ -47,24 +58,20 @@ they are combined with **OR**:
 # Actor can see their own posts AND all published posts
 ```
 
-### Scope Inheritance = AND
+### Combining conditions within one scope = AND
 
-When a scope **inherits** from parent scopes, they are combined with **AND**:
+If you need multiple conditions to all hold for one scope, write them directly
+in the expression:
 
 ```elixir
-ash_grant do
-  scope :own, expr(author_id == ^actor(:id))
-  scope :draft, expr(status == :draft)
-  scope :own_draft, [:own], expr(status == :draft)
-  # Inheritance: [:own] + expr(status == :draft)
-end
+scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
 
 # :own_draft filter: (author_id == actor.id) AND (status == :draft)
 # NOT the same as having two separate permissions!
 ```
 
 > **Key difference:** Multiple permissions expand access (OR),
-> scope inheritance restricts access (AND).
+> a single combined scope restricts access (AND).
 
 ## Date-Based Scopes
 
@@ -74,8 +81,9 @@ You can use SQL fragments for temporal filtering:
 # Records created today only
 scope :today, expr(fragment("DATE(inserted_at) = CURRENT_DATE"))
 
-# Combined with ownership
-scope :own_today, [:own], expr(fragment("DATE(inserted_at) = CURRENT_DATE"))
+# Combined with ownership — inline the combined filter
+scope :own_today,
+  expr(author_id == ^actor(:id) and fragment("DATE(inserted_at) = CURRENT_DATE"))
 ```
 
 ## Multi-Tenancy Support
@@ -104,7 +112,7 @@ defmodule MyApp.Blog.Post do
     scope :always, true
     scope :same_tenant, expr(tenant_id == ^tenant())
     scope :own, expr(author_id == ^actor(:id))
-    scope :own_in_tenant, [:same_tenant], expr(author_id == ^actor(:id))
+    scope :own_in_tenant, expr(tenant_id == ^tenant() and author_id == ^actor(:id))
   end
 
   # ...
@@ -325,15 +333,16 @@ ash_grant do
 end
 ```
 
-### Multi-Tenant with Inheritance
+### Multi-Tenant combined scopes
 
-Combined scopes using inheritance:
+Write combined conditions directly in the expression:
 
 ```elixir
 ash_grant do
   scope :tenant, expr(tenant_id == ^actor(:tenant_id))
-  scope :tenant_active, [:tenant], expr(status == :active)
-  scope :tenant_own, [:tenant], expr(created_by_id == ^actor(:id))
+  scope :tenant_active, expr(tenant_id == ^actor(:tenant_id) and status == :active)
+  scope :tenant_own,
+    expr(tenant_id == ^actor(:tenant_id) and created_by_id == ^actor(:id))
 end
 ```
 

--- a/lib/ash_grant.ex
+++ b/lib/ash_grant.ex
@@ -210,7 +210,7 @@ defmodule AshGrant do
         scope :always, true
         scope :own, expr(author_id == ^actor(:id))
         scope :published, expr(status == :published)
-        scope :own_draft, [:own], expr(status == :draft)  # Inheritance
+        scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
       end
 
   ### Context Injection for Testable Scopes

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -28,7 +28,6 @@ defmodule AshGrant.Dsl do
 
   | Option | Type | Description |
   |--------|------|-------------|
-  | `inherits` | list of atoms | Parent scopes to inherit and combine with |
   | `description` | string | Human-readable description for explain/4 output |
   | `write` | expression, boolean, or nil | **Deprecated.** Prefer argument-based scopes + `resolve_argument`. See below. |
 
@@ -94,7 +93,7 @@ defmodule AshGrant.Dsl do
           scope :always, true
           scope :own, expr(author_id == ^actor(:id))
           scope :published, expr(status == :published)
-          scope :own_draft, [:own], expr(status == :draft)
+          scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
 
           # Relational scope — works for reads and writes automatically
           scope :team_visible, expr(exists(team.members, user_id == ^actor(:id)))
@@ -161,19 +160,22 @@ defmodule AshGrant.Dsl do
     ## Examples
 
         # No filtering - access to all records
-        scope :always, true, description: "All records without restriction"
+        scope :always, true
 
         # Filter to records owned by the actor
-        scope :own, expr(author_id == ^actor(:id)),
-          description: "Records owned by the current user"
+        scope :own, expr(author_id == ^actor(:id))
 
-        # Filter to published records
+        # Description via keyword option
         scope :published, expr(status == :published),
           description: "Published records visible to everyone"
 
-        # Inheritance: combines parent scope(s) with this filter
-        scope :own_draft, [:own], expr(status == :draft),
-          description: "User's own records that are in draft status"
+        # Description via do-block
+        scope :own, expr(author_id == ^actor(:id)) do
+          description "Records owned by the current user"
+        end
+
+        # Combine conditions directly — scopes don't inherit
+        scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
 
         # Context injection for testable temporal scopes
         scope :today, expr(fragment("DATE(inserted_at) = ?", ^context(:reference_date))),
@@ -182,8 +184,8 @@ defmodule AshGrant.Dsl do
         # Relational scope — DB query fallback handles writes automatically
         scope :team_member, expr(exists(team.members, user_id == ^actor(:id)))
 
-        # Description is optional - backward compatible
-        scope :archived, expr(status == :archived)
+    Each scope is standalone: if you want a combined filter, write the combined
+    expression directly with `and`.
 
     For multi-hop authorization (e.g., "refund.order.center_id"), prefer
     argument-based scopes paired with `resolve_argument`:
@@ -197,14 +199,14 @@ defmodule AshGrant.Dsl do
       "scope :always, true",
       "scope :own, expr(author_id == ^actor(:id))",
       "scope :published, expr(status == :published)",
-      "scope :own_draft, [:own], expr(status == :draft)",
+      "scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)",
       ~s|scope :today, expr(fragment("DATE(inserted_at) = ?", ^context(:reference_date)))|,
       ~s|scope :own, expr(author_id == ^actor(:id)), description: "Records owned by the current user"|,
       "scope :team_member, expr(exists(team.members, user_id == ^actor(:id)))",
       "scope :at_own_unit, expr(^arg(:center_id) in ^actor(:own_org_unit_ids))"
     ],
     target: AshGrant.Dsl.Scope,
-    args: [:name, {:optional, :inherits}, :filter],
+    args: [:name, :filter],
     deprecations: [
       write:
         "`write:` is deprecated. Prefer argument-based scopes + `resolve_argument` " <>
@@ -216,10 +218,6 @@ defmodule AshGrant.Dsl do
         type: :atom,
         required: true,
         doc: "The name of the scope"
-      ],
-      inherits: [
-        type: {:list, :atom},
-        doc: "List of parent scopes to inherit from"
       ],
       filter: [
         type: {:or, [:boolean, :any]},
@@ -607,17 +605,15 @@ defmodule AshGrant.Dsl.Scope do
   ## Fields
 
   - `:name` - The atom name of the scope (e.g., `:own`, `:published`)
-  - `:inherits` - List of parent scope names to inherit from
   - `:filter` - The filter expression (`true` for no filtering, or an Ash.Expr)
   - `:write` - **Deprecated.** Optional write-specific expression. Prefer argument-based scopes with `resolve_argument`.
   - `:description` - Optional human-readable description for debugging/explain
   """
 
-  defstruct [:name, :inherits, :filter, :write, :description, :__spark_metadata__]
+  defstruct [:name, :filter, :write, :description, :__spark_metadata__]
 
   @type t :: %__MODULE__{
           name: atom(),
-          inherits: [atom()] | nil,
           filter: boolean() | Ash.Expr.t(),
           write: boolean() | Ash.Expr.t() | nil,
           description: String.t() | nil,

--- a/lib/ash_grant/info.ex
+++ b/lib/ash_grant/info.ex
@@ -227,7 +227,6 @@ defmodule AshGrant.Info do
   Resolves a scope to its read filter expression.
 
   Uses the scope's `filter` field (ignoring any `write:` option).
-  If the scope has inheritance, the parent scopes are combined with AND.
   Returns `false` for unknown scopes.
 
   For write action scope resolution, use `resolve_write_scope_filter/3` instead.
@@ -243,7 +242,7 @@ defmodule AshGrant.Info do
         end
 
       scope ->
-        resolve_scope_with_inheritance(resource, scope, context)
+        scope.filter
     end
   end
 
@@ -255,13 +254,6 @@ defmodule AshGrant.Info do
   when relationship traversal (exists/dot-paths) cannot be evaluated in-memory.
 
   Returns `false` for unknown scopes, or when `write: false` is explicitly set.
-
-  ## Resolution Order
-
-  1. If scope has `write:` set → use `write` value (`false`, `true`, or expression)
-  2. If scope has no `write:` → fall back to `scope.filter` (backward compatible)
-  3. Inheritance: parent `write:` values are resolved recursively and combined with AND
-  4. If any parent returns `false` → short-circuit to `false` (deny propagation)
 
   ## Examples
 
@@ -287,7 +279,7 @@ defmodule AshGrant.Info do
         end
 
       scope ->
-        resolve_write_scope_with_inheritance(resource, scope, context)
+        if scope.write == nil, do: scope.filter, else: scope.write
     end
   end
 
@@ -356,77 +348,5 @@ defmodule AshGrant.Info do
 
   defp resolve_with_legacy_resolver(resolver, scope, context) when is_atom(resolver) do
     resolver.resolve(scope, context)
-  end
-
-  defp resolve_scope_with_inheritance(resource, scope, context) do
-    # First, get the base filter for this scope
-    base_filter = scope.filter
-
-    # If there's inheritance, combine with parent scope(s)
-    case scope.inherits do
-      nil ->
-        base_filter
-
-      [] ->
-        base_filter
-
-      parent_names when is_list(parent_names) ->
-        parent_filters =
-          parent_names
-          |> Enum.map(&resolve_scope_filter(resource, &1, context))
-          |> Enum.reject(&(&1 == true))
-
-        case {parent_filters, base_filter} do
-          {[], filter} ->
-            filter
-
-          {filters, true} ->
-            combine_filters_with_and(filters)
-
-          {filters, filter} ->
-            combine_filters_with_and(filters ++ [filter])
-        end
-    end
-  end
-
-  defp resolve_write_scope_with_inheritance(resource, scope, context) do
-    base_filter = if scope.write == nil, do: scope.filter, else: scope.write
-
-    if base_filter == false do
-      false
-    else
-      resolve_write_parents(resource, scope.inherits, base_filter, context)
-    end
-  end
-
-  defp resolve_write_parents(_resource, nil, base_filter, _context), do: base_filter
-  defp resolve_write_parents(_resource, [], base_filter, _context), do: base_filter
-
-  defp resolve_write_parents(resource, parent_names, base_filter, context) do
-    parent_filters = Enum.map(parent_names, &resolve_write_scope_filter(resource, &1, context))
-
-    if Enum.any?(parent_filters, &(&1 == false)) do
-      false
-    else
-      merge_parent_and_base_filters(parent_filters, base_filter)
-    end
-  end
-
-  defp merge_parent_and_base_filters(parent_filters, base_filter) do
-    non_true_filters = Enum.reject(parent_filters, &(&1 == true))
-
-    case {non_true_filters, base_filter} do
-      {[], filter} -> filter
-      {filters, true} -> combine_filters_with_and(filters)
-      {filters, filter} -> combine_filters_with_and(filters ++ [filter])
-    end
-  end
-
-  defp combine_filters_with_and([single]), do: single
-
-  defp combine_filters_with_and([first | rest]) do
-    Enum.reduce(rest, first, fn filter, acc ->
-      Ash.Expr.expr(^acc and ^filter)
-    end)
   end
 end

--- a/lib/ash_grant/transformers/add_argument_resolvers.ex
+++ b/lib/ash_grant/transformers/add_argument_resolvers.ex
@@ -69,59 +69,13 @@ defmodule AshGrant.Transformers.AddArgumentResolvers do
     |> Transformer.get_entities([:ash_grant])
     |> Enum.filter(&match?(%AshGrant.Dsl.Scope{}, &1))
     |> Enum.reduce(%{}, fn scope, acc ->
-      resolved = resolve_scope_in_dsl(dsl_state, scope)
-      args = ArgumentAnalyzer.referenced_args(resolved)
+      expr = if scope.write == nil, do: scope.filter, else: scope.write
+      args = ArgumentAnalyzer.referenced_args(expr)
 
       Enum.reduce(args, acc, fn arg, inner ->
         Map.update(inner, arg, [scope.name], &Enum.uniq([scope.name | &1]))
       end)
     end)
-  end
-
-  # Resolve a scope's filter with inheritance from the in-progress DSL state.
-  defp resolve_scope_in_dsl(dsl_state, %AshGrant.Dsl.Scope{} = scope) do
-    base = if scope.write == nil, do: scope.filter, else: scope.write
-
-    case base do
-      false ->
-        false
-
-      _ ->
-        parents = scope.inherits || []
-
-        parent_filters =
-          Enum.map(parents, fn parent_name ->
-            find_scope(dsl_state, parent_name)
-            |> case do
-              nil -> true
-              parent -> resolve_scope_in_dsl(dsl_state, parent)
-            end
-          end)
-
-        combine(parent_filters, base)
-    end
-  end
-
-  defp find_scope(dsl_state, name) do
-    dsl_state
-    |> Transformer.get_entities([:ash_grant])
-    |> Enum.find(&(match?(%AshGrant.Dsl.Scope{}, &1) and &1.name == name))
-  end
-
-  defp combine(parent_filters, base) do
-    non_true = Enum.reject(parent_filters, &(&1 == true))
-
-    case {non_true, base} do
-      {[], filter} -> filter
-      {filters, true} -> and_all(filters)
-      {filters, filter} -> and_all(filters ++ [filter])
-    end
-  end
-
-  defp and_all([single]), do: single
-
-  defp and_all([first | rest]) do
-    Enum.reduce(rest, first, fn f, acc -> Ash.Expr.expr(^acc and ^f) end)
   end
 
   defp validate_referenced_by_scope(%{name: name} = decl, arg_map, resource) do

--- a/test/ash_grant/domain_inheritance_test.exs
+++ b/test/ash_grant/domain_inheritance_test.exs
@@ -120,29 +120,26 @@ defmodule AshGrant.DomainInheritanceTest do
     end
   end
 
-  # ── cross-boundary scope inheritance ─────────────────────
+  # ── cross-boundary scope merging ─────────────────────────
 
-  describe "cross-boundary scope inheritance" do
-    test "resource scope inherits from domain-defined parent" do
-      scope = Info.get_scope(DomainCrossInheritPost, :own_draft)
-      assert scope.inherits == [:own]
-
-      # :own must be present (merged from domain)
+  describe "cross-boundary scope merging" do
+    test "domain scopes merge into resource alongside resource-defined scopes" do
+      # :own comes from domain, :own_draft is resource-defined
       assert Info.get_scope(DomainCrossInheritPost, :own) != nil
+      assert Info.get_scope(DomainCrossInheritPost, :own_draft) != nil
     end
 
-    test "resolve_scope_filter combines parent and child" do
+    test "resolve_scope_filter returns the resource-defined combined expression" do
       filter_str =
         DomainCrossInheritPost
         |> Info.resolve_scope_filter(:own_draft, %{})
         |> inspect()
 
-      # :own (author_id) AND :own_draft (status == :draft)
       assert filter_str =~ "author_id"
       assert filter_str =~ "status"
     end
 
-    test "resolve_write_scope_filter works with domain-inherited parent" do
+    test "resolve_write_scope_filter returns the same combined expression" do
       filter_str =
         DomainCrossInheritPost
         |> Info.resolve_write_scope_filter(:own_draft, %{})
@@ -370,7 +367,7 @@ defmodule AshGrant.DomainInheritanceTest do
     end
   end
 
-  describe "e2e: cross-boundary scope inheritance" do
+  describe "e2e: cross-boundary scope merging" do
     test "own_draft scope filters by author + draft status" do
       me = Ash.UUID.generate()
       other = Ash.UUID.generate()

--- a/test/ash_grant/explain_test.exs
+++ b/test/ash_grant/explain_test.exs
@@ -49,13 +49,13 @@ defmodule AshGrant.ExplainTest do
 
       resource_name("post")
 
-      scope(:always, [], true, description: "All records without restriction")
+      scope(:always, true, description: "All records without restriction")
 
-      scope(:own, [], expr(author_id == ^actor(:id)),
+      scope(:own, expr(author_id == ^actor(:id)),
         description: "Records owned by the current user"
       )
 
-      scope(:published, [], expr(status == :published),
+      scope(:published, expr(status == :published),
         description: "Published records visible to everyone"
       )
     end

--- a/test/ash_grant/policy_test/edge_cases_test.exs
+++ b/test/ash_grant/policy_test/edge_cases_test.exs
@@ -79,7 +79,7 @@ defmodule AshGrant.PolicyTest.EdgeCasesTest do
   end
 
   describe "scope inheritance" do
-    # Post has: scope(:own_draft, [:own], expr(status == :draft))
+    # Post has: scope(:own_draft, expr(author_id == ^actor(:id) and status == :draft))
     # which inherits from :own
     test "inherited scope combines filters with AND" do
       # Editor with own_draft permission needs BOTH own AND draft

--- a/test/ash_grant/scope_dsl_test.exs
+++ b/test/ash_grant/scope_dsl_test.exs
@@ -14,9 +14,9 @@ defmodule AshGrant.ScopeDslTest do
     ash_grant do
       resolver(fn _actor, _context -> [] end)
 
-      scope(:always, [], true, description: "All records without restriction")
+      scope(:always, true, description: "All records without restriction")
 
-      scope(:published, [], expr(status == :published),
+      scope(:published, expr(status == :published),
         description: "Published posts visible to everyone"
       )
 
@@ -27,29 +27,6 @@ defmodule AshGrant.ScopeDslTest do
       uuid_primary_key(:id)
       attribute(:title, :string, public?: true)
       attribute(:status, :atom, constraints: [one_of: [:draft, :published]])
-      attribute(:author_id, :uuid)
-    end
-  end
-
-  # Test resource with inherited scope
-  defmodule TestComment do
-    use Ash.Resource,
-      domain: nil,
-      validate_domain_inclusion?: false,
-      extensions: [AshGrant]
-
-    ash_grant do
-      resolver(fn _actor, _context -> [] end)
-
-      scope(:always, true)
-      scope(:pending, expr(status == :pending))
-      scope(:always_pending, [:always], expr(status == :pending))
-    end
-
-    attributes do
-      uuid_primary_key(:id)
-      attribute(:body, :string, public?: true)
-      attribute(:status, :atom, constraints: [one_of: [:pending, :approved]])
       attribute(:author_id, :uuid)
     end
   end
@@ -71,8 +48,6 @@ defmodule AshGrant.ScopeDslTest do
 
       assert all_scope.name == :always
       assert all_scope.filter == true
-      # inherits can be nil or empty list when not specified
-      assert all_scope.inherits in [nil, []]
     end
 
     test "scope can have expression filter" do
@@ -82,16 +57,6 @@ defmodule AshGrant.ScopeDslTest do
       assert published_scope.name == :published
       assert published_scope.filter != nil
       refute published_scope.filter == true
-    end
-  end
-
-  describe "scope inheritance" do
-    test "scope can inherit from another scope" do
-      scopes = Info.scopes(TestComment)
-      always_pending_scope = Enum.find(scopes, &(&1.name == :always_pending))
-
-      assert always_pending_scope.name == :always_pending
-      assert always_pending_scope.inherits == [:always]
     end
   end
 
@@ -123,13 +88,6 @@ defmodule AshGrant.ScopeDslTest do
       filter = Info.resolve_scope_filter(TestPost, :unknown, %{})
       assert filter == false
     end
-
-    test "combines inherited scope with own filter" do
-      filter = Info.resolve_scope_filter(TestComment, :always_pending, %{})
-      # :always is true, so result should just be the pending filter
-      assert filter != nil
-      refute filter == true
-    end
   end
 
   describe "scope description" do
@@ -154,6 +112,52 @@ defmodule AshGrant.ScopeDslTest do
 
     test "Info.scope_description/2 returns nil for unknown scope" do
       assert Info.scope_description(TestPost, :unknown) == nil
+    end
+  end
+
+  describe "scope do-block form" do
+    defmodule DoBlockPost do
+      use Ash.Resource,
+        domain: nil,
+        validate_domain_inclusion?: false,
+        extensions: [AshGrant]
+
+      ash_grant do
+        resolver(fn _actor, _context -> [] end)
+
+        scope :always, true do
+          description("All records without restriction")
+        end
+
+        scope :own, expr(author_id == ^actor(:id)) do
+          description("Records owned by the current user")
+        end
+
+        scope(:no_description, expr(status == :published))
+      end
+
+      attributes do
+        uuid_primary_key(:id)
+        attribute(:status, :atom, constraints: [one_of: [:draft, :published]])
+        attribute(:author_id, :uuid)
+      end
+    end
+
+    test "description set via do-block is preserved" do
+      assert Info.get_scope(DoBlockPost, :always).description ==
+               "All records without restriction"
+
+      assert Info.get_scope(DoBlockPost, :own).description ==
+               "Records owned by the current user"
+    end
+
+    test "do-block description is optional" do
+      assert Info.get_scope(DoBlockPost, :no_description).description == nil
+    end
+
+    test "Info.scope_description/2 returns do-block description" do
+      assert Info.scope_description(DoBlockPost, :own) ==
+               "Records owned by the current user"
     end
   end
 end

--- a/test/ash_grant/temporal_scope_test.exs
+++ b/test/ash_grant/temporal_scope_test.exs
@@ -122,14 +122,19 @@ defmodule AshGrant.TemporalScopeTest do
       # Today's transactions
       scope(:today, expr(fragment("DATE(inserted_at) = CURRENT_DATE")))
 
-      # Combined: own + today (using inheritance)
-      scope(:own_today, [:own], expr(fragment("DATE(inserted_at) = CURRENT_DATE")))
+      # Combined: own + today
+      scope(
+        :own_today,
+        expr(user_id == ^actor(:id) and fragment("DATE(inserted_at) = CURRENT_DATE"))
+      )
 
       # Own transactions from this week
       scope(
         :own_this_week,
-        [:own],
-        expr(fragment("inserted_at >= DATE_TRUNC('week', CURRENT_DATE)"))
+        expr(
+          user_id == ^actor(:id) and
+            fragment("inserted_at >= DATE_TRUNC('week', CURRENT_DATE)")
+        )
       )
     end
 
@@ -190,7 +195,7 @@ defmodule AshGrant.TemporalScopeTest do
   end
 
   describe "combined temporal + ownership scopes" do
-    test "defines combined scopes with inheritance" do
+    test "defines combined scopes" do
       scopes = Info.scopes(Transaction)
       scope_names = Enum.map(scopes, & &1.name)
 
@@ -200,20 +205,7 @@ defmodule AshGrant.TemporalScopeTest do
       assert :own_this_week in scope_names
     end
 
-    test "own_today inherits from own" do
-      scope = Info.get_scope(Transaction, :own_today)
-
-      assert scope.inherits == [:own]
-      refute scope.filter == true
-    end
-
-    test "own_this_week inherits from own" do
-      scope = Info.get_scope(Transaction, :own_this_week)
-
-      assert scope.inherits == [:own]
-    end
-
-    test "resolve_scope_filter combines inherited scope" do
+    test "resolve_scope_filter returns the combined expression" do
       filter = Info.resolve_scope_filter(Transaction, :own_today, %{})
 
       # Should return a filter (not true or false)

--- a/test/ash_grant/write_scope_deprecation_test.exs
+++ b/test/ash_grant/write_scope_deprecation_test.exs
@@ -26,7 +26,7 @@ defmodule AshGrant.WriteScopeDeprecationTest do
 
           ash_grant do
             resolver(fn _, _ -> [] end)
-            scope(:readonly, [], expr(author_id == ^actor(:id)), write: false)
+            scope(:readonly, expr(author_id == ^actor(:id)), write: false)
           end
 
           attributes do

--- a/test/ash_grant/write_scope_test.exs
+++ b/test/ash_grant/write_scope_test.exs
@@ -4,7 +4,7 @@ defmodule AshGrant.WriteScopeTest do
 
   Covers:
   - DSL: `write:` option on scope entity
-  - Info: `resolve_write_scope_filter/3` with fallback and inheritance
+  - Info: `resolve_write_scope_filter/3` with fallback to `filter`
   - Check: write actions use write scope resolution
   - FilterCheck: read actions are unaffected (still use `filter`)
   - Transformer: warnings for relationship scopes without `write:`
@@ -38,18 +38,18 @@ defmodule AshGrant.WriteScopeTest do
       scope(:always, true)
 
       # Same expression for read and write (simple ownership)
-      scope(:own, [], expr(author_id == ^actor(:id)), write: expr(author_id == ^actor(:id)))
+      scope(:own, expr(author_id == ^actor(:id)), write: expr(author_id == ^actor(:id)))
 
       # Different expressions: read uses equality, write uses `in` list
-      scope(:team_visible, [], expr(team_id == ^actor(:team_id)),
+      scope(:team_visible, expr(team_id == ^actor(:team_id)),
         write: expr(team_id in ^actor(:team_ids))
       )
 
       # Explicitly deny writes
-      scope(:readonly, [], expr(status == :published), write: false)
+      scope(:readonly, expr(status == :published), write: false)
 
       # Explicitly allow all writes (write: true)
-      scope(:write_all, [], expr(status == :draft), write: true)
+      scope(:write_all, expr(status == :draft), write: true)
 
       # No write: option — should fall back to filter
       scope(:simple, expr(status == :draft))
@@ -60,62 +60,6 @@ defmodule AshGrant.WriteScopeTest do
       attribute(:title, :string, public?: true)
       attribute(:status, :atom, constraints: [one_of: [:draft, :published]])
       attribute(:author_id, :uuid)
-      attribute(:team_id, :uuid)
-    end
-  end
-
-  # Resource with write scope inheritance scenarios:
-  # - :team          → parent with write: expr(...)
-  # - :team_draft    → child inherits parent write, no own write:
-  # - :team_blog     → child inherits parent write, has own write:
-  # - :readonly_base → parent with write: false
-  # - :readonly_child → child inherits parent's write: false (propagation)
-  # - :deny_child    → child with write: false, parent with write: expr
-  # - :always_draft     → inherits from :always (filter=true)
-  # - :multi_parent  → inherits from multiple parents
-  # - :simple_scope  → no write: (used as second parent in multi_parent)
-  defmodule InheritedWritePost do
-    use Ash.Resource,
-      domain: nil,
-      validate_domain_inclusion?: false,
-      extensions: [AshGrant]
-
-    ash_grant do
-      resolver(fn _actor, _context -> [] end)
-
-      scope(:always, true)
-
-      # Parent with write expression
-      scope(:team, [], expr(team_id == ^actor(:team_id)),
-        write: expr(team_id in ^actor(:team_ids))
-      )
-
-      # Child inherits from :team — no own write:, should use parent's write + own filter
-      scope(:team_draft, [:team], expr(status == :draft))
-
-      # Child inherits from :team AND has its own write:
-      scope(:team_blog, [:team], expr(category == :blog), write: expr(category == :blog))
-
-      # Parent with write: false — should propagate to children
-      scope(:readonly_base, [], expr(status == :published), write: false)
-
-      scope(:readonly_child, [:readonly_base], expr(category == :blog))
-
-      # Child with write: false, parent with write expression
-      scope(:deny_child, [:team], expr(status == :archived), write: false)
-
-      # Parent with all scope (true filter, no write: → fallback to true)
-      scope(:always_draft, [:always], expr(status == :draft))
-
-      # Multiple parents: one has write:, one doesn't
-      scope(:simple_scope, expr(category == :news))
-      scope(:multi_parent, [:team, :simple_scope], expr(status == :draft))
-    end
-
-    attributes do
-      uuid_primary_key(:id)
-      attribute(:status, :atom, constraints: [one_of: [:draft, :published, :archived]])
-      attribute(:category, :atom, constraints: [one_of: [:blog, :news]])
       attribute(:team_id, :uuid)
     end
   end
@@ -154,7 +98,6 @@ defmodule AshGrant.WriteScopeTest do
       assert Map.has_key?(scope, :name)
       assert Map.has_key?(scope, :filter)
       assert Map.has_key?(scope, :write)
-      assert Map.has_key?(scope, :inherits)
       assert Map.has_key?(scope, :description)
     end
   end
@@ -188,18 +131,6 @@ defmodule AshGrant.WriteScopeTest do
       # Read filter should be expr(status == :draft), not true
       refute filter == true
       assert inspect(filter) =~ "status"
-    end
-
-    test "inherited read path ignores parent write: option" do
-      # :team_draft inherits from :team. Read path should use parent's filter,
-      # not parent's write expression
-      filter = Info.resolve_scope_filter(InheritedWritePost, :team_draft, %{})
-      filter_str = inspect(filter)
-      # Should contain team_id (from parent filter) and status (from own filter)
-      assert filter_str =~ "team_id"
-      assert filter_str =~ "status"
-      # Read path uses equality from parent, not `in`
-      refute filter_str =~ ":in"
     end
   end
 
@@ -258,86 +189,6 @@ defmodule AshGrant.WriteScopeTest do
   end
 
   # ============================================================
-  # Write path: inheritance
-  # ============================================================
-
-  describe "resolve_write_scope_filter/3 inheritance" do
-    test "child inherits parent's write expression (not parent's read filter)" do
-      # :team_draft inherits from :team which has:
-      #   filter: team_id == ^actor(:team_id)
-      #   write:  team_id in ^actor(:team_ids)
-      # :team_draft has no write:, own filter is status == :draft
-      # Expected: parent's WRITE expr AND child's filter
-      filter = Info.resolve_write_scope_filter(InheritedWritePost, :team_draft, %{})
-      refute filter == false
-      refute filter == true
-
-      filter_str = inspect(filter)
-      # Should contain the `in` operator from parent's write (not equality from read)
-      assert filter_str =~ "team_ids" or filter_str =~ ":in"
-      # Should also contain the child's own filter
-      assert filter_str =~ "status"
-    end
-
-    test "child with own write: overrides fallback to filter" do
-      # :team_blog inherits from :team, has its own write: expr(category == :blog)
-      # Expected: parent's write AND child's write
-      filter = Info.resolve_write_scope_filter(InheritedWritePost, :team_blog, %{})
-      refute filter == false
-      refute filter == true
-
-      filter_str = inspect(filter)
-      assert filter_str =~ "team_id" or filter_str =~ "team_ids"
-      assert filter_str =~ "category"
-    end
-
-    test "parent write: false propagates to child" do
-      # :readonly_child inherits from :readonly_base which has write: false
-      assert Info.resolve_write_scope_filter(InheritedWritePost, :readonly_child, %{}) == false
-    end
-
-    test "child write: false overrides parent's write expression" do
-      # :deny_child inherits from :team (has write: expr(...)), but has write: false
-      assert Info.resolve_write_scope_filter(InheritedWritePost, :deny_child, %{}) == false
-    end
-
-    test "inheriting from :always (filter=true, no write) works" do
-      # :always_draft inherits from :always (true). Parent write fallback = true (skipped).
-      # Result should be child's own filter (status == :draft)
-      filter = Info.resolve_write_scope_filter(InheritedWritePost, :always_draft, %{})
-      refute filter == true
-      refute filter == false
-      assert inspect(filter) =~ "status"
-    end
-
-    test "multiple parents: write expressions are combined with AND" do
-      # :multi_parent inherits from [:team, :simple_scope]
-      # :team has write: expr(team_id in ^actor(:team_ids))
-      # :simple_scope has no write: → fallback to filter: category == :news
-      # :multi_parent own filter is status == :draft (no write:)
-      # Expected: team_write AND simple_filter AND own_filter
-      filter = Info.resolve_write_scope_filter(InheritedWritePost, :multi_parent, %{})
-      refute filter == false
-      refute filter == true
-
-      filter_str = inspect(filter)
-      assert filter_str =~ "team_id" or filter_str =~ "team_ids"
-    end
-
-    test "parent write expression is used, not parent read filter" do
-      # Verify the parent's write expression is actually different from read
-      team_write = Info.resolve_write_scope_filter(InheritedWritePost, :team, %{})
-      team_read = Info.resolve_scope_filter(InheritedWritePost, :team, %{})
-
-      refute inspect(team_write) == inspect(team_read)
-
-      # Write should use `in`, read should use equality
-      assert inspect(team_write) =~ "team_ids" or inspect(team_write) =~ ":in"
-      refute inspect(team_read) =~ "team_ids"
-    end
-  end
-
-  # ============================================================
   # Check integration: write scope values flow correctly to Check
   # ============================================================
 
@@ -384,17 +235,6 @@ defmodule AshGrant.WriteScopeTest do
       assert write_str =~ "team_ids"
       # Read should reference team_id (singular — the equality field)
       refute read_str =~ "team_ids"
-    end
-
-    test "inherited write expression combines parent write and child filter" do
-      filter = Info.resolve_write_scope_filter(InheritedWritePost, :team_draft, %{})
-      filter_str = inspect(filter)
-
-      # Must be a combined AND expression with:
-      # - parent's write: team_id in ^actor(:team_ids)
-      # - child's filter: status == :draft
-      assert filter_str =~ "team_ids" or filter_str =~ ":in"
-      assert filter_str =~ "status" or filter_str =~ "draft"
     end
   end
 

--- a/test/support/resources/bulk_item.ex
+++ b/test/support/resources/bulk_item.ex
@@ -43,22 +43,28 @@ defmodule AshGrant.Test.BulkItem do
 
     scope(:always, true)
     scope(:own, expr(author_id == ^actor(:id)))
-    scope(:team_member, [], expr(exists(team.memberships, user_id == ^actor(:id))))
+    scope(:team_member, expr(exists(team.memberships, user_id == ^actor(:id))))
 
     scope(
       :own_in_team,
-      [],
       expr(author_id == ^actor(:id) and exists(team.memberships, user_id == ^actor(:id)))
     )
 
-    scope(:named_team, [], expr(team.name == ^actor(:team_name)))
+    scope(:named_team, expr(team.name == ^actor(:team_name)))
 
-    # Composite scopes: inherit from a relational parent + add direct-attribute check.
-    # These reproduce a bug where should_use_db_query? checks only the child's own
-    # filter (no relationship ref) instead of the resolved filter (with inherited
-    # relationship refs), causing in-memory eval to fail on create actions.
-    scope(:team_member_and_own, [:team_member], expr(author_id == ^actor(:id)))
-    scope(:named_team_and_own, [:named_team], expr(author_id == ^actor(:id)))
+    # Composite scopes: combine a relational parent + direct-attribute check.
+    # These reproduce a bug where should_use_db_query? checks only the direct-attr
+    # part of the filter (no relationship ref) and causes in-memory eval to fail
+    # on create actions when the real filter traverses relationships.
+    scope(
+      :team_member_and_own,
+      expr(author_id == ^actor(:id) and exists(team.memberships, user_id == ^actor(:id)))
+    )
+
+    scope(
+      :named_team_and_own,
+      expr(author_id == ^actor(:id) and team.name == ^actor(:team_name))
+    )
   end
 
   attributes do

--- a/test/support/resources/domain_cross_inherit_post.ex
+++ b/test/support/resources/domain_cross_inherit_post.ex
@@ -9,8 +9,7 @@ defmodule AshGrant.Test.DomainCrossInheritPost do
   ash_grant do
     default_policies(true)
 
-    # Inherits from :own which is defined at domain level
-    scope(:own_draft, [:own], expr(status == :draft))
+    scope(:own_draft, expr(author_id == ^actor(:id) and status == :draft))
   end
 
   attributes do

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -29,7 +29,7 @@ defmodule AshGrant.Test.Post do
     scope(:own, expr(author_id == ^actor(:id)))
     scope(:published, expr(status == :published))
     scope(:draft, expr(status == :draft))
-    scope(:own_draft, [:own], expr(status == :draft))
+    scope(:own_draft, expr(author_id == ^actor(:id) and status == :draft))
     scope(:today, expr(fragment("DATE(inserted_at) = CURRENT_DATE")))
 
     # Injectable temporal scope - uses context for testability

--- a/test/support/resources/shared_document.ex
+++ b/test/support/resources/shared_document.ex
@@ -63,8 +63,12 @@ defmodule AshGrant.Test.SharedDocument do
 
     # Multi-tenant scopes
     scope(:tenant, expr(tenant_id == ^actor(:tenant_id)))
-    scope(:tenant_active, [:tenant], expr(status == :active))
-    scope(:tenant_own, [:tenant], expr(created_by_id == ^actor(:id)))
+    scope(:tenant_active, expr(tenant_id == ^actor(:tenant_id) and status == :active))
+
+    scope(
+      :tenant_own,
+      expr(tenant_id == ^actor(:tenant_id) and created_by_id == ^actor(:id))
+    )
 
     # Status scopes
     scope(:active, expr(status == :active))

--- a/test/support/resources/tenant_post.ex
+++ b/test/support/resources/tenant_post.ex
@@ -71,7 +71,7 @@ defmodule AshGrant.Test.TenantPost do
     scope(:always, true)
     scope(:same_tenant, expr(tenant_id == ^tenant()))
     scope(:own, expr(author_id == ^actor(:id)))
-    scope(:own_in_tenant, [:same_tenant], expr(author_id == ^actor(:id)))
+    scope(:own_in_tenant, expr(tenant_id == ^tenant() and author_id == ^actor(:id)))
   end
 
   attributes do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -182,13 +182,17 @@ When a user has `"feed:feed_abc:read:"`, they can read all posts where
 
 ```elixir
 scope :name, filter_expression
-scope :name, [:parent_scopes], filter_expression
 scope :name, filter_expression, description: "Human-readable text"
+
+scope :name, filter_expression do
+  description "Human-readable text"
+end
 ```
 
 - Use `true` for a scope that matches all records (no filtering).
 - Use `expr(...)` for attribute-based filtering.
-- Use the optional second argument (list of atoms) to inherit from parent scopes.
+- Scopes do **not** inherit from other scopes — combine conditions directly
+  with `and` in the expression.
 - `write:` option exists but is **deprecated** (see "DON'T: Use the `write:`
   scope option" below) — prefer `resolve_argument` for multi-hop cases.
 
@@ -199,7 +203,7 @@ ash_grant do
   scope :always, true
   scope :own, expr(author_id == ^actor(:id))
   scope :published, expr(status == :published)
-  scope :own_draft, [:own], expr(status == :draft)  # own AND draft
+  scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
   scope :same_tenant, expr(tenant_id == ^tenant())  # Multi-tenancy
 end
 ```
@@ -321,15 +325,22 @@ scope :today, expr(fragment("DATE(inserted_at) = ?", ^context(:reference_date)))
 scope :today, expr(fragment("DATE(inserted_at) = CURRENT_DATE"))
 ```
 
-### Scope inheritance
+### DO: Combine conditions inline rather than via scope inheritance
 
-Child scopes combine parent filters with AND logic:
+Scopes are standalone. If multiple conditions must all hold, write them with
+`and` in one expression:
 
 ```elixir
+# DO
 scope :own, expr(author_id == ^actor(:id))
-scope :own_draft, [:own], expr(status == :draft)
-# Effective filter: author_id == ^actor(:id) AND status == :draft
+scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
+
+# DON'T — `inherits` is not supported
+# scope :own_draft, expr(status == :draft), inherits: [:own]
 ```
+
+Multiple permissions on the same action are still OR'd together by the
+policy layer — use that for disjunctive access.
 
 ## Check Types
 


### PR DESCRIPTION
## Summary

Removes `inherits` from the scope DSL and enables a do-block form for setting `description` (and any future scope option):

```elixir
scope :my_scope_name, expr(...) do
  description "This is important"
end
```

**Breaking change**: `inherits` is gone. The old positional form (`scope :own_draft, [:own], expr(status == :draft)`) and the keyword form (`scope :name, expr(...), inherits: [:parent]`) no longer compile. Write each scope as one expression:

```elixir
# Before
scope :own, expr(author_id == ^actor(:id))
scope :own_draft, [:own], expr(status == :draft)

# After
scope :own, expr(author_id == ^actor(:id))
scope :own_draft, expr(author_id == ^actor(:id) and status == :draft)
```

Why: scope inheritance added hidden coupling (child behaviour depended on parent filters that might live in a different module), interacted awkwardly with `write:` and argument-based scopes, and — because `inherits` was an optional positional arg — blocked `scope` from supporting Spark do-blocks at all. Inlining with `and` is mechanically trivial, reads plainly, and shows up straight in `AshGrant.explain/4`.

Domain-level scope merging is unchanged — a resource still sees scopes defined on its domain. Only scope-to-scope inheritance is removed.

### Net change

Net −191 LoC across lib/. Info's `resolve_scope_filter/3` is now a direct lookup; `AddArgumentResolvers` lost the recursive DSL-state walker.

### Docs

- `usage-rules.md`: scope entity section updated, inheritance rule replaced with "combine inline" DO.
- `README.md`, `guides/scopes.md`, `guides/authorization-patterns.md`, `guides/scope-naming-convention.md`, `guides/getting-started.md`, `guides/advanced-patterns.md`: removed inheritance references, updated examples.
- `guides/migration.md`: new section explaining the removal and migration path.
- `CHANGELOG.md` (Unreleased): breaking change + added do-block form.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test` — 1045 tests pass (1 pre-existing failure in `default_field_policies_test.exs`, unrelated)
- [x] `mix format --check-formatted` clean
- [x] `mix credo` — only pre-existing non-blocking suggestions
- [x] Test resources and guide examples all compile after inlining combined filters
- [x] Do-block form verified via new tests in `test/ash_grant/scope_dsl_test.exs`