### PR TITLE
feat: validate and signal invalid deny+field_group permissions (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-06-24
+
+### Added
+
+- **`field_group_permissions` option + validation for invalid field-group denies** (#117). A permission that is a deny (`!` prefix) **and** carries a `field_group` (5th part) — e.g. `"!employee:*:read:always:sensitive"` — is invalid: field-group access is positive-only, so column restrictions belong in the resource's `field_group` definition (`inherits`/`except`/`mask`), not in a deny rule. Such a deny currently over-denies the *entire* action (fail-closed) rather than the named group. The new `field_group_permissions` option on the `ash_grant` block controls how this is signaled, without changing the authorization outcome:
+  - `:off` — silent (legacy behavior)
+  - `:warn` — over-denial plus a `Logger.warning` (**default**)
+  - `:strict` — raise `AshGrant.PermissionValidation.InvalidPermissionError`
+
+  A global default may be set with `config :ash_grant, field_group_permissions: :strict`. Introduced `AshGrant.PermissionValidation` and `AshGrant.Info.field_group_permissions/1`; `AshGrant.Evaluator.normalize_permissions/1` is now public.
+
 ## [0.14.2] - 2026-06-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ mix ash_grant.verify path/to/test.yaml --verbose  # Verbose output
 
 - **`AshGrant.Check`** (`lib/ash_grant/checks/check.ex`) - SimpleCheck for write actions (returns true/false)
 - **`AshGrant.FilterCheck`** (`lib/ash_grant/checks/filter_check.ex`) - FilterCheck for read actions (returns filter expression)
+- **`AshGrant.PermissionValidation`** (`lib/ash_grant/permission_validation.ex`) - Validates resolved permissions and signals invalid deny+field_group combinations per the `field_group_permissions` mode (`:off`/`:warn`/`:strict`); never changes the authorization outcome
 
 ### Calculations
 

--- a/guides/field-level-permissions.md
+++ b/guides/field-level-permissions.md
@@ -55,6 +55,18 @@ The 5th part of the permission string specifies the field group:
 
 Fields not in the actor's field group are replaced with `%Ash.ForbiddenField{}`.
 
+> #### Field groups are grant-only {: .warning}
+>
+> A field_group can only appear on an **allow** permission. A deny rule that
+> carries a field_group (e.g. `"!employee:*:read:always:sensitive"`) is invalid —
+> field-group access is positive-only, so column restrictions belong in the
+> `field_group` definition (`inherits`/`except`/`mask`), not in a deny rule. In a
+> hierarchy, "all fields except X" is already expressible as a positive grant of
+> the lower group (here, `:public`). The `field_group_permissions` option
+> (`:off` / `:warn` (default) / `:strict`) controls whether an invalid
+> field-group deny is silent, logged, or raises — it never changes the
+> (fail-closed) outcome.
+
 ## Mode A: Manual Field Policies
 
 Write Ash `field_policies` using `AshGrant.field_check/1`:

--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -292,6 +292,12 @@ defmodule AshGrant.Check do
     # Resolve permissions
     permissions = resolve_permissions(resolver, actor, context)
 
+    AshGrant.PermissionValidation.validate(
+      permissions,
+      AshGrant.Info.field_group_permissions(resource_module),
+      resource: resource_module
+    )
+
     # Check access using evaluator
     case AshGrant.Evaluator.has_access?(permissions, resource_name, action_name, action_type) do
       false ->

--- a/lib/ash_grant/checks/field_check.ex
+++ b/lib/ash_grant/checks/field_check.ex
@@ -69,6 +69,12 @@ defmodule AshGrant.FieldCheck do
 
     permissions = resolve_permissions(resolver, actor, context)
 
+    AshGrant.PermissionValidation.validate(
+      permissions,
+      AshGrant.Info.field_group_permissions(resource_module),
+      resource: resource_module
+    )
+
     actor_field_groups =
       AshGrant.Evaluator.get_all_field_groups(
         permissions,

--- a/lib/ash_grant/checks/filter_check.ex
+++ b/lib/ash_grant/checks/filter_check.ex
@@ -228,6 +228,12 @@ defmodule AshGrant.FilterCheck do
     # Resolve permissions
     permissions = resolve_permissions(resolver, actor, context)
 
+    AshGrant.PermissionValidation.validate(
+      permissions,
+      AshGrant.Info.field_group_permissions(resource_module),
+      resource: resource_module
+    )
+
     # Get RBAC scopes (instance_id = "*")
     scopes =
       AshGrant.Evaluator.get_all_scopes(permissions, resource_name, action_name, action_type)

--- a/lib/ash_grant/dsl.ex
+++ b/lib/ash_grant/dsl.ex
@@ -588,6 +588,25 @@ defmodule AshGrant.Dsl do
         With this, `"feed:feed_abc:read:"` generates `WHERE feed_id IN ('feed_abc')`
         instead of `WHERE id IN ('feed_abc')`.
         """
+      ],
+      field_group_permissions: [
+        type: {:in, [:strict, :warn, :off]},
+        doc: """
+        Controls signaling when a resolved permission is a deny (`!` prefix) that
+        also carries a `field_group` (5th part) — an invalid combination.
+
+        Field-group access is positive-only: column restrictions belong in the
+        `field_group` definition (`inherits`/`except`/`mask`), not in a deny rule.
+        A deny carrying a field_group currently over-denies the entire action
+        (fail-closed). This option only changes *signaling*, never the outcome.
+
+        - `:off`    — silent (legacy behavior)
+        - `:warn`   — over-denial plus a `Logger.warning` (default)
+        - `:strict` — raise `AshGrant.PermissionValidation.InvalidPermissionError`
+
+        Defaults to `:warn`. A global default may be set with
+        `config :ash_grant, field_group_permissions: :strict`.
+        """
       ]
     ]
   }

--- a/lib/ash_grant/evaluator.ex
+++ b/lib/ash_grant/evaluator.ex
@@ -554,11 +554,18 @@ defmodule AshGrant.Evaluator do
     |> normalize_permissions()
   end
 
-  # Private functions
+  @doc """
+  Normalizes a list of permission representations into `%AshGrant.Permission{}` structs.
 
-  defp normalize_permissions(permissions) do
+  Accepts strings, `%AshGrant.Permission{}` structs, `%AshGrant.PermissionInput{}`,
+  and `Permissionable` maps — the same inputs the evaluator and checks accept.
+  """
+  @spec normalize_permissions(permissions()) :: [Permission.t()]
+  def normalize_permissions(permissions) do
     Enum.map(permissions, &normalize_permission/1)
   end
+
+  # Private functions
 
   defp normalize_permission(%Permission{} = perm), do: perm
 

--- a/lib/ash_grant/info.ex
+++ b/lib/ash_grant/info.ex
@@ -80,6 +80,20 @@ defmodule AshGrant.Info do
   end
 
   @doc """
+  Gets the `field_group_permissions` signaling mode (`:strict | :warn | :off`).
+
+  Precedence: the resource-level option, else the global
+  `config :ash_grant, :field_group_permissions`, else `:warn`.
+  Governs how a deny rule that carries a field_group (an invalid combination)
+  is signaled — see `AshGrant.PermissionValidation`.
+  """
+  @spec field_group_permissions(Ash.Resource.t()) :: :strict | :warn | :off
+  def field_group_permissions(resource) do
+    Spark.Dsl.Extension.get_opt(resource, [:ash_grant], :field_group_permissions) ||
+      Application.get_env(:ash_grant, :field_group_permissions, :warn)
+  end
+
+  @doc """
   Gets all scope_through entities for a resource.
 
   Returns an empty list if none are configured.

--- a/lib/ash_grant/permission_validation.ex
+++ b/lib/ash_grant/permission_validation.ex
@@ -1,0 +1,107 @@
+defmodule AshGrant.PermissionValidation do
+  @moduledoc """
+  Validates resolved actor permissions and signals invalid combinations.
+
+  Currently enforces one rule (issue #117): a permission that is a **deny**
+  (`!` prefix) must not carry a **field_group** (5th part). A field-group deny is
+  invalid because field-group access is positive-only — column restrictions
+  belong in the resource's `field_group` definition (`inherits`/`except`/`mask`),
+  and a deny carrying a field_group currently over-denies the *entire* action
+  (fail-closed) rather than the named group.
+
+  The validator never changes the authorization outcome; it only *signals* the
+  invalid permission according to the configured mode:
+
+    * `:off`    — do nothing
+    * `:warn`   — emit a `Logger.warning` (deduplicated per process)
+    * `:strict` — raise `AshGrant.PermissionValidation.InvalidPermissionError`
+
+  The mode is configured per resource via the `field_group_permissions` option in
+  the `ash_grant` DSL block (default `:warn`).
+  """
+
+  require Logger
+
+  alias AshGrant.Permission
+
+  defmodule InvalidPermissionError do
+    @moduledoc """
+    Raised in `:strict` mode when an actor's permissions contain a deny rule that
+    carries a field_group — an invalid combination. See `AshGrant.PermissionValidation`.
+    """
+    defexception [:message]
+  end
+
+  @type mode :: :off | :warn | :strict
+
+  @doc """
+  Validates `permissions` and signals any invalid deny+field_group entries per `mode`.
+
+  Accepts the same permission representations the resolver may return (strings,
+  `%AshGrant.Permission{}` structs, `%AshGrant.PermissionInput{}`, or
+  `Permissionable` maps). Always returns `:ok`; raises `InvalidPermissionError`
+  only in `:strict` mode when an offender is present.
+
+  ## Options
+
+    * `:resource` — the resource module, included in the message for context.
+  """
+  @spec validate(list(), mode(), keyword()) :: :ok
+  def validate(permissions, mode, opts \\ [])
+
+  def validate(_permissions, :off, _opts), do: :ok
+
+  def validate(permissions, mode, opts) when mode in [:warn, :strict] do
+    case offenders(permissions) do
+      [] -> :ok
+      offenders -> signal(offenders, mode, opts)
+    end
+  end
+
+  defp offenders(permissions) do
+    permissions
+    |> AshGrant.Evaluator.normalize_permissions()
+    |> Enum.filter(fn
+      %Permission{} = p -> p.deny and not is_nil(p.field_group)
+      _ -> false
+    end)
+  end
+
+  defp signal(offenders, :strict, opts) do
+    raise InvalidPermissionError, message: message(offenders, opts)
+  end
+
+  defp signal(offenders, :warn, opts) do
+    key = {opts[:resource], offenders |> offender_strings() |> Enum.sort()}
+
+    unless warned?(key) do
+      mark_warned(key)
+      Logger.warning(message(offenders, opts))
+    end
+
+    :ok
+  end
+
+  defp message(offenders, opts) do
+    strings = offender_strings(offenders)
+    on = if resource = opts[:resource], do: " on #{inspect(resource)}", else: ""
+
+    "AshGrant: deny rules cannot carry a field_group (5th part)#{on}. " <>
+      "These permissions are invalid and currently over-deny the entire action " <>
+      "(fail-closed): #{inspect(strings)}. Field-group access is positive-only — " <>
+      "express column restrictions in the resource's field_group definition " <>
+      "(inherits/except/mask) and grant groups positively."
+  end
+
+  defp offender_strings(offenders), do: Enum.map(offenders, &Permission.to_string/1)
+
+  # Per-process dedup so repeated checks within one request log at most once per
+  # {resource, offender-set}. The dedup set lives in the process dictionary; in a
+  # typical request-per-process model it dies with the request. Offenders are a
+  # misconfiguration and expected to be rare, so the set stays small.
+  defp warned?(key), do: MapSet.member?(warned_set(), key)
+
+  defp mark_warned(key), do: Process.put(__MODULE__, MapSet.put(warned_set(), key))
+
+  defp warned_set, do: Process.get(__MODULE__, MapSet.new())
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.14.2"
+  @version "0.15.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do

--- a/test/ash_grant/field_group_permissions_test.exs
+++ b/test/ash_grant/field_group_permissions_test.exs
@@ -1,0 +1,119 @@
+defmodule AshGrant.FieldGroupPermissionsTest do
+  @moduledoc """
+  Config + end-to-end coverage for the `field_group_permissions` option
+  (issue #117, phase ①): a deny rule carrying a field_group is invalid and is
+  signaled per the configured mode, without changing the (already fail-closed)
+  authorization outcome.
+  """
+  # async: false because one test mutates the global :ash_grant app-env.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias AshGrant.Test.{SensitiveRecord, StrictFieldGroupRecord}
+
+  describe "AshGrant.Info.field_group_permissions/1" do
+    test "returns the resource-level option when set" do
+      assert AshGrant.Info.field_group_permissions(StrictFieldGroupRecord) == :strict
+    end
+
+    test "defaults to :warn when unset on the resource" do
+      assert AshGrant.Info.field_group_permissions(SensitiveRecord) == :warn
+    end
+
+    test "falls back to the global app-env when no resource option is set" do
+      Application.put_env(:ash_grant, :field_group_permissions, :strict)
+      on_exit(fn -> Application.delete_env(:ash_grant, :field_group_permissions) end)
+
+      assert AshGrant.Info.field_group_permissions(SensitiveRecord) == :strict
+    end
+  end
+
+  describe "end-to-end :strict resource" do
+    setup do
+      record =
+        StrictFieldGroupRecord
+        |> Ash.Changeset.for_create(
+          :create,
+          %{name: "Alice", department: "Eng", phone: "010-1", address: "1 St"},
+          authorize?: false
+        )
+        |> Ash.create!()
+
+      %{record: record}
+    end
+
+    test "a deny rule carrying a field_group raises InvalidPermissionError on read" do
+      actor = %{
+        permissions: [
+          "strictfieldgrouprecord:*:read:always",
+          "!strictfieldgrouprecord:*:read:always:sensitive"
+        ]
+      }
+
+      # AshGrant raises InvalidPermissionError; Ash wraps non-Ash exceptions
+      # from a check in Ash.Error.Unknown, preserving the (clear) message.
+      err =
+        assert_raise Ash.Error.Unknown, fn ->
+          StrictFieldGroupRecord |> Ash.read!(actor: actor)
+        end
+
+      assert Exception.message(err) =~ "deny rules cannot carry a field_group"
+      assert Exception.message(err) =~ "!strictfieldgrouprecord:*:read:always:sensitive"
+    end
+
+    test "a valid allow + field_group permission reads normally", %{record: record} do
+      actor = %{permissions: ["strictfieldgrouprecord:*:read:always:sensitive"]}
+
+      result =
+        StrictFieldGroupRecord
+        |> Ash.read!(actor: actor)
+        |> Enum.find(&(&1.id == record.id))
+
+      assert result != nil
+      assert result.name == "Alice"
+      assert result.phone == "010-1"
+    end
+  end
+
+  describe "end-to-end default :warn resource" do
+    setup do
+      record =
+        SensitiveRecord
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            name: "John",
+            department: "Eng",
+            position: "Dev",
+            email: "j@x.com",
+            phone: "010-2",
+            address: "2 St",
+            salary: 100
+          },
+          authorize?: false
+        )
+        |> Ash.create!()
+
+      %{record: record}
+    end
+
+    test "a deny rule carrying a field_group logs a warning and stays fail-closed" do
+      actor = %{
+        permissions: [
+          "sensitiverecord:*:read:always",
+          "!sensitiverecord:*:read:always:sensitive"
+        ]
+      }
+
+      log =
+        capture_log(fn ->
+          assert_raise Ash.Error.Forbidden, fn ->
+            SensitiveRecord |> Ash.read!(actor: actor)
+          end
+        end)
+
+      assert log =~ "deny rules cannot carry a field_group"
+    end
+  end
+end

--- a/test/ash_grant/permission_validation_test.exs
+++ b/test/ash_grant/permission_validation_test.exs
@@ -1,0 +1,119 @@
+defmodule AshGrant.PermissionValidationTest do
+  @moduledoc """
+  Unit tests for AshGrant.PermissionValidation (issue #117, phase ①).
+
+  A permission that is BOTH a deny (`!`) AND carries a field_group (5th part) is
+  invalid: deny + field_group currently over-denies the whole action (fail-closed).
+  The validator only *signals* this per the configured mode — it never changes the
+  authorization outcome.
+  """
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias AshGrant.PermissionValidation
+  alias AshGrant.PermissionValidation.InvalidPermissionError
+
+  @deny_fg ["employee:*:read:always", "!employee:*:read:always:sensitive"]
+
+  describe "validate/3 — deny + field_group detection" do
+    test ":strict raises InvalidPermissionError naming the offending permission" do
+      err =
+        assert_raise InvalidPermissionError, fn ->
+          PermissionValidation.validate(@deny_fg, :strict)
+        end
+
+      assert err.message =~ "field_group"
+      assert err.message =~ "!employee:*:read:always:sensitive"
+    end
+
+    test ":warn logs a warning but does not raise and returns :ok" do
+      log =
+        capture_log(fn ->
+          assert PermissionValidation.validate(@deny_fg, :warn) == :ok
+        end)
+
+      assert log =~ "field_group"
+      assert log =~ "!employee:*:read:always:sensitive"
+    end
+
+    test ":off does nothing — no raise, no log, returns :ok" do
+      log =
+        capture_log(fn ->
+          assert PermissionValidation.validate(@deny_fg, :off) == :ok
+        end)
+
+      refute log =~ "field_group"
+    end
+
+    test "accepts raw permission strings and %Permission{} structs alike" do
+      structs = Enum.map(@deny_fg, &AshGrant.Permission.parse!/1)
+
+      assert_raise InvalidPermissionError, fn ->
+        PermissionValidation.validate(structs, :strict)
+      end
+    end
+
+    test "includes the resource in the message when given" do
+      err =
+        assert_raise InvalidPermissionError, fn ->
+          PermissionValidation.validate(@deny_fg, :strict, resource: MyApp.Employee)
+        end
+
+      assert err.message =~ "MyApp.Employee"
+    end
+  end
+
+  describe "validate/3 — valid permissions pass in every mode" do
+    # Each of these must NOT signal: they are either allows carrying a field_group
+    # (legitimate), plain denies with no field_group, or a 5-part deny whose
+    # field_group is empty (parses to nil — not a field-group deny).
+    @valid [
+      ["employee:*:read:always:sensitive"],
+      ["employee:*:read:own:sensitive"],
+      ["employee:*:read:always", "!employee:*:read:always"],
+      ["!employee:*:read:always:"]
+    ]
+
+    test ":strict does not raise for any valid set" do
+      for perms <- @valid do
+        assert PermissionValidation.validate(perms, :strict) == :ok,
+               "expected #{inspect(perms)} to be valid"
+      end
+    end
+
+    test ":warn does not log for any valid set" do
+      log =
+        capture_log(fn ->
+          for perms <- @valid, do: PermissionValidation.validate(perms, :warn)
+        end)
+
+      refute log =~ "field_group"
+    end
+  end
+
+  describe "validate/3 — :warn dedups within a process" do
+    test "logs at most once for repeated identical offenders in the same process" do
+      log =
+        capture_log(fn ->
+          PermissionValidation.validate(@deny_fg, :warn)
+          PermissionValidation.validate(@deny_fg, :warn)
+          PermissionValidation.validate(@deny_fg, :warn)
+        end)
+
+      occurrences = length(Regex.scan(~r/!employee:\*:read:always:sensitive/, log))
+      assert occurrences == 1, "expected exactly one warning, got #{occurrences}"
+    end
+
+    test "warns separately for the same offenders on different resources" do
+      log =
+        capture_log(fn ->
+          PermissionValidation.validate(@deny_fg, :warn, resource: MyApp.A)
+          PermissionValidation.validate(@deny_fg, :warn, resource: MyApp.B)
+        end)
+
+      occurrences = length(Regex.scan(~r/!employee:\*:read:always:sensitive/, log))
+      assert occurrences == 2, "expected one warning per resource, got #{occurrences}"
+    end
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -45,6 +45,9 @@ defmodule AshGrant.Test.Domain do
     # Field-group column-level authorization test resource
     resource(AshGrant.Test.SensitiveRecord)
 
+    # field_group_permissions :strict test resource (issue #117)
+    resource(AshGrant.Test.StrictFieldGroupRecord)
+
     # Field masking test resource
     resource(AshGrant.Test.MaskedRecord)
 

--- a/test/support/resources/strict_field_group_record.ex
+++ b/test/support/resources/strict_field_group_record.ex
@@ -1,0 +1,47 @@
+defmodule AshGrant.Test.StrictFieldGroupRecord do
+  @moduledoc """
+  Test resource mirroring `SensitiveRecord` but with
+  `field_group_permissions :strict` (issue #117, phase ①).
+
+  Used to verify end-to-end that a deny rule carrying a field_group
+  (`!record:*:read:always:sensitive`) raises
+  `AshGrant.PermissionValidation.InvalidPermissionError` through the checks,
+  rather than silently over-denying.
+  """
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    default_policies(true)
+    default_field_policies(true)
+    resource_name("strictfieldgrouprecord")
+    field_group_permissions(:strict)
+
+    scope(:always, true)
+
+    field_group(:public, [:name, :department])
+    field_group(:sensitive, [:phone, :address], inherits: [:public])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:name, :string, public?: true)
+    attribute(:department, :string, public?: true)
+    attribute(:phone, :string, public?: true)
+    attribute(:address, :string, public?: true)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -61,6 +61,26 @@ Instance permissions with a scope name impose an attribute-based condition.
 
 When the 5th part is omitted (4-part format), all fields are visible.
 
