### PR TITLE
feat: declarative grants DSL with compile-time verification

### DIFF
--- a/lib/ash_grant.ex
+++ b/lib/ash_grant.ex
@@ -309,8 +309,13 @@ defmodule AshGrant do
 
   use Spark.Dsl.Extension,
     sections: AshGrant.Dsl.sections(),
+    verifiers: [
+      AshGrant.Verifiers.ValidateGrantReferences
+    ],
     transformers: [
       AshGrant.Transformers.MergeDomainConfig,
+      AshGrant.Transformers.NormalizeGrants,
+      AshGrant.Transformers.SynthesizeGrantsResolver,
       AshGrant.Transformers.ValidateResolverPresent,
       AshGrant.Transformers.ValidateScopes,
       AshGrant.Transformers.ValidateScopeThroughs,

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -446,10 +446,203 @@ defmodule AshGrant.Dsl do
     ]
   }
 
+  @permission %Spark.Dsl.Entity{
+    name: :permission,
+    describe: """
+    Declares a single permission within a `grant`.
+
+    Positional form: `permission :name, :action, :scope`. The target resource
+    is inferred from the enclosing resource's `ash_grant` block, or supplied
+    via `on:`. Instance defaults to `:*` (RBAC) and can be set with the
+    `instance:` keyword option.
+
+    `AshGrant.Verifiers.ValidateGrantReferences` runs at compile time and
+    checks that `on` is an `Ash.Resource`, that `action` exists on it (or is
+    `:*`), and that `scope` is defined in its `ash_grant` block.
+
+    ## Examples
+
+        permission :read_all_posts, :read, :always
+        permission :update_own, :update, :own, purpose: :content_management
+        permission :audit_access, :read, :always, purposes: [:audit, :compliance]
+
+        # Cross-resource (e.g. from a domain-level grant)
+        permission :read_comments, :read, :always, on: Blog.Comment
+
+        permission :read_tickets, :read, :assigned do
+          description "Read tickets assigned to this agent"
+          purpose :ticket_triage
+        end
+
+    For deny rules, pass `deny: true`:
+
+        permission :block_archived_destroy, :destroy, :archived, deny: true
+    """,
+    examples: [
+      "permission :read_all_posts, :read, :always",
+      "permission :update_own, :update, :own, purpose: :content_management",
+      "permission :audit_access, :read, :always, on: Blog.Post"
+    ],
+    target: AshGrant.Dsl.Permission,
+    args: [:name, :action, :scope],
+    schema: [
+      name: [
+        type: :atom,
+        required: true,
+        doc: "Stable identifier for this permission within its grant."
+      ],
+      on: [
+        type: :atom,
+        required: false,
+        doc:
+          "The resource module this permission applies to. Defaults to the enclosing resource " <>
+            "when declared inside a resource's `ash_grant do` block."
+      ],
+      instance: [
+        type: :any,
+        default: :*,
+        doc:
+          "Instance id this permission targets. Defaults to `:*` (RBAC). " <>
+            "Hardcoded instance ids are rare; dynamic instance permissions should use a resolver function."
+      ],
+      action: [
+        type: :atom,
+        required: true,
+        doc: "The action this permission covers. Use `:*` for all actions."
+      ],
+      scope: [
+        type: :atom,
+        required: true,
+        doc: "Scope name defined on the target resource (e.g. `:always`, `:own`)."
+      ],
+      purpose: [
+        type: :atom,
+        required: false,
+        doc: "Single compliance-purpose atom. Sugar for `purposes: [value]`."
+      ],
+      purposes: [
+        type: {:list, :atom},
+        required: false,
+        doc: "List of compliance-purpose atoms this permission serves."
+      ],
+      deny: [
+        type: :boolean,
+        default: false,
+        doc: "When `true`, the permission becomes a deny rule. Deny always wins."
+      ],
+      description: [
+        type: :string,
+        required: false,
+        doc: "Human-readable description used in docs, audits, and explain output."
+      ]
+    ]
+  }
+
+  @grant %Spark.Dsl.Entity{
+    name: :grant,
+    describe: """
+    Declares a named grant — an actor predicate paired with a set of
+    permissions. When the predicate returns `true` for an actor, every
+    permission in the grant is awarded.
+
+    The predicate is a 1-arity function `(actor) -> boolean`. Prefer concise
+    predicates that inspect actor attributes (role, plan, group membership)
+    rather than performing IO; AshGrant evaluates the predicate on every
+    permission check.
+
+    ## Examples
+
+        grant :admin, fn actor -> actor && actor.role == :admin end do
+          description "Full access for admins"
+          permission :manage_all, :*, :always
+        end
+
+        grant :editor, fn actor -> actor && actor.role == :editor end do
+          description "Editors publish and maintain their own posts"
+          purpose :content_management
+
+          permission :read_all, :read, :always
+          permission :update_own, :update, :own
+        end
+    """,
+    examples: [
+      """
+      grant :admin, fn actor -> actor && actor.role == :admin end do
+        permission :manage_all, :*, :always
+      end
+      """
+    ],
+    target: AshGrant.Dsl.Grant,
+    args: [:name, :predicate],
+    entities: [permissions: [@permission]],
+    schema: [
+      name: [
+        type: :atom,
+        required: true,
+        doc: "Stable identifier for this grant (e.g. `:admin`, `:editor`)."
+      ],
+      predicate: [
+        type: {:fun, 1},
+        required: true,
+        doc: "1-arity function `(actor) -> boolean` deciding grant membership."
+      ],
+      description: [
+        type: :string,
+        required: false,
+        doc: "Human-readable description of what this grant represents."
+      ],
+      purpose: [
+        type: :atom,
+        required: false,
+        doc:
+          "Single grant-level compliance-purpose atom. Inherited by every permission in the grant."
+      ],
+      purposes: [
+        type: {:list, :atom},
+        required: false,
+        doc: "List of grant-level compliance-purpose atoms inherited by every permission."
+      ]
+    ]
+  }
+
+  @grants %Spark.Dsl.Section{
+    name: :grants,
+    top_level?: false,
+    describe: """
+    Declarative grants for permission-based authorization.
+
+    Each `grant` pairs an actor predicate with a list of named permissions.
+    AshGrant synthesizes a resolver from the declared grants at compile time,
+    so resources using `grants` do not need to provide an explicit `resolver`
+    function.
+
+    Grants are mutually exclusive with an explicit `resolver` — use one or the
+    other, not both. Use an explicit resolver when permissions need to be
+    fetched from a database or external system (e.g. runtime instance-specific
+    grants).
+    """,
+    examples: [
+      """
+      grants do
+        grant :admin, fn actor -> actor && actor.role == :admin end do
+          permission :manage_all, :*, :always
+        end
+
+        grant :editor, fn actor -> actor && actor.role == :editor end do
+          permission :read_all, :read, :always
+          permission :update_own, :update, :own
+        end
+      end
+      """
+    ],
+    entities: [@grant]
+  }
+
   @ash_grant %Spark.Dsl.Section{
     name: :ash_grant,
     top_level?: false,
     imports: [Ash.Expr],
+    sections: [@grants],
     describe: """
     Configuration for permission-based authorization.
 
@@ -569,6 +762,27 @@ defmodule AshGrant.Dsl do
             can_perform_actions [:update, :destroy]
 
         Generates `:can_update?` and `:can_destroy?` calculations.
+        """
+      ],
+      purposes: [
+        type: {:list, :atom},
+        required: false,
+        doc: """
+        Declared vocabulary of compliance-purpose atoms.
+
+        When set, the `ValidateGrants` verifier rejects any `purpose:` / `purposes:`
+        value on a grant or permission that is not in this list, catching typos
+        like `:costumer_support` at compile time.
+
+        Leave unset (or set to `nil`) to allow any atom.
+
+        ## Example
+
+            ash_grant do
+              purposes [:customer_support, :fraud_investigation, :billing,
+                        :identity_verification, :audit, :compliance]
+              # ...
+            end
         """
       ],
       instance_key: [
@@ -737,6 +951,96 @@ defmodule AshGrant.Dsl.ScopeThrough do
           relationship: atom(),
           resource: module() | nil,
           actions: [atom()] | nil,
+          __spark_metadata__: map() | nil
+        }
+end
+
+defmodule AshGrant.Dsl.Permission do
+  @moduledoc """
+  Represents a single permission nested inside a `grant` in the AshGrant DSL.
+
+  Permissions are structured, compile-time-verified equivalents of permission
+  strings (`resource:instance:action:scope`). The verifier ensures that
+  `on` is a real `Ash.Resource`, `action` exists on that resource, and
+  `scope` is defined on that resource. Purposes provide compliance metadata
+  that downstream projects (audit, RoPA generation) can consume.
+
+  ## Fields
+
+  - `:name` — stable identifier for this permission within its grant
+  - `:on` — the resource module this permission applies to
+  - `:instance` — instance id to match, or `:*` for RBAC (default `:*`)
+  - `:action` — action name on the resource (or `:*`)
+  - `:scope` — scope name defined on the resource
+  - `:purpose` — single compliance-purpose atom (sugar for `purposes: [x]`)
+  - `:purposes` — list of compliance-purpose atoms
+  - `:deny` — when `true`, the permission is a deny rule (deny wins)
+  - `:description` — human-readable description for docs/audits
+  """
+
+  defstruct [
+    :name,
+    :on,
+    :instance,
+    :action,
+    :scope,
+    :purpose,
+    :purposes,
+    :deny,
+    :description,
+    :__spark_metadata__
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          on: module() | nil,
+          instance: atom() | String.t() | nil,
+          action: atom(),
+          scope: atom(),
+          purpose: atom() | nil,
+          purposes: [atom()] | nil,
+          deny: boolean() | nil,
+          description: String.t() | nil,
+          __spark_metadata__: map() | nil
+        }
+end
+
+defmodule AshGrant.Dsl.Grant do
+  @moduledoc """
+  Represents a named grant in the AshGrant DSL.
+
+  A grant pairs an actor predicate with a set of named permissions. At runtime,
+  if the predicate returns `true` for a given actor, every permission in the
+  grant is awarded to that actor.
+
+  ## Fields
+
+  - `:name` — stable identifier for the grant (e.g. `:editor`, `:admin`)
+  - `:predicate` — 1-arity function `(actor) -> boolean` deciding membership
+  - `:description` — human-readable description for docs/audits
+  - `:purpose` — single compliance-purpose atom (sugar for `purposes: [x]`)
+  - `:purposes` — list of compliance-purpose atoms inherited by every
+    permission in this grant
+  - `:permissions` — list of `AshGrant.Dsl.Permission` structs
+  """
+
+  defstruct [
+    :name,
+    :predicate,
+    :description,
+    :purpose,
+    :purposes,
+    :permissions,
+    :__spark_metadata__
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          predicate: (any() -> boolean()),
+          description: String.t() | nil,
+          purpose: atom() | nil,
+          purposes: [atom()] | nil,
+          permissions: [AshGrant.Dsl.Permission.t()],
           __spark_metadata__: map() | nil
         }
 end

