### PR TITLE
feat: per-record field visibility (#117 phase ②)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-06-24
+
+### Added
+
+- **Per-record field visibility** (#117 phase ②). Field-group access can now vary **per record** instead of per action. An actor whose row access is broader than their field-group access sees a field on some records and `%Ash.ForbiddenField{}` on others, in the same result set — the pattern the action-wide model could not express:
+
+  ```elixir
+  # public on every readable row, sensitive only on rows the actor owns
+  ["employee:*:read:always:public", "employee:*:read:own:sensitive"]
+
+  # sensitive only on a specific instance
+  ["employee:*:read:always:public", "employee:emp_123:read::sensitive"]
+  ```
+
+  `default_field_policies: true` now generates field policies backed by the new `AshGrant.FieldFilterCheck` (an `Ash.Policy.FilterCheck`) instead of the action-wide `AshGrant.FieldCheck` (a `SimpleCheck`). For each field group it builds a per-row predicate from the actor's reaching grants — the scope expression for RBAC grants, `id in [...]` for instance grants — OR-combined, with downward inheritance. A new `AshGrant.Evaluator.field_group_grants/5` enumerates those grants (including instance permissions, which `get_all_field_groups/4` discards).
+
+  **Backward-compatible**: a trivial-scope grant (`resource:*:read:always:group`) resolves to `true` → visible on all rows, identical to the previous action-wide behavior; masking and the #116 group-less collapse are unchanged.
+
+### Fixed
+
+- **Ungrouped public fields were forbidden for every actor** under `default_field_policies: true`. A public attribute in no field group (e.g. a timestamp or foreign key) became `%Ash.ForbiddenField{}` for everyone, because the generated catch-all `field_policy :*` was keyed literally in the rebuilt field-policy cache while Ash looks fields up concretely. The cache now expands `:*` into the concrete ungrouped fields, so they stay visible (matching the catch-all's documented intent).
+
 ## [0.15.0] - 2026-06-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ mix ash_grant.verify path/to/test.yaml --verbose  # Verbose output
 - **`AshGrant.Check`** (`lib/ash_grant/checks/check.ex`) - SimpleCheck for write actions (returns true/false)
 - **`AshGrant.FilterCheck`** (`lib/ash_grant/checks/filter_check.ex`) - FilterCheck for read actions (returns filter expression)
 - **`AshGrant.PermissionValidation`** (`lib/ash_grant/permission_validation.ex`) - Validates resolved permissions and signals invalid deny+field_group combinations per the `field_group_permissions` mode (`:off`/`:warn`/`:strict`); never changes the authorization outcome
+- **`AshGrant.FieldFilterCheck`** (`lib/ash_grant/checks/field_filter_check.ex`) - FilterCheck for **per-record** field-group visibility; generated into `field_policies` by `AddFieldPolicies`. Builds a per-row predicate from `Evaluator.field_group_grants/5` (a field is visible on some records, `%Ash.ForbiddenField{}` on others)
+- **`AshGrant.FieldCheck`** (`lib/ash_grant/checks/field_check.ex`) - legacy action-wide SimpleCheck for field groups (superseded by `FieldFilterCheck` in generation; still present)
 
 ### Calculations
 

--- a/guides/field-level-permissions.md
+++ b/guides/field-level-permissions.md
@@ -66,6 +66,35 @@ Fields not in the actor's field group are replaced with `%Ash.ForbiddenField{}`.
 > (`:off` / `:warn` (default) / `:strict`) controls whether an invalid
 > field-group deny is silent, logged, or raises — it never changes the
 > (fail-closed) outcome.
+## Per-Record Field Visibility
+
+Field-group access can vary **per record**. When an actor's *row* access is
+broader than their *field-group* access for some group, the group's fields are
+visible only on the records the grant applies to, and `%Ash.ForbiddenField{}`
+elsewhere — in the same result set:
+
+```elixir
+# public fields on every readable row, sensitive fields only on owned rows
+["employee:*:read:always:public", "employee:*:read:own:sensitive"]
+
+# sensitive fields only on a specific instance
+["employee:*:read:always:public", "employee:emp_123:read::sensitive"]
+```
+
+For field group `G`, visibility on a row is the OR of the row predicate of every
+allow grant that reaches `G` (directly or via inheritance): the scope expression
+for RBAC grants (`employee:*:read:own:G`), `id in [...]` for instance grants
+(`employee:emp_123:read::G`). A **trivial scope** (`always`) yields a constant
+`true` — visible on every row, identical to action-wide behavior. A group-less
+(4-part) grant with a scope grants *all* fields on the rows matching that scope.
+
+> #### Caveat: ordering by a per-record-hidden field {: .warning}
+>
+> Ash applies sorting and filtering at the data layer, *before* field visibility
+> is resolved. Sorting a query by a field that is `%Ash.ForbiddenField{}` on some
+> rows still orders those rows by their true (hidden) value — an ordering oracle.
+> The value itself is never returned, but relative order can be inferred. Avoid
+> exposing sorts/filters on fields an actor may not see on every row.
 
 ## Mode A: Manual Field Policies
 

--- a/lib/ash_grant/checks/field_filter_check.ex
+++ b/lib/ash_grant/checks/field_filter_check.ex
@@ -1,0 +1,197 @@
+defmodule AshGrant.FieldFilterCheck do
+  @moduledoc """
+  Per-record field-group visibility check (issue #117 phase ②).
+
+  An `Ash.Policy.FilterCheck` used inside Ash `field_policies`. For a required
+  field group, `filter/3` returns a per-row predicate — `false` (the group's
+  fields are `%Ash.ForbiddenField{}` on every row), `true` (visible on every
+  row), or an Ash expression (visible only on rows matching the contributing
+  grants' scope / instance ids). Ash compiles the predicate into a per-row
+  calculation, so a field can be visible on some records and forbidden on others
+  in the same result set.
+
+  This is the per-record counterpart to the action-wide `AshGrant.FieldCheck`
+  (a `SimpleCheck`). It reuses `AshGrant.Evaluator.field_group_grants/5` to find
+  the allow grants that reach the required group (including instance permissions
+  and inheritance), then builds the predicate exactly like `AshGrant.FilterCheck`
+  builds row filters.
+  """
+  use Ash.Policy.FilterCheck
+
+  require Ash.Expr
+
+  alias AshGrant.{Evaluator, Info}
+
+  @doc """
+  Builds the check tuple for a required field group, for use in a `field_policy`.
+  """
+  def field_filter_check(field_group), do: {__MODULE__, [field_group: field_group]}
+
+  @impl true
+  def describe(opts) do
+    "actor may see the #{inspect(opts[:field_group])} field group on this row"
+  end
+
+  @impl true
+  def filter(actor, authorizer, opts) do
+    if actor == nil do
+      false
+    else
+      do_filter(actor, authorizer, opts)
+    end
+  end
+
+  defp do_filter(actor, authorizer, opts) do
+    required_group = Keyword.fetch!(opts, :field_group)
+    resource = authorizer.resource
+    action = authorizer.action
+    resolver = Info.resolver(resource)
+    action_name = to_string(action.name)
+    action_type = action_type_from(action)
+
+    context = %{
+      actor: actor,
+      resource: resource,
+      action: action,
+      tenant: get_tenant(authorizer)
+    }
+
+    permissions = resolve_permissions(resolver, actor, context)
+
+    field_visibility_filter(permissions, resource, action_name, required_group, action_type)
+  end
+
+  @doc """
+  Builds the per-row visibility predicate for `required_group` from `permissions`.
+
+  Returns `false` (forbidden on every row), `true` (visible on every row), or an
+  Ash expression (visible only on rows matching the contributing grants' scope /
+  instance ids). Exposed for testing.
+  """
+  def field_visibility_filter(
+        permissions,
+        resource,
+        action_name,
+        required_group,
+        action_type \\ nil
+      ) do
+    grants =
+      Evaluator.field_group_grants(
+        permissions,
+        resource,
+        action_name,
+        required_group,
+        action_type
+      )
+
+    {scopes, instance_ids} = partition_grants(grants)
+
+    build_filter(
+      scopes,
+      instance_ids,
+      Info.instance_key(resource),
+      Info.scope_resolver(resource),
+      resource
+    )
+  end
+
+  # RBAC grants (instance_id "*") contribute their scope; instance grants
+  # contribute their instance_id. A group-less grant keeps its scope/instance and
+  # is already included by field_group_grants/5 for every group.
+  defp partition_grants(grants) do
+    {rbac, instance} = Enum.split_with(grants, &(&1.instance_id == "*"))
+
+    scopes = rbac |> Enum.map(& &1.scope) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+    instance_ids = instance |> Enum.map(& &1.instance_id) |> Enum.uniq()
+
+    {scopes, instance_ids}
+  end
+
+  # Mirrors AshGrant.FilterCheck.build_filter_with_instances (raw true/false/expr)
+  # but with CanPerform's empty-context scope resolution, because this predicate
+  # becomes a per-row field-policy calculation that Ash fills templates on.
+  defp build_filter(scopes, instance_ids, instance_key, scope_resolver, resource) do
+    if global_access?(scopes) do
+      true
+    else
+      rbac_filter = if scopes != [], do: build_rbac_filter(scopes, scope_resolver, resource)
+
+      instance_filter =
+        if instance_ids != [], do: build_instance_filter(instance_ids, instance_key)
+
+      [rbac_filter, instance_filter]
+      |> Enum.reject(&(is_nil(&1) or &1 == false))
+      |> or_combine(false)
+    end
+  end
+
+  defp global_access?(scopes), do: "always" in scopes or "all" in scopes or "global" in scopes
+
+  defp build_rbac_filter(scopes, scope_resolver, resource) do
+    scopes
+    |> Enum.map(&resolve_scope(resource, scope_resolver, &1))
+    |> Enum.reject(&(&1 == true))
+    |> or_combine(true)
+  end
+
+  # OR-combine a list of Ash expressions, returning `empty` when the list is empty.
+  defp or_combine([], empty), do: empty
+  defp or_combine([single], _empty), do: single
+
+  defp or_combine([first | rest], _empty),
+    do: Enum.reduce(rest, first, &Ash.Expr.expr(^&2 or ^&1))
+
+  defp build_instance_filter(instance_ids, :id) do
+    Ash.Expr.expr(id in ^instance_ids)
+  end
+
+  defp build_instance_filter(instance_ids, instance_key) do
+    Ash.Expr.expr(^ref(instance_key) in ^instance_ids)
+  end
+
+  # Mirrors CanPerform.resolve_scope — empty context; template refs (^actor,
+  # ^tenant, ^context) are filled by Ash after the field policy compiles.
+  defp resolve_scope(resource, scope_resolver, scope) do
+    scope_atom = if is_binary(scope), do: String.to_existing_atom(scope), else: scope
+
+    case Info.get_scope(resource, scope_atom) do
+      nil -> resolve_with_scope_resolver(scope_resolver, scope)
+      _scope_def -> Info.resolve_scope_filter(resource, scope_atom, %{})
+    end
+  rescue
+    ArgumentError -> resolve_with_scope_resolver(scope_resolver, scope)
+  end
+
+  defp resolve_with_scope_resolver(nil, "always"), do: true
+  defp resolve_with_scope_resolver(nil, "all"), do: true
+  # An unknown scope with no resolver grants nothing (fail-closed at the field level).
+  defp resolve_with_scope_resolver(nil, _scope), do: false
+
+  defp resolve_with_scope_resolver(resolver, scope) when is_function(resolver, 2) do
+    resolver.(scope, %{})
+  end
+
+  defp resolve_with_scope_resolver(resolver, scope) when is_atom(resolver) do
+    resolver.resolve(scope, %{})
+  end
+
+  defp action_type_from(%{type: type}), do: type
+  defp action_type_from(_), do: nil
+
+  defp get_tenant(authorizer) do
+    case authorizer do
+      %{query: %{tenant: tenant}} when not is_nil(tenant) -> tenant
+      %{changeset: %{tenant: tenant}} when not is_nil(tenant) -> tenant
+      %{action_input: %{tenant: tenant}} when not is_nil(tenant) -> tenant
+      _ -> nil
+    end
+  end
+
+  defp resolve_permissions(resolver, actor, context) when is_function(resolver, 2) do
+    resolver.(actor, context)
+  end
+
+  defp resolve_permissions(resolver, actor, context) when is_atom(resolver) do
+    resolver.resolve(actor, context)
+  end
+end

--- a/lib/ash_grant/evaluator.ex
+++ b/lib/ash_grant/evaluator.ex
@@ -462,6 +462,64 @@ defmodule AshGrant.Evaluator do
   end
 
   @doc """
+  Returns the ALLOW permissions that grant visibility of `required_group` on some
+  rows, for per-record field-group authorization (issue #117 phase ②).
+
+  Unlike `get_all_field_groups/4`, this INCLUDES instance permissions (whose
+  field_group `get_all_field_groups` discards) and keeps each grant's `scope` and
+  `instance_id` intact, so a per-record predicate can be built from the result
+  (`AshGrant.FieldFilterCheck`).
+
+  A permission contributes when it is an allow, matches the resource and action
+  (for any `instance_id`), and either is group-less (4-part — grants every group)
+  or its `field_group` equals or inherits toward `required_group`.
+
+  `resource_module` is the resource module (needed to resolve field-group
+  inheritance); `required_group` is the field-group atom.
+  """
+  @spec field_group_grants(permissions(), module(), String.t(), atom(), atom() | nil) ::
+          [Permission.t()]
+  def field_group_grants(permissions, resource_module, action, required_group, action_type \\ nil) do
+    resource_name = AshGrant.Info.resource_name(resource_module)
+
+    permissions
+    |> normalize_permissions()
+    |> Enum.filter(fn perm ->
+      not Permission.deny?(perm) and
+        Permission.matches_resource?(perm.resource, resource_name) and
+        Permission.matches_action?(perm.action, action, action_type) and
+        grants_field_group?(resource_module, perm.field_group, required_group)
+    end)
+  end
+
+  # A group-less (4-part) grant has no field_group — it grants every group.
+  defp grants_field_group?(_resource_module, nil, _required), do: true
+
+  defp grants_field_group?(resource_module, field_group, required) when is_binary(field_group) do
+    field_group == to_string(required) or
+      field_group_inherits_toward?(resource_module, field_group, required)
+  end
+
+  defp field_group_inherits_toward?(resource_module, field_group, required) do
+    group_atom = String.to_existing_atom(field_group)
+    inherits_toward?(resource_module, group_atom, required)
+  rescue
+    # Unknown field-group string (e.g. a typo) cannot inherit toward anything.
+    ArgumentError -> false
+  end
+
+  defp inherits_toward?(resource_module, group_atom, target) do
+    case AshGrant.Info.get_field_group(resource_module, group_atom) do
+      nil ->
+        false
+
+      fg ->
+        parents = fg.inherits || []
+        target in parents or Enum.any?(parents, &inherits_toward?(resource_module, &1, target))
+    end
+  end
+
+  @doc """
   Finds all matching permissions (both allow and deny).
 
   ## Examples

--- a/lib/ash_grant/transformers/add_field_policies.ex
+++ b/lib/ash_grant/transformers/add_field_policies.ex
@@ -87,22 +87,9 @@ defmodule AshGrant.Transformers.AddFieldPolicies do
         end
       end)
 
-    # Add catch-all: field_policy :* -> authorize_if always()
-    catch_all = %Ash.Policy.FieldPolicy{
-      __identifier__: System.unique_integer(),
-      fields: [:*],
-      bypass?: false,
-      condition: [],
-      policies: [
-        %Ash.Policy.Check{
-          type: :authorize_if,
-          check_module: Ash.Policy.Check.Static,
-          check: {Ash.Policy.Check.Static, [result: true]},
-          check_opts: [result: true]
-        }
-      ]
-    }
-
+    # Add catch-all: field_policy :* -> authorize_if always(). rebuild_field_policy_cache/1
+    # expands the :* into the concrete ungrouped fields so they stay visible.
+    catch_all = build_catch_all([:*])
     dsl_state = Transformer.add_entity(dsl_state, [:field_policies], catch_all)
 
     # Rebuild the field-to-policy cache since CacheFieldPolicies may have
@@ -136,6 +123,25 @@ defmodule AshGrant.Transformers.AddFieldPolicies do
     }
   end
 
+  # Catch-all policy: the given ungrouped fields are visible to anyone with row
+  # access (authorize_if always()).
+  defp build_catch_all(fields) do
+    %Ash.Policy.FieldPolicy{
+      __identifier__: System.unique_integer(),
+      fields: fields,
+      bypass?: false,
+      condition: [],
+      policies: [
+        %Ash.Policy.Check{
+          type: :authorize_if,
+          check_module: Ash.Policy.Check.Static,
+          check: {Ash.Policy.Check.Static, [result: true]},
+          check_opts: [result: true]
+        }
+      ]
+    }
+  end
+
   # Rebuild the :fields_to_field_policies persisted cache.
   # This replicates the logic from Ash.Policy.Authorizer.Transformers.CacheFieldPolicies
   # because that transformer runs within the Authorizer extension and may execute
@@ -144,11 +150,28 @@ defmodule AshGrant.Transformers.AddFieldPolicies do
     all_field_policies =
       Transformer.get_entities(dsl_state, [:field_policies])
 
+    # Fields explicitly named by a concrete (non-`:*`) field policy.
+    explicit_fields =
+      all_field_policies
+      |> Enum.flat_map(fn fp -> if fp.fields == [:*], do: [], else: fp.fields end)
+      |> MapSet.new()
+
+    # A `:*` catch-all covers the remaining (ungrouped) valid fields. Ash looks
+    # the cache up by concrete field name, so `:*` must be expanded here — a
+    # literal `:*` key is never matched, which would leave ungrouped fields with
+    # no policy and forbidden for everyone.
+    ungrouped_fields =
+      dsl_state
+      |> valid_field_policy_targets()
+      |> MapSet.difference(explicit_fields)
+      |> MapSet.to_list()
+
     fields_to_field_policies =
       all_field_policies
       |> Enum.reduce(%{}, fn field_policy, acc ->
-        field_policy.fields
-        |> Enum.reduce(acc, fn field, acc ->
+        fields = if field_policy.fields == [:*], do: ungrouped_fields, else: field_policy.fields
+
+        Enum.reduce(fields, acc, fn field, acc ->
           Map.update(acc, field, [field_policy], &(&1 ++ [field_policy]))
         end)
       end)

--- a/lib/ash_grant/transformers/add_field_policies.ex
+++ b/lib/ash_grant/transformers/add_field_policies.ex
@@ -113,6 +113,13 @@ defmodule AshGrant.Transformers.AddFieldPolicies do
   end
 
   defp build_field_policy(group_name, fields) do
+    # `ash_field_policy?: true, access_type: :filter` are normally injected by
+    # `Ash.Policy.FieldPolicy.transform/1` for checks declared via the field_policy
+    # DSL. We build the struct manually (bypassing that transform), so we set them
+    # here — without `access_type: :filter` a FilterCheck is treated as
+    # non-filterable and Ash raises "partial filter for a field policy".
+    opts = [field_group: group_name, ash_field_policy?: true, access_type: :filter]
+
     %Ash.Policy.FieldPolicy{
       __identifier__: System.unique_integer(),
       fields: fields,
@@ -121,9 +128,9 @@ defmodule AshGrant.Transformers.AddFieldPolicies do
       policies: [
         %Ash.Policy.Check{
           type: :authorize_if,
-          check_module: AshGrant.FieldCheck,
-          check: {AshGrant.FieldCheck, [field_group: group_name]},
-          check_opts: [field_group: group_name]
+          check_module: AshGrant.FieldFilterCheck,
+          check: {AshGrant.FieldFilterCheck, opts},
+          check_opts: opts
         }
       ]
     }

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.15.0"
+  @version "0.16.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do

--- a/test/ash_grant/default_field_policies_test.exs
+++ b/test/ash_grant/default_field_policies_test.exs
@@ -49,7 +49,7 @@ defmodule AshGrant.DefaultFieldPoliciesTest do
       assert :email in confidential_policy.fields
     end
 
-    test "field policies use FieldCheck with correct field_group" do
+    test "field policies use FieldFilterCheck with correct field_group" do
       field_policies = Ash.Policy.Info.field_policies(AshGrant.Test.SensitiveRecord)
 
       # Find the policy for public fields
@@ -57,7 +57,7 @@ defmodule AshGrant.DefaultFieldPoliciesTest do
       assert public_policy != nil
 
       [check] = public_policy.policies
-      assert check.check_module == AshGrant.FieldCheck
+      assert check.check_module == AshGrant.FieldFilterCheck
       assert check.check_opts[:field_group] == :public
     end
   end

--- a/test/ash_grant/field_filter_check_test.exs
+++ b/test/ash_grant/field_filter_check_test.exs
@@ -1,0 +1,81 @@
+defmodule AshGrant.FieldFilterCheckTest do
+  @moduledoc """
+  Unit tests for `AshGrant.FieldFilterCheck.field_visibility_filter/5`
+  (issue #117 phase ②, stage 2).
+
+  Tests the per-row predicate the check builds for a required field group:
+  `false` (forbid everywhere), `true` (visible everywhere), or an Ash expression
+  (visible only on rows matching the grants' scope / instance ids).
+
+  Uses `AshGrant.Test.OwnedRecord`: field groups `:public [:title] ⊂ :sensitive
+  [:secret]`, scopes `:always` and `:own` (`owner_id == ^actor(:id)`).
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.FieldFilterCheck
+  alias AshGrant.Test.OwnedRecord
+
+  defp vis(perms, group, action \\ "read", action_type \\ nil) do
+    FieldFilterCheck.field_visibility_filter(perms, OwnedRecord, action, group, action_type)
+  end
+
+  describe "boolean cases" do
+    test "no grant for the group => false (forbidden on every row)" do
+      assert vis([], :sensitive) == false
+      assert vis(["ownedrecord:*:read:always:public"], :sensitive) == false
+    end
+
+    test "group-less grant with a trivial scope => true (visible on every row)" do
+      assert vis(["ownedrecord:*:read:always"], :sensitive) == true
+    end
+
+    test "direct grant with a trivial scope => true" do
+      assert vis(["ownedrecord:*:read:always:sensitive"], :sensitive) == true
+    end
+
+    test "inherited grant with a trivial scope => true (sensitive grants public)" do
+      assert vis(["ownedrecord:*:read:always:sensitive"], :public) == true
+    end
+  end
+
+  describe "scoped (per-row) cases" do
+    test "a non-trivial scope yields an expression, not a boolean" do
+      result = vis(["ownedrecord:*:read:own:sensitive"], :sensitive)
+      refute result === true
+      refute result === false
+      assert inspect(result) =~ "owner_id"
+    end
+
+    test "a group-less grant with a non-trivial scope is scoped (D3), not all-rows" do
+      result = vis(["ownedrecord:*:read:own"], :sensitive)
+      refute result === true
+      refute result === false
+      assert inspect(result) =~ "owner_id"
+    end
+
+    test "an instance grant yields an id predicate" do
+      result = vis(["ownedrecord:rec1:read::sensitive"], :sensitive)
+      refute result === true
+      refute result === false
+      assert inspect(result) =~ "rec1"
+    end
+  end
+
+  describe "the demonstrator: public on all rows + sensitive on own rows" do
+    @shape5 [
+      "ownedrecord:*:read:always:public",
+      "ownedrecord:*:read:own:sensitive"
+    ]
+
+    test ":public is visible on every row (true)" do
+      assert vis(@shape5, :public) == true
+    end
+
+    test ":sensitive is visible only on own rows (scoped expression)" do
+      result = vis(@shape5, :sensitive)
+      refute result === true
+      refute result === false
+      assert inspect(result) =~ "owner_id"
+    end
+  end
+end

--- a/test/ash_grant/field_group_grants_test.exs
+++ b/test/ash_grant/field_group_grants_test.exs
@@ -1,0 +1,140 @@
+defmodule AshGrant.FieldGroupGrantsTest do
+  @moduledoc """
+  Unit + property tests for `AshGrant.Evaluator.field_group_grants/5`
+  (issue #117 phase ②, stage 1).
+
+  The helper returns the ALLOW permissions that grant visibility of a required
+  field group on some rows — including INSTANCE permissions (which
+  `get_all_field_groups/4` discards) and keeping each grant's scope / instance_id
+  intact, so a per-record predicate can be built from them later
+  (`AshGrant.FieldFilterCheck`).
+
+  Uses `AshGrant.Test.SensitiveRecord` for its field-group inheritance chain:
+  `:public ⊂ :sensitive ⊂ :confidential` (resource_name "sensitiverecord").
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias AshGrant.Evaluator
+  alias AshGrant.Test.SensitiveRecord
+
+  defp groups(perms, required, action \\ "read", action_type \\ nil) do
+    Evaluator.field_group_grants(perms, SensitiveRecord, action, required, action_type)
+  end
+
+  describe "direct + inheritance reach" do
+    test "a direct grant of the required group contributes" do
+      grants = groups(["sensitiverecord:*:read:always:public"], :public)
+      assert [%{field_group: "public", scope: "always"}] = grants
+    end
+
+    test "holding a child group grants its ancestors (sensitive reaches public)" do
+      grants = groups(["sensitiverecord:*:read:always:sensitive"], :public)
+      assert [%{field_group: "sensitive"}] = grants
+    end
+
+    test "holding confidential reaches public and sensitive (transitive)" do
+      perms = ["sensitiverecord:*:read:always:confidential"]
+      assert [%{field_group: "confidential"}] = groups(perms, :public)
+      assert [%{field_group: "confidential"}] = groups(perms, :sensitive)
+      assert [%{field_group: "confidential"}] = groups(perms, :confidential)
+    end
+
+    test "holding a parent group does NOT grant a descendant (public !-> confidential)" do
+      assert groups(["sensitiverecord:*:read:always:public"], :confidential) == []
+    end
+  end
+
+  describe "group-less grants" do
+    test "a group-less (4-part) allow contributes to every group" do
+      perms = ["sensitiverecord:*:read:always"]
+      assert [%{field_group: nil}] = groups(perms, :public)
+      assert [%{field_group: nil}] = groups(perms, :sensitive)
+      assert [%{field_group: nil}] = groups(perms, :confidential)
+    end
+  end
+
+  describe "instance permissions (the get_all_field_groups blind spot)" do
+    test "an instance permission with a field_group is included, instance_id intact" do
+      grants = groups(["sensitiverecord:rec1:read::sensitive"], :sensitive)
+      assert [%{field_group: "sensitive", instance_id: "rec1"}] = grants
+    end
+
+    test "for comparison, get_all_field_groups drops the same instance grant" do
+      perms = ["sensitiverecord:rec1:read::sensitive"]
+      assert Evaluator.get_all_field_groups(perms, "sensitiverecord", "read") == []
+    end
+  end
+
+  describe "scope is retained for predicate building" do
+    test "a non-trivial scope is preserved on the returned grant" do
+      assert [%{scope: "own"}] = groups(["sensitiverecord:*:read:own:sensitive"], :sensitive)
+    end
+  end
+
+  describe "exclusions" do
+    test "denies are excluded (they are row-level, handled by the read policy)" do
+      perms = ["sensitiverecord:*:read:always:sensitive", "!sensitiverecord:*:read:always"]
+      assert [%{field_group: "sensitive", deny: false}] = groups(perms, :sensitive)
+    end
+
+    test "permissions for a different resource or action are excluded" do
+      perms = [
+        "other:*:read:always:public",
+        "sensitiverecord:*:update:always:public"
+      ]
+
+      assert groups(perms, :public, "read") == []
+    end
+
+    test "a grant that does not reach the required group is excluded" do
+      # :public grant does not reach :confidential
+      perms = ["sensitiverecord:*:read:always:public", "sensitiverecord:*:read:own:sensitive"]
+      assert groups(perms, :confidential) == []
+    end
+  end
+
+  describe "union — multiple contributing grants" do
+    test "all reaching grants are returned (for predicate OR-combination)" do
+      perms = [
+        "sensitiverecord:*:read:always:public",
+        "sensitiverecord:*:read:own:sensitive"
+      ]
+
+      # :public is reached by the direct :public grant AND the :sensitive grant
+      public_grants = groups(perms, :public)
+      assert length(public_grants) == 2
+      assert Enum.map(public_grants, & &1.field_group) |> Enum.sort() == ["public", "sensitive"]
+
+      # :sensitive is reached only by the :sensitive grant
+      assert [%{field_group: "sensitive", scope: "own"}] = groups(perms, :sensitive)
+    end
+  end
+
+  describe "action_type matching" do
+    test "a read* type-wildcard grant matches a custom read action via action_type" do
+      perms = ["sensitiverecord:*:read*:always:sensitive"]
+      assert [%{field_group: "sensitive"}] = groups(perms, :sensitive, "by_dept", :read)
+    end
+  end
+
+  describe "properties" do
+    property "a group-less allow always contributes to every defined group" do
+      check all(
+              group <- member_of([:public, :sensitive, :confidential]),
+              scope <- member_of(["always", "own"])
+            ) do
+        grants = groups(["sensitiverecord:*:read:#{scope}"], group)
+        assert [%{field_group: nil}] = grants
+      end
+    end
+
+    property "a direct grant naming exactly G contributes to G" do
+      check all(group <- member_of([:public, :sensitive, :confidential])) do
+        grants = groups(["sensitiverecord:*:read:always:#{group}"], group)
+        assert [%{field_group: g}] = grants
+        assert g == to_string(group)
+      end
+    end
+  end
+end

--- a/test/ash_grant/overlapping_field_policies_test.exs
+++ b/test/ash_grant/overlapping_field_policies_test.exs
@@ -119,7 +119,7 @@ defmodule AshGrant.OverlappingFieldPoliciesTest do
   defp find_policy_by_group(policies, group_name) do
     Enum.find(policies, fn policy ->
       Enum.any?(policy.policies, fn check ->
-        check.check_module == AshGrant.FieldCheck and
+        check.check_module == AshGrant.FieldFilterCheck and
           check.check_opts[:field_group] == group_name
       end)
     end)

--- a/test/ash_grant/per_record_field_visibility_test.exs
+++ b/test/ash_grant/per_record_field_visibility_test.exs
@@ -1,0 +1,98 @@
+defmodule AshGrant.PerRecordFieldVisibilityTest do
+  @moduledoc """
+  End-to-end tests for per-record field visibility (issue #117 phase ②, stage 3).
+
+  A field can be visible on some records and `%Ash.ForbiddenField{}` on others in
+  the same result set, decided by each grant's scope / instance id. This is the
+  pattern the action-wide field model cannot express.
+
+  Uses `AshGrant.Test.OwnedRecord`: field groups `:public [:title] ⊂ :sensitive
+  [:secret]`, scopes `:always` and `:own` (`owner_id == ^actor(:id)`).
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.Test.OwnedRecord
+
+  defp create_record!(owner_id, attrs) do
+    OwnedRecord
+    |> Ash.Changeset.for_create(:create, Map.put(attrs, :owner_id, owner_id), authorize?: false)
+    |> Ash.create!()
+  end
+
+  defp read(actor), do: OwnedRecord |> Ash.read!(actor: actor)
+  defp find(results, id), do: Enum.find(results, &(&1.id == id))
+  defp forbidden?(value), do: match?(%Ash.ForbiddenField{}, value)
+
+  setup do
+    mine = create_record!("u1", %{title: "Mine", secret: "my-secret"})
+    other = create_record!("u2", %{title: "Theirs", secret: "their-secret"})
+    %{mine: mine, other: other}
+  end
+
+  describe "scope-conditioned field visibility (the demonstrator)" do
+    test "public on all rows, sensitive only on own rows", %{mine: mine, other: other} do
+      actor = %{
+        id: "u1",
+        permissions: [
+          "ownedrecord:*:read:always:public",
+          "ownedrecord:*:read:own:sensitive"
+        ]
+      }
+
+      results = read(actor)
+      mine_row = find(results, mine.id)
+      other_row = find(results, other.id)
+
+      # Both rows are readable (the :always:public grant gives broad row access).
+      assert mine_row != nil
+      assert other_row != nil
+
+      # public field visible on BOTH
+      assert mine_row.title == "Mine"
+      assert other_row.title == "Theirs"
+
+      # sensitive field visible on OWN row, forbidden on the other
+      assert mine_row.secret == "my-secret"
+      assert forbidden?(other_row.secret)
+    end
+  end
+
+  describe "instance-conditioned field visibility" do
+    test "sensitive visible only on the named instance", %{mine: mine, other: other} do
+      actor = %{
+        id: "anyone",
+        permissions: [
+          "ownedrecord:*:read:always:public",
+          "ownedrecord:#{mine.id}:read::sensitive"
+        ]
+      }
+
+      results = read(actor)
+
+      assert find(results, mine.id).secret == "my-secret"
+      assert forbidden?(find(results, other.id).secret)
+    end
+  end
+
+  describe "backward-compat: trivial scope stays action-wide" do
+    test "a trivial-scope sensitive grant shows the field on every row", %{
+      mine: mine,
+      other: other
+    } do
+      actor = %{id: "u1", permissions: ["ownedrecord:*:read:always:sensitive"]}
+      results = read(actor)
+
+      assert find(results, mine.id).secret == "my-secret"
+      assert find(results, other.id).secret == "their-secret"
+    end
+
+    test "public-only grant forbids sensitive on every row", %{mine: mine, other: other} do
+      actor = %{id: "u1", permissions: ["ownedrecord:*:read:always:public"]}
+      results = read(actor)
+
+      assert forbidden?(find(results, mine.id).secret)
+      assert forbidden?(find(results, other.id).secret)
+      assert find(results, mine.id).title == "Mine"
+    end
+  end
+end

--- a/test/ash_grant/per_record_field_visibility_test.exs
+++ b/test/ash_grant/per_record_field_visibility_test.exs
@@ -74,6 +74,22 @@ defmodule AshGrant.PerRecordFieldVisibilityTest do
     end
   end
 
+  describe "ungrouped fields" do
+    test "a public field in no field_group is visible to any actor with row access", %{
+      mine: mine,
+      other: other
+    } do
+      # owner_id is in no field_group — it must stay visible (covered by the
+      # catch-all), not become %Ash.ForbiddenField{}.
+      actor = %{id: "u1", permissions: ["ownedrecord:*:read:always:public"]}
+      results = read(actor)
+
+      refute forbidden?(find(results, mine.id).owner_id)
+      assert find(results, mine.id).owner_id == "u1"
+      assert find(results, other.id).owner_id == "u2"
+    end
+  end
+
   describe "backward-compat: trivial scope stays action-wide" do
     test "a trivial-scope sensitive grant shows the field on every row", %{
       mine: mine,

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -48,6 +48,9 @@ defmodule AshGrant.Test.Domain do
     # field_group_permissions :strict test resource (issue #117)
     resource(AshGrant.Test.StrictFieldGroupRecord)
 
+    # Per-record field visibility test resource (field groups + :own scope, #117 ②)
+    resource(AshGrant.Test.OwnedRecord)
+
     # Field masking test resource
     resource(AshGrant.Test.MaskedRecord)
 

--- a/test/support/resources/owned_record.ex
+++ b/test/support/resources/owned_record.ex
@@ -1,0 +1,47 @@
+defmodule AshGrant.Test.OwnedRecord do
+  @moduledoc """
+  Test resource for per-record field visibility (issue #117 phase ②).
+
+  Has BOTH field groups and a relational `:own` scope, so per-record field
+  visibility (e.g. "public on all rows, secret only on own rows") can be
+  exercised — the pattern the action-wide model cannot express.
+
+  Field groups: `:public [:title] ⊂ :sensitive [:secret]`.
+  Scopes: `:always` (true) and `:own` (`owner_id == ^actor(:id)`).
+  """
+  use Ash.Resource,
+    domain: AshGrant.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGrant]
+
+  ash_grant do
+    resolver(fn actor, _context ->
+      case actor do
+        %{permissions: perms} -> perms
+        _ -> []
+      end
+    end)
+
+    default_policies(true)
+    default_field_policies(true)
+    resource_name("ownedrecord")
+
+    scope(:always, true)
+    scope(:own, expr(owner_id == ^actor(:id)))
+
+    field_group(:public, [:title])
+    field_group(:sensitive, [:secret], inherits: [:public])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:title, :string, public?: true)
+    attribute(:secret, :string, public?: true)
+    attribute(:owner_id, :string, public?: true)
+  end
+
+  actions do
+    defaults([:read, :destroy, create: :*, update: :*])
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -80,6 +80,17 @@ invalid field-group deny is signaled (it never changes the outcome, which is
 already fail-closed): `:off` (silent), `:warn` (logs a warning — default), or
 `:strict` (raises `AshGrant.PermissionValidation.InvalidPermissionError`). Set a
 global default with `config :ash_grant, field_group_permissions: :strict`.
+Field-group visibility is **per-record**: with `default_field_policies: true`, a
+non-trivial scope or a specific instance id on a 5-part grant restricts the
+group's fields to the matching rows only (forbidden elsewhere). Combine a broad
+row grant with a narrow field grant to vary field visibility by record:
+
+```elixir
+# public fields on all rows, sensitive fields only on owned rows
+["employee:*:read:always:public", "employee:*:read:own:sensitive"]
+```
+
+A trivial scope (`always`) keeps the group visible on every row (action-wide).
 
 ## Resource Setup
 


### PR DESCRIPTION
## Summary

**Phase ② of #117** — field-group access can now vary **per record** instead of per action. When an actor's *row* access is broader than their *field-group* access for some group, that group's fields are visible only on the records the grant applies to, and `%Ash.ForbiddenField{}` elsewhere — in the same result set. This is the pattern the action-wide model could not express:

```elixir
# public on every readable row, sensitive only on owned rows
["employee:*:read:always:public", "employee:*:read:own:sensitive"]
# sensitive only on a specific instance
["employee:*:read:always:public", "employee:emp_123:read::sensitive"]
```

### How
- **NEW `AshGrant.FieldFilterCheck`** (`Ash.Policy.FilterCheck`) — per field group, builds a per-row predicate: OR of each reaching allow grant's scope expr (RBAC) or `id in [...]` (instance), with downward inheritance; group-less → its scope predicate; trivial scope → `true`; nothing → `false`. Ash compiles it to a per-row calc → `ForbiddenField` per record.
- **NEW `AshGrant.Evaluator.field_group_grants/5`** — enumerates the reaching grants, **including instance permissions** (which `get_all_field_groups/4` discards).
- **`AddFieldPolicies`** now generates `FieldFilterCheck`-backed field policies instead of the action-wide `FieldCheck`. The manually-built check sets `access_type: :filter` (normally injected by `Ash.Policy.FieldPolicy.transform/1`).
- **Fix (pre-existing, fail-closed):** ungrouped public fields (timestamps, FKs) were `%Ash.ForbiddenField{}` for everyone because the catch-all `field_policy :*` was keyed literally in the rebuilt cache. The cache now expands `:*` into the concrete ungrouped fields.

### Backward-compatible
A trivial-scope grant (`resource:*:read:always:group`) → predicate `true` → visible on all rows, **identical** to the previous action-wide behavior. Masking and the #116 group-less collapse are unchanged.

## Test plan
Built test-first (red → green) across 3 stages + the ungrouped-fields fix.
- [x] `compile --warnings-as-errors`, `format`, `credo` (clean on new code)
- [x] `mix test` — 39 doctests, 105 properties, **1088 tests, 0 failures**
- [x] Unit: `field_group_grants/5` (instance inclusion, inheritance, deny exclusion, scope retention) + `FieldFilterCheck.field_visibility_filter/5` (true/false/expr cases)
- [x] End-to-end: per-record scope + instance visibility, backward-compat, ungrouped fields
- [x] **Adversarial review** — 4 worktree-isolated agents each *wrote and ran* real tests: **no fail-open in any dimension** (instance grants don't bleed across records, `:own` properly scoped, public-only keeps fields forbidden, filtering/selecting a hidden field never leaks its value, inheritance/multi-group correct, masking intact). It surfaced the ungrouped-fields bug (now fixed).

## Notes
- **Stacks on #117 phase ① (#119, 0.15.0).** This branch is cut from `main` and is independent of ①; merge ① first, then this. The CHANGELOG `[0.16.0]` entry sits above `[0.15.0]` after rebase.
- **Caveat documented** (inherent to Ash, not AshGrant): sorting/filtering by a field that is per-record-forbidden orders rows by the true hidden value (data-layer sort precedes field masking) — an ordering oracle. The value is never returned.
- **Deferred:** per-record *masking* (Stage 4) — `ApplyMasking` still resolves one mask set per query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)