### PR TITLE
fix: group-less field grant no longer narrowed by field-group grant (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.2] - 2026-06-23
+
+### Fixed
+
+- **Group-less (4-part) read grant was silently narrowed by a field-group grant** (#116). `AshGrant.Evaluator.get_all_field_groups/4` dropped group-less allow grants via `Enum.reject(&is_nil/1)`, so a broad "all fields" grant (`employee:*:read:always`) combined with a narrow field-group grant (`employee:*:read:always:sensitive`) downgraded the actor to **only** the narrow group's fields — every other field became `%Ash.ForbiddenField{}`, and via `AshGrant.Preparations.ApplyMasking` fields that should have been raw started being masked. Adding an allow grant must never subtract access. The union now collapses to `[]` (the "unrestricted" signal every consumer already understands) whenever any matching allow grant is group-less, so a broader group-less grant is never narrowed by a more specific field-group grant. A group-less grant scoped to a *different* action is correctly excluded and does not over-grant.
+
 ## [0.14.1] - 2026-04-13
 
 Two fixes that make `resolve_argument` (introduced in 0.14.0) actually

--- a/lib/ash_grant/evaluator.ex
+++ b/lib/ash_grant/evaluator.ex
@@ -408,11 +408,21 @@ defmodule AshGrant.Evaluator do
   When an actor has multiple permissions with different field groups, these are merged
   as a union to determine the combined set of accessible fields.
 
+  A matching group-less (4-part) allow grant means "all fields are visible". Since
+  unrestricted access dominates the union (all fields ∪ anything = all fields), such a
+  grant collapses the result to `[]` — the same "unrestricted" signal consumers use
+  when there is no field restriction at all. A broader group-less grant is therefore
+  never narrowed by a more specific field-group grant (additive allow semantics).
+
   ## Examples
 
       iex> permissions = ["employee:*:read:always:sensitive", "employee:*:read:always:billing"]
       iex> AshGrant.Evaluator.get_all_field_groups(permissions, "employee", "read")
       ["sensitive", "billing"]
+
+      iex> permissions = ["employee:*:read:always", "employee:*:read:always:sensitive"]
+      iex> AshGrant.Evaluator.get_all_field_groups(permissions, "employee", "read")
+      []
 
       iex> permissions = ["employee:*:read:always:sensitive", "!employee:*:read:always"]
       iex> AshGrant.Evaluator.get_all_field_groups(permissions, "employee", "read")
@@ -431,13 +441,23 @@ defmodule AshGrant.Evaluator do
     if has_deny do
       []
     else
-      permissions
-      |> Enum.filter(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
-      |> Enum.map(& &1.field_group)
-      |> Enum.reject(&is_nil/1)
-      |> Enum.uniq()
+      matching_allows =
+        Enum.filter(permissions, fn perm ->
+          not Permission.deny?(perm) and
+            Permission.matches?(perm, resource, action, action_type)
+        end)
+
+      # A group-less (4-part) allow grant means "all fields are visible" and
+      # dominates the union, so it collapses the result to [] (unrestricted).
+      # Without this, adding a narrower field-group grant on top of a broad
+      # group-less grant would silently subtract access (see issue #116).
+      if Enum.any?(matching_allows, &is_nil(&1.field_group)) do
+        []
+      else
+        matching_allows
+        |> Enum.map(& &1.field_group)
+        |> Enum.uniq()
+      end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.14.1"
+  @version "0.14.2"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do

--- a/test/ash_grant/evaluator_test.exs
+++ b/test/ash_grant/evaluator_test.exs
@@ -290,13 +290,52 @@ defmodule AshGrant.EvaluatorTest do
       assert Evaluator.get_all_field_groups(permissions, "employee", "write") == []
     end
 
-    test "get_all_field_groups ignores permissions without field_group" do
+    test "get_all_field_groups returns [] when a group-less grant is present (issue #116)" do
+      # A group-less (4-part) grant means "all fields visible". It dominates the
+      # union, so combined with any field-group grant the result is still
+      # unrestricted ([]). Adding an allow grant must never subtract access.
       permissions = [
         "employee:*:read:always:sensitive",
         "employee:*:read:own"
       ]
 
+      assert Evaluator.get_all_field_groups(permissions, "employee", "read") == []
+    end
+
+    test "get_all_field_groups: group-less grant dominates regardless of order (issue #116)" do
+      assert Evaluator.get_all_field_groups(
+               ["employee:*:read:always", "employee:*:read:always:sensitive"],
+               "employee",
+               "read"
+             ) == []
+
+      assert Evaluator.get_all_field_groups(
+               ["employee:*:read:always:sensitive", "employee:*:read:always"],
+               "employee",
+               "read"
+             ) == []
+    end
+
+    test "get_all_field_groups: group-less grant for a different action does not collapse (issue #116)" do
+      # Over-grant guard: the group-less grant is on :update, so a :read query
+      # must stay restricted to :sensitive. matches?/4 filters by action before
+      # the group-less check, so the :update grant never enters the union.
+      permissions = [
+        "employee:*:update:always",
+        "employee:*:read:always:sensitive"
+      ]
+
       assert Evaluator.get_all_field_groups(permissions, "employee", "read") == ["sensitive"]
+    end
+
+    test "get_all_field_groups: deny wins over a group-less grant (issue #116)" do
+      # A matching deny short-circuits to [] — byte-identical to the
+      # "unrestricted" signal — but here it means DENIED. Consumers gate field
+      # access on has_access?, which returns false, so deny-wins is preserved.
+      permissions = ["employee:*:read:always", "!employee:*:read:always"]
+
+      assert Evaluator.get_all_field_groups(permissions, "employee", "read") == []
+      refute Evaluator.has_access?(permissions, "employee", "read")
     end
   end
 
@@ -502,6 +541,14 @@ defmodule AshGrant.EvaluatorTest do
       assert Evaluator.get_all_field_groups(permissions, "employee", "by_department", :read) == [
                "sensitive"
              ]
+    end
+
+    test "group-less grant collapses the union via action_type (issue #116)" do
+      # The group-less read* grant matches the custom by_department read action
+      # via action_type, so it dominates the union and yields [] (unrestricted).
+      permissions = ["employee:*:read*:always", "employee:*:read*:always:sensitive"]
+
+      assert Evaluator.get_all_field_groups(permissions, "employee", "by_department", :read) == []
     end
   end
 

--- a/test/ash_grant/field_group_integration_test.exs
+++ b/test/ash_grant/field_group_integration_test.exs
@@ -172,6 +172,40 @@ defmodule AshGrant.FieldGroupIntegrationTest do
       assert forbidden_field?(result.email)
     end
 
+    test "group-less grant + narrow field_group grant — sees all fields (issue #116)", %{
+      record: record
+    } do
+      # Regression for issue #116: a broad group-less (4-part) read grant means
+      # "all fields visible". Adding a narrow field-group (5-part) grant must NOT
+      # narrow the actor down to that group — additive allow grants never subtract
+      # access. Before the fix, get_all_field_groups dropped the group-less grant
+      # and the actor was silently downgraded to :public only.
+      actor = %{
+        permissions: [
+          "sensitiverecord:*:read:always",
+          "sensitiverecord:*:read:always:public"
+        ]
+      }
+
+      results = read_records(actor)
+      result = find_record(results, record.id)
+
+      assert result != nil, "record not found in results"
+
+      # All fields visible — the group-less grant dominates the union.
+      assert result.name == "John Doe"
+      assert result.department == "Engineering"
+      assert result.position == "Senior Developer"
+      assert result.phone == "010-1234-5678"
+      assert result.address == "123 Main St"
+      assert result.salary == 80_000
+      assert result.email == "john@example.com"
+
+      # Fields OUTSIDE the narrow :public group must not be forbidden.
+      refute forbidden_field?(result.salary)
+      refute forbidden_field?(result.email)
+    end
+
     test "field_group hierarchy: :confidential subsumes :public", %{record: record} do
       # An actor with :confidential should see everything a :public actor sees plus more
       public_actor = %{permissions: ["sensitiverecord:*:read:always:public"]}

--- a/test/ash_grant/field_group_property_test.exs
+++ b/test/ash_grant/field_group_property_test.exs
@@ -260,6 +260,44 @@ defmodule AshGrant.FieldGroupPropertyTest do
         assert groups == []
       end
     end
+
+    property "a matching group-less grant makes the union unrestricted ([]) (issue #116)" do
+      check all(
+              resource <- resource_gen(),
+              action <- action_gen(),
+              scope <- scope_gen(),
+              groups <- list_of(non_nil_field_group_gen(), min_length: 1, max_length: 3)
+            ) do
+        group_perms = Enum.map(groups, &"#{resource}:*:#{action}:always:#{&1}")
+        group_less = "#{resource}:*:#{action}:#{scope}"
+
+        # A group-less (4-part) grant for the same resource/action means "all
+        # fields visible" and dominates the union, so the result collapses to []
+        # whether the group-less grant comes first or last. A more specific
+        # field-group grant must never narrow a broader group-less one.
+        assert Evaluator.get_all_field_groups([group_less | group_perms], resource, action) == []
+        assert Evaluator.get_all_field_groups(group_perms ++ [group_less], resource, action) == []
+      end
+    end
+
+    property "a group-less grant for a different action does not collapse the union (issue #116)" do
+      check all(
+              resource <- resource_gen(),
+              action <- action_gen(),
+              other_action <- action_gen() |> filter(&(&1 != action)),
+              group <- non_nil_field_group_gen()
+            ) do
+        permissions = [
+          "#{resource}:*:#{other_action}:always",
+          "#{resource}:*:#{action}:always:#{group}"
+        ]
+
+        # The group-less grant is on `other_action`, so it must not match the
+        # `action` query — the union stays restricted to the named group. Guards
+        # against the group-less collapse leaking across actions (over-grant).
+        assert Evaluator.get_all_field_groups(permissions, resource, action) == [group]
+      end
+    end
   end
 
   # ============================================

--- a/test/ash_grant/masking_integration_test.exs
+++ b/test/ash_grant/masking_integration_test.exs
@@ -153,6 +153,41 @@ defmodule AshGrant.MaskingIntegrationTest do
       assert result.phone == "010-1234-5678"
       assert result.address == "123 Main St"
     end
+
+    test "actor with group-less grant + :sensitive sees unmasked — group-less wins (issue #116)",
+         %{record: record} do
+      # Regression for issue #116 on the masking path. A group-less (4-part)
+      # read grant means "all fields visible, unmasked". Adding the masking
+      # :sensitive grant on top must NOT start masking phone/address — additive
+      # allow grants never subtract access. Before the fix, get_all_field_groups
+      # dropped the group-less grant and ApplyMasking masked phone/address down
+      # to the :sensitive group.
+      actor = %{
+        permissions: [
+          "maskedrecord:*:read:always",
+          "maskedrecord:*:read:always:sensitive"
+        ]
+      }
+
+      results = read_records(actor)
+      result = find_record(results, record.id)
+
+      assert result != nil, "record not found"
+
+      # Group-less grant => no masking, every field raw.
+      assert result.name == "John Doe"
+      assert result.department == "Engineering"
+      assert result.phone == "010-1234-5678"
+      assert result.address == "123 Main St"
+      assert result.salary == 80_000
+      assert result.email == "john@example.com"
+
+      # phone/address must NOT be masked, and nothing is forbidden.
+      refute result.phone == "*************"
+      refute result.address == "***********"
+      refute forbidden_field?(result.salary)
+      refute forbidden_field?(result.email)
+    end
   end
 
   describe "masking with multiple records" do


### PR DESCRIPTION
## Summary

Fixes #116. `AshGrant.Evaluator.get_all_field_groups/4` discarded group-less (4-part) allow grants via `Enum.reject(&is_nil/1)`. Because a group-less grant means **"all fields visible"** and the result feeds a binary toggle (`[]` → unrestricted; non-empty → restrict to exactly those groups), an actor holding a broad `resource:*:read:always` grant **plus** a narrow `resource:*:read:always:sensitive` grant was silently downgraded to only the `:sensitive` fields — every other field became `%Ash.ForbiddenField{}`, and via `AshGrant.Preparations.ApplyMasking` fields that should have been raw started being masked. **Adding an allow grant removed access**, violating additive/deny-wins semantics.

The union now collapses to `[]` (the "unrestricted" signal every consumer already understands) whenever any matching allow grant is group-less, so a broad group-less grant is never narrowed by a more specific field-group grant. A group-less grant scoped to a *different* action is correctly excluded by `matches?/4` and does **not** over-grant.

- `lib/ash_grant/evaluator.ex` — `get_all_field_groups/4`: in the allow branch, return `[]` if any matching allow grant has `field_group == nil`; otherwise the deduped union. The `has_deny` short-circuit is unchanged, so deny-wins is preserved. Docstring + doctest updated.
- `CHANGELOG.md` / `mix.exs` — 0.14.2 entry and version bump.

Developed test-first (red → green): the prior `evaluator_test.exs` case that asserted the buggy `["sensitive"]` was corrected to `[]`.

## Test plan

- [x] `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo` — all clean
- [x] `mix test` — 39 doctests, 103 properties, **1061 tests, 0 failures**
- [x] Unit: group-less + field-group collapses to `[]` (both orders); group-less for a *different* action does **not** collapse (over-grant guard); deny-wins over a group-less grant; `action_type` 4-arg collapse
- [x] Property: a matching group-less grant collapses the union to `[]`; a group-less grant for a different action leaves the union intact
- [x] Integration: actor with group-less + narrow grant sees **all** fields (no `%Ash.ForbiddenField{}`)
- [x] Masking integration: group-less + masking-group grant → fields returned **raw**, not masked
- [x] Adversarial review confirmed correctness across all 5 consumers; full repo doc sweep found no stale docs

## Notes

A distinct, deny-side bug surfaced while verifying this fix — a field-group-scoped deny (`!resource:*:read:always:group`) over-denies the entire action (raises `Ash.Error.Forbidden`) because `matches?/4` ignores `field_group`. Filed separately as #117; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)