--- a/lib/ash_grant/grants_resolver.ex
+++ b/lib/ash_grant/grants_resolver.ex
@@ -1,0 +1,64 @@
+defmodule AshGrant.GrantsResolver do
+  @moduledoc """
+  A generic `AshGrant.PermissionResolver` that synthesizes permissions from
+  declarative `grants` blocks at runtime.
+
+  This resolver walks the grants declared on `context.resource`, evaluates
+  each grant's predicate against the actor, and emits permission strings from
+  every matching grant's permissions. It is set as the resolver on any
+  resource that declares a `grants` block and does not provide its own
+  resolver.
+
+  Resources should never reference this module directly — the
+  `AshGrant.Transformers.SynthesizeGrantsResolver` transformer wires it up
+  automatically.
+  """
+
+  @behaviour AshGrant.PermissionResolver
+
+  @impl true
+  def resolve(actor, %{resource: resource}) when not is_nil(resource) do
+    resolve_for_resource(actor, resource)
+  end
+
+  def resolve(_actor, _context), do: []
+
+  defp resolve_for_resource(actor, resource) do
+    resource
+    |> AshGrant.Info.grants()
+    |> Enum.flat_map(fn grant ->
+      if safe_predicate(grant.predicate, actor) do
+        Enum.map(grant.permissions || [], &to_permission_string/1)
+      else
+        []
+      end
+    end)
+  end
+
+  defp safe_predicate(predicate, actor) when is_function(predicate, 1) do
+    !!predicate.(actor)
+  rescue
+    _ -> false
+  end
+
+  defp safe_predicate(_, _), do: false
+
+  defp to_permission_string(%AshGrant.Dsl.Permission{} = permission) do
+    resource_name = AshGrant.Info.resource_name(permission.on)
+    prefix = if permission.deny, do: "!", else: ""
+
+    prefix <>
+      resource_name <>
+      ":" <>
+      stringify(permission.instance) <>
+      ":" <>
+      stringify(permission.action) <>
+      ":" <>
+      stringify(permission.scope)
+  end
+
+  defp stringify(:*), do: "*"
+  defp stringify(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/lib/ash_grant/info.ex
+++ b/lib/ash_grant/info.ex
@@ -194,6 +194,86 @@ defmodule AshGrant.Info do
   end
 
   @doc """
+  Gets all `grant` declarations for a resource.
+
+  Returns an empty list if none are configured.
+  """
+  @spec grants(Ash.Resource.t()) :: [AshGrant.Dsl.Grant.t()]
+  def grants(resource) do
+    Spark.Dsl.Extension.get_entities(resource, [:ash_grant, :grants])
+  end
+
+  @doc """
+  Gets a specific grant by name.
+  """
+  @spec get_grant(Ash.Resource.t(), atom()) :: AshGrant.Dsl.Grant.t() | nil
+  def get_grant(resource, name) do
+    grants(resource)
+    |> Enum.find(&(&1.name == name))
+  end
+
+  @doc """
+  Gets all permissions from all grants on a resource as a flat list.
+
+  Each permission's effective purposes (grant purposes + permission purposes)
+  are attached under the `__effective_purposes__/1` helper — use that accessor
+  rather than reading `:purposes` directly if you need the merged set.
+  """
+  @spec permissions(Ash.Resource.t()) :: [AshGrant.Dsl.Permission.t()]
+  def permissions(resource) do
+    grants(resource)
+    |> Enum.flat_map(fn grant -> grant.permissions || [] end)
+  end
+
+  @doc """
+  Returns every `{grant, permission}` pair touching the given compliance purpose.
+
+  Suitable for compliance projects that need Records of Processing Activities
+  (GDPR Article 30), access reviews, or "which capabilities invoke purpose X"
+  lookups.
+  """
+  @spec permissions_for_purpose(Ash.Resource.t(), atom()) ::
+          [{AshGrant.Dsl.Grant.t(), AshGrant.Dsl.Permission.t()}]
+  def permissions_for_purpose(resource, purpose) do
+    grants(resource)
+    |> Enum.flat_map(fn grant ->
+      grant.permissions
+      |> List.wrap()
+      |> Enum.filter(&permission_has_purpose?(grant, &1, purpose))
+      |> Enum.map(&{grant, &1})
+    end)
+  end
+
+  @doc """
+  Returns the declared compliance-purpose vocabulary for a resource, or `nil`
+  if the vocabulary is unconstrained.
+  """
+  @spec declared_purposes(Ash.Resource.t()) :: [atom()] | nil
+  def declared_purposes(resource) do
+    Spark.Dsl.Extension.get_opt(resource, [:ash_grant], :purposes)
+  end
+
+  @doc """
+  Returns the effective purposes for a permission — the union of its grant's
+  purposes and its own purposes.
+  """
+  @spec effective_purposes(AshGrant.Dsl.Grant.t(), AshGrant.Dsl.Permission.t()) :: [atom()]
+  def effective_purposes(grant, permission) do
+    (purpose_list(grant.purpose, grant.purposes) ++
+       purpose_list(permission.purpose, permission.purposes))
+    |> Enum.uniq()
+  end
+
+  defp permission_has_purpose?(grant, permission, purpose) do
+    purpose in effective_purposes(grant, permission)
+  end
+
+  defp purpose_list(nil, nil), do: []
+  defp purpose_list(single, nil), do: [single]
+  defp purpose_list(nil, list), do: list
+  defp purpose_list(single, list), do: [single | list]
+
+  @doc """
   Gets a specific field group by name.
   """
   @spec get_field_group(Ash.Resource.t(), atom()) :: AshGrant.Dsl.FieldGroup.t() | nil

--- a/lib/ash_grant/transformers/normalize_grants.ex
+++ b/lib/ash_grant/transformers/normalize_grants.ex
@@ -1,0 +1,145 @@
+defmodule AshGrant.Transformers.NormalizeGrants do
+  @moduledoc """
+  Normalizes and validates the `grants` DSL block.
+
+  This transformer runs once all entities are parsed and:
+
+  - Fills in `on:` with the current resource module when omitted on a
+    permission declared inside a resource's own `ash_grant` block.
+  - Validates that `grants` and an explicit `resolver` are not both set.
+  - Validates that every `purpose:` / `purposes:` atom is a member of the
+    declared vocabulary, when one is configured.
+
+  Reference validation (that each permission's `on:`, `action:`, and `scope:`
+  resolve to real things) is handled by
+  `AshGrant.Verifiers.ValidateGrantReferences`, which runs after all
+  transformers so that Ash's default actions have been materialized.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+  alias Spark.Error.DslError
+
+  @impl true
+  def after?(AshGrant.Transformers.MergeDomainConfig), do: true
+  def after?(_), do: false
+
+  @impl true
+  def before?(AshGrant.Transformers.SynthesizeGrantsResolver), do: true
+  def before?(_), do: false
+
+  @impl true
+  def transform(dsl_state) do
+    resource = Transformer.get_persisted(dsl_state, :module)
+    grants = Transformer.get_entities(dsl_state, [:ash_grant, :grants])
+
+    case grants do
+      [] ->
+        {:ok, dsl_state}
+
+      _ ->
+        with :ok <- validate_not_both_resolver_and_grants(dsl_state, resource),
+             {:ok, dsl_state} <- inject_default_resource(dsl_state, resource, grants),
+             :ok <- validate_grants(dsl_state, resource) do
+          {:ok, dsl_state}
+        end
+    end
+  end
+
+  defp validate_not_both_resolver_and_grants(dsl_state, resource) do
+    case Transformer.get_option(dsl_state, [:ash_grant], :resolver) do
+      nil ->
+        :ok
+
+      _resolver ->
+        {:error,
+         dsl_error(
+           resource,
+           [:ash_grant, :grants],
+           "Cannot declare both `grants` and `resolver` on #{inspect(resource)}. " <>
+             "Use one or the other — grants synthesize a resolver automatically."
+         )}
+    end
+  end
+
+  defp inject_default_resource(dsl_state, resource, grants) do
+    updated = Enum.reduce(grants, dsl_state, &inject_into_grant(&1, &2, resource))
+    {:ok, updated}
+  end
+
+  defp inject_into_grant(grant, dsl_state, resource) do
+    new_permissions = Enum.map(grant.permissions || [], &inject_permission_resource(&1, resource))
+    new_grant = %{grant | permissions: new_permissions}
+    Transformer.replace_entity(dsl_state, [:ash_grant, :grants], new_grant, &(&1.name == grant.name))
+  end
+
+  defp inject_permission_resource(%{on: nil} = permission, resource), do: %{permission | on: resource}
+  defp inject_permission_resource(permission, _resource), do: permission
+
+  defp validate_grants(dsl_state, resource) do
+    grants = Transformer.get_entities(dsl_state, [:ash_grant, :grants])
+    declared_purposes = Transformer.get_option(dsl_state, [:ash_grant], :purposes)
+
+    Enum.reduce_while(grants, :ok, fn grant, :ok ->
+      case validate_grant_purposes(grant, declared_purposes, resource) do
+        :ok -> {:cont, :ok}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp validate_grant_purposes(grant, declared_purposes, resource) do
+    with :ok <- validate_purpose_vocabulary(grant, declared_purposes, resource, grant_path(grant)) do
+      validate_permission_purposes(grant, declared_purposes, resource)
+    end
+  end
+
+  defp validate_permission_purposes(grant, declared_purposes, resource) do
+    Enum.reduce_while(grant.permissions || [], :ok, fn permission, :ok ->
+      case validate_purpose_vocabulary(
+             permission,
+             declared_purposes,
+             resource,
+             permission_path(grant, permission)
+           ) do
+        :ok -> {:cont, :ok}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp validate_purpose_vocabulary(_entity, nil, _resource, _path), do: :ok
+
+  defp validate_purpose_vocabulary(entity, declared, resource, path) do
+    purposes = purpose_list(entity)
+
+    case Enum.reject(purposes, &(&1 in declared)) do
+      [] ->
+        :ok
+
+      unknown ->
+        {:error,
+         dsl_error(
+           resource,
+           path,
+           "Unknown purpose(s) #{inspect(unknown)}. Declared vocabulary: #{inspect(declared)}. " <>
+             "Add them to `ash_grant do purposes [...] end` or remove them from this entity."
+         )}
+    end
+  end
+
+  defp purpose_list(%{purpose: nil, purposes: nil}), do: []
+  defp purpose_list(%{purpose: single, purposes: nil}), do: [single]
+  defp purpose_list(%{purpose: nil, purposes: list}), do: list
+  defp purpose_list(%{purpose: single, purposes: list}), do: [single | list]
+
+  defp grant_path(grant), do: [:ash_grant, :grants, :grant, grant.name]
+
+  defp permission_path(grant, permission),
+    do: [:ash_grant, :grants, :grant, grant.name, :permission, permission.name]
+
+  defp dsl_error(resource, path, message) do
+    DslError.exception(module: resource, path: path, message: message)
+  end
+end

--- a/lib/ash_grant/transformers/synthesize_grants_resolver.ex
+++ b/lib/ash_grant/transformers/synthesize_grants_resolver.ex
@@ -1,0 +1,52 @@
+defmodule AshGrant.Transformers.SynthesizeGrantsResolver do
+  @moduledoc """
+  Compiles the declarative `grants` block into a permission resolver function.
+
+  When a resource declares `grants do ... end` and no explicit `resolver`,
+  this transformer builds a 2-arity function that:
+
+  - Walks every declared grant
+  - Evaluates each grant's predicate against the supplied actor
+  - Emits permission strings from the permissions of grants that match
+
+  The synthesized resolver is stored in the `resolver` DSL option so the
+  existing `Check`, `FilterCheck`, and `Explainer` machinery picks it up
+  without change.
+
+  The resource name embedded in each permission string is resolved at runtime
+  via `AshGrant.Info.resource_name/1`, so grants can refer to other resources
+  that compile in a different order.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias Spark.Dsl.Transformer
+
+  @impl true
+  def after?(AshGrant.Transformers.NormalizeGrants), do: true
+  def after?(AshGrant.Transformers.MergeDomainConfig), do: true
+  def after?(_), do: false
+
+  @impl true
+  def before?(AshGrant.Transformers.ValidateResolverPresent), do: true
+  def before?(_), do: false
+
+  @impl true
+  def transform(dsl_state) do
+    grants = Transformer.get_entities(dsl_state, [:ash_grant, :grants])
+
+    case grants do
+      [] ->
+        {:ok, dsl_state}
+
+      _ ->
+        {:ok,
+         Transformer.set_option(
+           dsl_state,
+           [:ash_grant],
+           :resolver,
+           AshGrant.GrantsResolver
+         )}
+    end
+  end
+end

--- a/lib/ash_grant/transformers/validate_resolver_present.ex
+++ b/lib/ash_grant/transformers/validate_resolver_present.ex
@@ -13,10 +13,14 @@ defmodule AshGrant.Transformers.ValidateResolverPresent do
 
   @impl true
   def after?(AshGrant.Transformers.MergeDomainConfig), do: true
+  def after?(AshGrant.Transformers.NormalizeGrants), do: true
+  def after?(AshGrant.Transformers.SynthesizeGrantsResolver), do: true
   def after?(_), do: false
 
   @impl true
   def before?(AshGrant.Transformers.MergeDomainConfig), do: false
+  def before?(AshGrant.Transformers.NormalizeGrants), do: false
+  def before?(AshGrant.Transformers.SynthesizeGrantsResolver), do: false
   def before?(_), do: true
 
   @impl true

--- a/lib/ash_grant/verifiers/validate_grant_references.ex
+++ b/lib/ash_grant/verifiers/validate_grant_references.ex
@@ -1,0 +1,172 @@
+defmodule AshGrant.Verifiers.ValidateGrantReferences do
+  @moduledoc """
+  Verifies that every `permission` in a `grants` block refers to a real
+  resource, action, and scope.
+
+  This runs as a Spark verifier after every transformer so that Ash's default
+  actions have been materialized before we check them.
+  """
+
+  use Spark.Dsl.Verifier
+
+  alias Spark.Dsl.Verifier
+  alias Spark.Error.DslError
+
+  @impl true
+  def verify(dsl_state) do
+    resource = Verifier.get_persisted(dsl_state, :module)
+    grants = Verifier.get_entities(dsl_state, [:ash_grant, :grants])
+
+    case grants do
+      [] ->
+        :ok
+
+      _ ->
+        local_scopes =
+          Verifier.get_entities(dsl_state, [:ash_grant])
+          |> Enum.filter(&match?(%AshGrant.Dsl.Scope{}, &1))
+          |> Enum.map(& &1.name)
+
+        local_actions =
+          Verifier.get_entities(dsl_state, [:actions])
+          |> Enum.map(& &1.name)
+
+        validate_all_grants(grants, resource, local_scopes, local_actions)
+    end
+  end
+
+  defp validate_all_grants(grants, resource, local_scopes, local_actions) do
+    Enum.reduce_while(grants, :ok, fn grant, :ok ->
+      case validate_grant_permissions(grant, resource, local_scopes, local_actions) do
+        :ok -> {:cont, :ok}
+        err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp validate_grant_permissions(grant, resource, local_scopes, local_actions) do
+    Enum.reduce_while(grant.permissions || [], :ok, fn permission, :ok ->
+      case validate_permission(permission, grant, resource, local_scopes, local_actions) do
+        :ok -> {:cont, :ok}
+        err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp validate_permission(permission, grant, resource, local_scopes, local_actions) do
+    path = [:ash_grant, :grants, :grant, grant.name, :permission, permission.name]
+
+    with :ok <- validate_resource_reference(permission, resource, path),
+         :ok <- validate_action_reference(permission, resource, path, local_actions) do
+      validate_scope_reference(permission, resource, path, local_scopes)
+    end
+  end
+
+  defp validate_resource_reference(%{on: nil}, resource, path) do
+    dsl_error(
+      resource,
+      path,
+      "`on:` is required — could not infer the target resource. " <>
+        "Declare the permission inside a resource's `ash_grant` block, or pass `on: MyApp.Blog.Post`."
+    )
+  end
+
+  defp validate_resource_reference(%{on: target}, resource, path) when is_atom(target) do
+    cond do
+      target == resource ->
+        :ok
+
+      not Code.ensure_loaded?(target) ->
+        case Code.ensure_compiled(target) do
+          {:module, _} -> ensure_resource(target, resource, path)
+          _ -> :ok
+        end
+
+      true ->
+        ensure_resource(target, resource, path)
+    end
+  end
+
+  defp ensure_resource(target, resource, path) do
+    if Ash.Resource.Info.resource?(target) do
+      :ok
+    else
+      dsl_error(
+        resource,
+        path,
+        "`on: #{inspect(target)}` is not an `Ash.Resource`."
+      )
+    end
+  end
+
+  defp validate_action_reference(%{action: :*}, _resource, _path, _local_actions), do: :ok
+
+  defp validate_action_reference(%{on: target, action: action}, resource, path, local_actions)
+       when is_atom(target) and is_atom(action) do
+    cond do
+      target == resource ->
+        ensure_action_in(action, local_actions, target, resource, path)
+
+      Code.ensure_loaded?(target) ->
+        actions =
+          target
+          |> Ash.Resource.Info.actions()
+          |> Enum.map(& &1.name)
+
+        ensure_action_in(action, actions, target, resource, path)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp ensure_action_in(action, actions, target, resource, path) do
+    if action in actions do
+      :ok
+    else
+      dsl_error(
+        resource,
+        path,
+        "`action: #{inspect(action)}` is not defined on #{inspect(target)}. " <>
+          "Available actions: #{inspect(actions)}."
+      )
+    end
+  end
+
+  defp validate_scope_reference(%{on: target, scope: scope}, resource, path, local_scopes)
+       when is_atom(target) and is_atom(scope) do
+    cond do
+      target == resource ->
+        ensure_scope_in(scope, local_scopes, target, resource, path)
+
+      Code.ensure_loaded?(target) ->
+        scopes =
+          target
+          |> AshGrant.Info.scopes()
+          |> Enum.map(& &1.name)
+
+        ensure_scope_in(scope, scopes, target, resource, path)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp ensure_scope_in(scope, scopes, target, resource, path) do
+    if scope in scopes do
+      :ok
+    else
+      dsl_error(
+        resource,
+        path,
+        "`scope: #{inspect(scope)}` is not defined on #{inspect(target)}. " <>
+          "Available scopes: #{inspect(scopes)}. " <>
+          "Add one with `scope #{inspect(scope)}, expr(...)` in the resource's `ash_grant` block."
+      )
+    end
+  end
+
+  defp dsl_error(resource, path, message) do
+    {:error, DslError.exception(module: resource, path: path, message: message)}
+  end
+end

--- a/test/ash_grant/grants_dsl_test.exs
+++ b/test/ash_grant/grants_dsl_test.exs
@@ -1,0 +1,266 @@
+defmodule AshGrant.GrantsDslTest do
+  use ExUnit.Case, async: true
+
+  alias AshGrant.Info
+
+  defmodule Post do
+    use Ash.Resource,
+      domain: nil,
+      validate_domain_inclusion?: false,
+      extensions: [AshGrant]
+
+    ash_grant do
+      resource_name("post")
+
+      purposes([:content_management, :fraud_investigation, :audit, :compliance])
+
+      scope(:always, true)
+      scope(:own, expr(author_id == ^actor(:id)))
+      scope(:published, expr(status == :published))
+
+      grants do
+        grant :admin, fn actor -> actor && Map.get(actor, :role) == :admin end do
+          description("Full administrative access")
+          purpose(:compliance)
+
+          permission(:manage_all, :*, :always,
+            description: "Any action on any post"
+          )
+        end
+
+        grant :editor, fn actor -> actor && Map.get(actor, :role) == :editor end do
+          description("Editors manage content")
+          purpose(:content_management)
+
+          permission(:read_all, :read, :always)
+          permission(:update_own, :update, :own)
+        end
+
+        grant :viewer, fn actor -> actor && Map.get(actor, :role) == :viewer end do
+          permission(:read_published, :read, :published,
+            purposes: [:audit],
+            description: "Read published posts"
+          )
+        end
+
+        grant :archived_guard, fn actor -> actor && Map.get(actor, :role) == :editor end do
+          permission(:no_destroy_archived, :destroy, :published, deny: true)
+        end
+
+        grant :specific_admin, fn actor -> actor && Map.get(actor, :role) == :specific end do
+          permission(:manage_root_post, :update, :always, instance: "root-post-id")
+        end
+      end
+    end
+
+    actions do
+      defaults([:read, :create, :update, :destroy])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:title, :string, public?: true)
+      attribute(:status, :atom, constraints: [one_of: [:draft, :published]])
+      attribute(:author_id, :uuid)
+    end
+  end
+
+  describe "grants DSL parsing" do
+    test "returns all declared grants" do
+      grants = Info.grants(Post)
+      assert length(grants) == 5
+
+      names = Enum.map(grants, & &1.name)
+      assert :admin in names
+      assert :editor in names
+      assert :viewer in names
+      assert :archived_guard in names
+      assert :specific_admin in names
+    end
+
+    test "grants carry predicates and metadata" do
+      editor = Info.get_grant(Post, :editor)
+
+      assert editor.name == :editor
+      assert is_function(editor.predicate, 1)
+      assert editor.description == "Editors manage content"
+      assert editor.purpose == :content_management
+    end
+
+    test "flattens to permissions list" do
+      permissions = Info.permissions(Post)
+      assert length(permissions) == 6
+
+      names = Enum.map(permissions, & &1.name)
+      assert :manage_all in names
+      assert :read_all in names
+      assert :update_own in names
+      assert :read_published in names
+      assert :no_destroy_archived in names
+      assert :manage_root_post in names
+    end
+
+    test "instance defaults to :* when omitted" do
+      read_all = Info.permissions(Post) |> Enum.find(&(&1.name == :read_all))
+      assert read_all.instance == :*
+    end
+
+    test "instance keyword overrides default" do
+      specific = Info.permissions(Post) |> Enum.find(&(&1.name == :manage_root_post))
+      assert specific.instance == "root-post-id"
+    end
+
+    test "permission `on:` defaults to current resource" do
+      read_all = Info.permissions(Post) |> Enum.find(&(&1.name == :read_all))
+      assert read_all.on == Post
+      assert read_all.instance == :*
+      assert read_all.action == :read
+      assert read_all.scope == :always
+    end
+
+    test "deny flag is preserved" do
+      deny_perm =
+        Info.permissions(Post) |> Enum.find(&(&1.name == :no_destroy_archived))
+
+      assert deny_perm.deny == true
+    end
+  end
+
+  describe "purposes" do
+    test "declared vocabulary is introspectable" do
+      assert Info.declared_purposes(Post) ==
+               [:content_management, :fraud_investigation, :audit, :compliance]
+    end
+
+    test "effective purposes merge grant + permission purposes" do
+      viewer = Info.get_grant(Post, :viewer)
+      read_published = Enum.find(viewer.permissions, &(&1.name == :read_published))
+
+      assert Info.effective_purposes(viewer, read_published) == [:audit]
+    end
+
+    test "permissions_for_purpose returns matching pairs" do
+      pairs = Info.permissions_for_purpose(Post, :content_management)
+      assert length(pairs) == 2
+
+      perm_names = Enum.map(pairs, fn {_grant, perm} -> perm.name end)
+      assert :read_all in perm_names
+      assert :update_own in perm_names
+    end
+
+    test "permissions_for_purpose finds purpose via permission-level override" do
+      pairs = Info.permissions_for_purpose(Post, :audit)
+      assert [{grant, perm}] = pairs
+      assert grant.name == :viewer
+      assert perm.name == :read_published
+    end
+  end
+
+  describe "synthesized resolver" do
+    setup do
+      %{context: %{resource: Post}}
+    end
+
+    test "assigns the GrantsResolver module" do
+      assert Info.resolver(Post) == AshGrant.GrantsResolver
+    end
+
+    test "emits permissions for matching actor", %{context: context} do
+      admin_perms = AshGrant.GrantsResolver.resolve(%{role: :admin}, context)
+      assert "post:*:*:always" in admin_perms
+    end
+
+    test "emits permissions for editor", %{context: context} do
+      editor_perms = AshGrant.GrantsResolver.resolve(%{role: :editor}, context)
+
+      assert "post:*:read:always" in editor_perms
+      assert "post:*:update:own" in editor_perms
+      # :editor role is also matched by :archived_guard grant
+      assert "!post:*:destroy:published" in editor_perms
+    end
+
+    test "instance keyword is emitted in permission string", %{context: context} do
+      perms = AshGrant.GrantsResolver.resolve(%{role: :specific}, context)
+      assert "post:root-post-id:update:always" in perms
+    end
+
+    test "nil actor yields no permissions", %{context: context} do
+      assert AshGrant.GrantsResolver.resolve(nil, context) == []
+    end
+
+    test "unknown actor role yields no permissions", %{context: context} do
+      assert AshGrant.GrantsResolver.resolve(%{role: :random}, context) == []
+    end
+
+    test "deny prefix is emitted for deny permissions", %{context: context} do
+      perms = AshGrant.GrantsResolver.resolve(%{role: :editor}, context)
+      assert Enum.any?(perms, &String.starts_with?(&1, "!"))
+    end
+
+    test "missing resource in context yields no permissions" do
+      assert AshGrant.GrantsResolver.resolve(%{role: :admin}, %{}) == []
+    end
+  end
+
+  describe "compile-time verification" do
+    test "rejects unknown purpose when vocabulary is declared" do
+      assert_raise Spark.Error.DslError, ~r/Unknown purpose/s, fn ->
+        defmodule BadPurposePost do
+          use Ash.Resource,
+            domain: nil,
+            validate_domain_inclusion?: false,
+            extensions: [AshGrant]
+
+          actions do
+            defaults([:read])
+          end
+
+          ash_grant do
+            purposes([:audit])
+            scope(:always, true)
+
+            grants do
+              grant :bad, fn _ -> true end do
+                permission(:audit_read, :read, :always, purpose: :typo_purpose)
+              end
+            end
+          end
+
+          attributes do
+            uuid_primary_key(:id)
+          end
+        end
+      end
+    end
+
+    test "rejects declaring both grants and explicit resolver" do
+      assert_raise Spark.Error.DslError, ~r/both `grants` and `resolver`/s, fn ->
+        defmodule DuelResolverPost do
+          use Ash.Resource,
+            domain: nil,
+            validate_domain_inclusion?: false,
+            extensions: [AshGrant]
+
+          actions do
+            defaults([:read])
+          end
+
+          ash_grant do
+            resolver(fn _actor, _context -> [] end)
+            scope(:always, true)
+
+            grants do
+              grant :noop, fn _ -> true end do
+                permission(:read_all, :read, :always)
+              end
+            end
+          end
+
+          attributes do
+            uuid_primary_key(:id)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `grants` block to the `ash_grant` DSL so permissions can be **declared as data** rather than returned from an imperative resolver function. Each grant pairs an actor predicate with a set of named, structured permissions and optional compliance-purpose metadata.

### Before

```elixir
resolver fn actor, _ ->
  case actor do
    %{role: :admin}  -> [\"post:*:*:always\"]
    %{role: :editor} -> [\"post:*:read:always\", \"post:*:update:own\"]
    %{role: :viewer} -> [\"post:*:read:published\"]
    _ -> []
  end
end
```

### After

```elixir
ash_grant do
  purposes [:content_management, :audit, :compliance]

  scope :always, true
  scope :own, expr(author_id == ^actor(:id))
  scope :published, expr(status == :published)

  grants do
    grant :admin, fn actor -> actor && actor.role == :admin end do
      purpose :compliance
      permission :manage_all, :*, :always
    end

    grant :editor, fn actor -> actor && actor.role == :editor end do
      purpose :content_management
      permission :read_all,   :read,   :always
      permission :update_own, :update, :own
    end

    grant :viewer, fn actor -> actor && actor.role == :viewer end do
      permission :read_published, :read, :published, purpose: :audit
    end
  end
end
```

## What's new

- **`grant :name, predicate do ... end`** — predicate is a 1-arity function over the actor; matching grants contribute their permissions.
- **`permission :name, :action, :scope`** — positional mirrors the permission string format; `on:`, `instance:`, `purpose(s):`, `deny:`, `description:` as keyword options.
- **Extension-level `purposes [...]`** — declares the compliance vocabulary; unknown purpose atoms fail compilation.
- **`NormalizeGrants` transformer** — injects the enclosing resource as the default `on:`, rejects declaring both `grants` and an explicit `resolver`.
- **`ValidateGrantReferences` verifier** — compile-time checks that each permission's `on:` is an `Ash.Resource`, that `action:` exists on it (or is `:*`), and that `scope:` is defined in its `ash_grant` block.
- **`SynthesizeGrantsResolver` + `AshGrant.GrantsResolver`** — when grants are declared, wires `GrantsResolver` as the resource's resolver. `Check`, `FilterCheck`, and `Explainer` pick it up unchanged.
- **Introspection** — `Info.grants/1`, `permissions/1`, `permissions_for_purpose/2`, `effective_purposes/2`, `declared_purposes/1`. A downstream compliance project can call `permissions_for_purpose(Post, :identity_verification)` and get `{grant, permission}` pairs directly.

## Why

- **Inspectable, diffable, lintable** security config — grants become data a reviewer can scan top-to-bottom.
- **Compile-time safety** — renaming an action or deleting a scope breaks compilation, not runtime.
- **Compliance-ready** — purposes metadata gives downstream audit/RoPA tooling a structured view without parsing permission strings.

## Scope of this PR

Resource-level grants only. Deferred to follow-ups:

- Domain-level `grants` block
- Dedicated `use AshGrant.Grants` module form
- `expr()` form for the grant predicate (today it's a function)

Grants and an explicit `resolver` are mutually exclusive — for runtime instance-specific grants (DB-backed per-row shares) keep using the `resolver` function escape hatch.

## Test plan

- [x] 21 new tests in `test/ash_grant/grants_dsl_test.exs` cover DSL parsing, `instance:` override, deny rule, purposes vocabulary, effective purposes, `permissions_for_purpose`, synthesized resolver emission for several actor shapes (admin, editor, viewer, nil, unknown, specific instance), deny prefix emission, dual-resolver rejection, unknown-purpose rejection
- [x] Full suite: 1076 tests, 0 regressions from this PR (one pre-existing failure in `default_field_policies_test.exs` is unrelated)
- [x] `mix credo --strict` clean on all new files