### PR TITLE
test: lock empty/nil/absent actor-list read yields 0 rows (#121)

### DIFF
--- a/test/ash_grant/business_scenarios_test.exs
+++ b/test/ash_grant/business_scenarios_test.exs
@@ -513,6 +513,66 @@ defmodule AshGrant.BusinessScenariosTest do
       refute other_cust.id in ids
     end
 
+    test "empty assigned-territories list yields zero rows, not all rows (no-access edge)" do
+      # Seed customers in arbitrary territories the actor is NOT assigned to. These
+      # seeds are load-bearing: the admin baseline below asserts they exist and are
+      # readable, so a later 0-row result proves the filter is APPLIED rather than
+      # the table being empty (which would make `== []` pass vacuously). Do not remove.
+      _cust1 = generate(customer(territory_id: Ash.UUID.generate()))
+      _cust2 = generate(customer(territory_id: Ash.UUID.generate()))
+      assert length(Customer |> Ash.read!(actor: admin_actor())) == 2
+
+      # Actor holds the territory scope but is assigned to no territories: the
+      # "has access to nothing" state.
+      actor =
+        custom_actor(
+          permissions: ["customer:*:read:assigned_territories"],
+          territory_ids: []
+        )
+
+      customers = Customer |> Ash.read!(actor: actor)
+
+      # `territory_id in ^[]` must compile to a false filter ("no rows"), NOT to a
+      # dropped filter ("all rows"). If this ever regressed to "no filter", it would
+      # be a silent full-table data leak on any list endpoint; if it raised, an outage.
+      assert customers == []
+    end
+
+    test "nil assigned-territories list yields zero rows (no-access edge)" do
+      _cust1 = generate(customer(territory_id: Ash.UUID.generate()))
+      _cust2 = generate(customer(territory_id: Ash.UUID.generate()))
+      assert length(Customer |> Ash.read!(actor: admin_actor())) == 2
+
+      # Pins the observed behavior for a nil actor list. Unlike the empty-list case
+      # (deterministic SQL `IN ()` -> false), nil-safety rides on how Ash lowers
+      # `x in ^nil`; this locks the currently-observed 0-rows-no-error result so a
+      # future Ash change on the nil path would be caught here.
+      actor =
+        custom_actor(
+          permissions: ["customer:*:read:assigned_territories"],
+          territory_ids: nil
+        )
+
+      customers = Customer |> Ash.read!(actor: actor)
+
+      assert customers == []
+    end
+
+    test "missing assigned-territories key yields zero rows (no-access edge)" do
+      _cust1 = generate(customer(territory_id: Ash.UUID.generate()))
+      _cust2 = generate(customer(territory_id: Ash.UUID.generate()))
+      assert length(Customer |> Ash.read!(actor: admin_actor())) == 2
+
+      # Most production-realistic no-access shape: an actor map that simply omits the
+      # attribute. `^actor(:territory_ids)` resolves the missing key to nil, so this
+      # collapses to the nil case above — still zero rows, no error.
+      actor = custom_actor(permissions: ["customer:*:read:assigned_territories"])
+
+      customers = Customer |> Ash.read!(actor: actor)
+
+      assert customers == []
+    end
+
     test "regional_manager can see customers in same region, not other regions" do
       region_id = Ash.UUID.generate()
       other_region = Ash.UUID.generate()


### PR DESCRIPTION
## Summary

Closes #121 — a **test gap**, not a behavior change.

Read-path scopes shaped `scope :x, expr(field in ^actor(:list))` were only tested with **non-empty** actor lists. The security-sensitive "actor has access to nothing" edge (`^actor(:list) == []`) was untested: the filter must compile to *no rows* (a false filter), not *no filter → all rows* (a silent full-table leak), and must not raise.

Actual behavior was verified empirically against Postgres first (throwaway probe), then locked. On the `assigned_territories` scope (`territory_id in ^actor(:territory_ids)`), all three "no access" actor shapes yield **0 rows, no error**:

| Actor `territory_ids` | Behavior |
|---|---|
| `[]` (empty) | 0 rows |
| `nil` | 0 rows |
| key absent | 0 rows |
| `[t]` (control, pre-existing) | exactly the in-territory row |

Adds 3 locking tests to `business_scenarios_test.exs`, next to the existing non-empty territory test. Each **seeds two out-of-territory customers and asserts an admin baseline of 2 rows** before the filtered read, so `assert customers == []` cannot pass vacuously against an empty table — if empty-list handling ever regressed from a false filter to a dropped filter, these fail loudly instead of leaking.

Test-only; no library code changed.

## Test plan

- [x] `mix test` — 1106 tests, 39 doctests, 105 properties, 0 failures
- [x] 3 new tests green in isolation and in the full `business_scenarios_test.exs` file (55 total)
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo` — clean (no new findings)
- [x] `mix format --check-formatted` — clean
- [x] Behavior confirmed via probe before locking: empty / nil / missing-key all return 0 rows with 2 out-of-territory customers present; non-empty control returns exactly the matching row

🤖 Generated with [Claude Code](https://claude.com/claude-code)