+### DON'T: Combine a deny (`!`) with a field_group
+
+Field-group access is **positive-only**. A deny rule must not carry a field_group
+(5th part) — express column restrictions in the resource's `field_group`
+definition (`inherits`/`except`/`mask`) and grant groups positively instead.
+
+```elixir
+# DON'T — a deny carrying a field_group is invalid; it over-denies the whole action
+"!employee:*:read:always:sensitive"
+
+# DO — grant the group that contains exactly the fields the actor may see
+"employee:*:read:always:public"     # everything except sensitive/confidential
+```
+
+The `field_group_permissions` option on the `ash_grant` block controls how an
+invalid field-group deny is signaled (it never changes the outcome, which is
+already fail-closed): `:off` (silent), `:warn` (logs a warning — default), or
+`:strict` (raises `AshGrant.PermissionValidation.InvalidPermissionError`). Set a
+global default with `config :ash_grant, field_group_permissions: :strict`.
+
 ## Resource Setup
 
 ### Always include these three things


### PR DESCRIPTION
## Summary

Closes the **phase ① safety fix** for #117. A permission that is a deny (`!` prefix) **and** carries a `field_group` (5th part) — e.g. `"!employee:*:read:always:sensitive"` — is invalid. Field-group access is **positive-only**: column restrictions belong in the resource's `field_group` definition (`inherits`/`except`/`mask`), not in a deny rule. Because `AshGrant.Permission.matches?/4` ignores `field_group`, such a deny is treated as an action-wide deny and **over-denies the entire read** (fail-closed) instead of the named group.

This PR **detects and signals** the invalid combination **without changing the authorization outcome** (which is already fail-closed). A new `field_group_permissions` option on the `ash_grant` block selects the mode:

| Mode | Behavior |
|---|---|
| `:off` | silent (legacy) |
| `:warn` *(default)* | over-denial + `Logger.warning` (per-`{resource, offender-set}` process dedup) |
| `:strict` | raise `AshGrant.PermissionValidation.InvalidPermissionError` |

A global default may be set with `config :ash_grant, field_group_permissions: :strict`.

### Changes
- **NEW** `AshGrant.PermissionValidation` (`validate/3` + `InvalidPermissionError`)
- **NEW** `field_group_permissions` DSL option + `AshGrant.Info.field_group_permissions/1` (resource → app-env → `:warn`)
- `AshGrant.Evaluator.normalize_permissions/1` made public
- Validator wired into `Check` / `FilterCheck` / `FieldCheck` after permission resolution
- Docs: CHANGELOG (0.15.0), `usage-rules.md` (DON'T rule + option), field-level guide note, CLAUDE.md
- Version bump to **0.15.0** (new feature)

### Why this design
In a hierarchical field-group model, "all fields except X" is always expressible as a positive grant of the lower group, so field-group denies add no expressive power and conflict with the inheritance order (denying a *middle* group inverts sensitivity). Keeping `!` single-meaning (row/action only) keeps the permission syntax intuitive.

## Test plan

- [x] `compile --warnings-as-errors`, `format`, `credo` (clean on new code) — all pass
- [x] `mix test` — 39 doctests, 103 properties, **1076 tests, 0 failures**
- [x] Unit: `:strict` raises, `:warn` logs (+ per-resource dedup), `:off` silent; valid permissions (allow+fg, 4-part deny, empty-5th-part deny) pass in all modes; strings + structs handled
- [x] Config: `Info.field_group_permissions/1` resource option / `:warn` default / app-env fallback
- [x] End-to-end: `:strict` resource raises through the check; `:warn` resource logs and stays fail-closed; valid allow+fg reads normally
- [x] **Adversarial review** (3 dimensions) confirmed the change can **never fail open** — `:off` short-circuits before normalizing; `:warn`/`:strict` preserve the existing fail-closed outcome; a `:strict` raise inside a check aborts the request (no data leak)

## Follow-ups (deferred)
- **Phase ②** — per-record field visibility (`instance`/`scope` + field_group, e.g. "own→full, others→public"). Confirmed **feasible** via Ash's native filter-based field policies (a `FieldFilterCheck` replacing the current `SimpleCheck`); deserves its own design cycle.
- Nice-to-haves: avoid double-normalization in checks, Ash-native `:strict` error class, surface deny+field_group in `Introspect`/`PolicyTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)