### PR TITLE
fix: OR-compose write scopes across all matching grants (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Post |> Ash.read!(actor: viewer)
 ## Guides
 
 - **[Getting Started](guides/getting-started.md)** — Module-based resolvers, explicit policies, domain-level DSL, resolver patterns
-- **[Permissions](guides/permissions.md)** — Permission format, wildcards, RBAC, instance permissions, instance_key, scope_through, deny-wins
+- **[Permissions](guides/permissions.md)** — Permission format, wildcards, RBAC, instance permissions, instance_key, scope_through, deny-wins, multi-grant OR-composition
 - **[Scopes](guides/scopes.md)** — Scope DSL, inheritance, combination rules, multi-tenancy, relational scopes, business examples
 - **[Scope Naming Convention](guides/scope-naming-convention.md)** — Predicate naming, sentence test, RBAC/ABAC patterns, AND/OR composition
 - **[Argument-Based Scope](guides/argument-based-scope.md)** — Multi-hop authorization via action arguments + resource-local lazy loading, avoids DB-query fallback

--- a/guides/debugging-and-introspection.md
+++ b/guides/debugging-and-introspection.md
@@ -132,7 +132,7 @@ AshGrant.Introspect.available_permissions(Post)
 
 ```elixir
 AshGrant.Introspect.can?(Post, :read, user)
-# => {:allow, %{scope: "all", instance_ids: nil, field_groups: []}}
+# => {:allow, %{scope: "all", scopes: ["all"], instance_ids: nil, field_groups: []}}
 
 AshGrant.Introspect.can?(Post, :destroy, user)
 # => {:deny, %{reason: :no_permission}}
@@ -227,7 +227,7 @@ AshGrant.Introspect.explain_by_identifier(
 
 ```elixir
 AshGrant.Introspect.can_by_identifier("user_1", "post", :read)
-# => {:allow, %{scope: "always", instance_ids: nil, field_groups: []}}
+# => {:allow, %{scope: "always", scopes: ["always"], instance_ids: nil, field_groups: []}}
 
 AshGrant.Introspect.can_by_identifier("user_1", "post", :destroy)
 # => {:deny, %{reason: :no_permission}}

--- a/guides/permissions.md
+++ b/guides/permissions.md
@@ -293,3 +293,34 @@ This pattern is useful for:
 - Revoking specific permissions from broad grants
 - Creating "except" rules (e.g., "all except delete")
 - Implementing inheritance with overrides
+
+## Multiple Matching Grants (OR-Composition)
+
+When an actor holds several allow permissions matching the same resource and
+action (e.g. from multiple roles, or a role plus an add-on bundle), their
+scopes **OR-compose**: access is granted when ANY grant's scope passes.
+Grants are purely additive — adding a narrower grant on top of a broader one
+never subtracts access. Deny rules are the only subtractive device.
+
+```elixir
+permissions = [
+  "schedule:*:cancel:online_content",  # narrow add-on bundle
+  "schedule:*:*:always"                # blanket grant
+]
+
+# cancel on ANY schedule -> allowed (the :always grant passes)
+# The narrow grant does not shadow the blanket one, and permission
+# order never changes the outcome.
+```
+
+This applies uniformly across every evaluation path (#123):
+
+- **Read** (`AshGrant.FilterCheck`) — matching grants' scope filters are
+  OR-ed into a single query filter
+- **Write / generic** (`AshGrant.Check`) — the action is authorized when any
+  grant's scope passes (`AshGrant.Evaluator.get_write_scopes/4`)
+- **UI** (`AshGrant.Calculation.CanPerform`) and **policy tests**
+  (`assert_can/3`) — the same union
+
+To restrict access, use a `!` deny rule — never rely on one grant
+"overriding" another.

--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -77,11 +77,12 @@ defmodule AshGrant.Check do
 
   1. **Resolve permissions**: Calls the configured `PermissionResolver` to get
      the actor's permissions
-  2. **Check access**: Uses `AshGrant.Evaluator.has_access?/3` to verify
-     the actor has a matching permission (deny-wins semantics)
-  3. **Get scope**: Extracts the scope from the matching permission
-  4. **Verify scope**: Uses `Ash.Expr.eval/2` to evaluate the scope filter
-     against the target record
+  2. **Collect scopes**: Uses `AshGrant.Evaluator.get_write_scopes/4` to gather
+     the scopes of ALL matching allow grants (deny-wins semantics)
+  3. **Verify scopes**: Evaluates each scope filter with `Ash.Expr.eval/2`
+     against the target record — the action is authorized if ANY grant's
+     scope passes. Grants are additive: a narrow grant never shadows a
+     broader one (issue #123), matching the read path's OR-composition
 
   ## Scope Evaluation
 
@@ -116,6 +117,13 @@ defmodule AshGrant.Check do
 
       scope :readonly, expr(exists(org.users, id == ^actor(:id))),
         write: false
+
+  > #### write: false is per-grant, not per-actor {: .warning}
+  >
+  > `write: false` makes a grant carrying that scope never authorize a write —
+  > but the actor's other matching grants are still evaluated (scopes
+  > OR-compose, issue #123). To hard-block an action for an actor regardless
+  > of their other grants, use a `!` deny permission.
 
   ## Relational Scopes and DB Query Fallback
 
@@ -298,10 +306,21 @@ defmodule AshGrant.Check do
       resource: resource_module
     )
 
-    # Check access using evaluator
-    case AshGrant.Evaluator.has_access?(permissions, resource_name, action_name, action_type) do
-      false ->
-        # RBAC check failed — try scope_through (parent instance permissions)
+    # OR-compose ALL matching grants' scopes (#123): grants are additive, so
+    # the action is authorized when ANY grant's scope passes — a narrow grant
+    # must never shadow a broader one. `!` deny is the only subtractive device.
+    write_scopes =
+      AshGrant.Evaluator.get_write_scopes(permissions, resource_name, action_name, action_type)
+
+    case write_scopes do
+      :unrestricted ->
+        true
+
+      {:scopes, [_ | _] = scopes} ->
+        Enum.any?(scopes, &check_scope_access(&1, scope_resolver, context, authorizer, opts))
+
+      _denied_or_no_match ->
+        # No usable RBAC grant — try scope_through (parent instance permissions)
         check_scope_through_write(
           resource_module,
           permissions,
@@ -309,13 +328,6 @@ defmodule AshGrant.Check do
           action_type,
           authorizer
         )
-
-      true ->
-        # Has permission, now check scope
-        scope =
-          AshGrant.Evaluator.get_scope(permissions, resource_name, action_name, action_type)
-
-        check_scope_access(scope, scope_resolver, context, authorizer, opts)
     end
   end
 

--- a/lib/ash_grant/evaluator.ex
+++ b/lib/ash_grant/evaluator.ex
@@ -73,6 +73,9 @@ defmodule AshGrant.Evaluator do
       Evaluator.get_all_scopes(permissions, "blog", "read")
       # => ["own", "published"]
 
+      Evaluator.get_write_scopes(permissions, "blog", "read")
+      # => {:scopes, ["own", "published"]}
+
   ### Instance Permissions
 
       # Instance permission format: resource:instance_id:action:
@@ -106,8 +109,9 @@ defmodule AshGrant.Evaluator do
   |----------|---------|
   | `has_access?/3` | Check if actor can perform action on resource type |
   | `has_instance_access?/3` | Check if actor can perform action on specific instance |
-  | `get_scope/3` | Get first matching scope (for SimpleCheck) |
+  | `get_scope/3` | Get first matching scope (introspection only) |
   | `get_all_scopes/3` | Get all matching scopes (for FilterCheck) |
+  | `get_write_scopes/4` | Union of matching grant scopes (for Check) |
   | `get_field_group/3` | Get first matching field group from 5-part permissions |
   | `get_all_field_groups/3` | Get all matching field groups (union for field access) |
   | `get_instance_scope/3` | Get scope from instance permission (for ABAC conditions) |
@@ -289,6 +293,14 @@ defmodule AshGrant.Evaluator do
   Returns the scope from the first matching allow permission.
   Returns nil if no matching permission is found or if the match is a deny.
 
+  > #### First match only {: .warning}
+  >
+  > Returns the scope of whichever matching allow permission appears first in
+  > the list — an order-dependent answer that ignores every other grant.
+  > Authorization must use `get_write_scopes/4` (union) instead, as
+  > `AshGrant.Check` does since issue #123. This function remains for
+  > introspection and single-grant convenience.
+
   ## Examples
 
       iex> permissions = ["blog:*:read:always", "blog:*:update:own"]
@@ -358,6 +370,70 @@ defmodule AshGrant.Evaluator do
       |> Enum.map(& &1.scope)
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
+    end
+  end
+
+  @doc """
+  Gets the scopes of ALL matching allow permissions for boolean (write-path)
+  authorization, OR-composing multiple grants (issue #123).
+
+  `AshGrant.Check` authorizes a write action when ANY of the returned scopes
+  passes — the same union semantics `AshGrant.FilterCheck` and
+  `AshGrant.Calculation.CanPerform` apply on the read path. Grants are
+  additive: adding a narrower grant on top of a broader one must never
+  subtract access (the write-path analogue of the group-less collapse in
+  `get_all_field_groups/4`, issue #116).
+
+  Returns:
+
+  - `:denied` — a deny rule matches (deny-wins)
+  - `:unrestricted` — a matching allow grant has no scope (legacy 2-part
+    format, or an empty 4th part); such a grant applies to every record and
+    dominates the union
+  - `{:scopes, scopes}` — the deduplicated scopes of all matching allow
+    permissions, in permission-list order (`{:scopes, []}` when nothing
+    matches)
+
+  ## Examples
+
+      iex> permissions = ["schedule:*:cancel:online_content", "schedule:*:*:always"]
+      iex> AshGrant.Evaluator.get_write_scopes(permissions, "schedule", "cancel", :update)
+      {:scopes, ["online_content", "always"]}
+
+      iex> permissions = ["blog:*:*:always", "!blog:*:delete:always"]
+      iex> AshGrant.Evaluator.get_write_scopes(permissions, "blog", "delete")
+      :denied
+
+      iex> AshGrant.Evaluator.get_write_scopes(["blog:update"], "blog", "update")
+      :unrestricted
+
+  """
+  @spec get_write_scopes(permissions(), String.t(), String.t(), atom() | nil) ::
+          :denied | :unrestricted | {:scopes, [String.t()]}
+  def get_write_scopes(permissions, resource, action, action_type \\ nil) do
+    permissions = normalize_permissions(permissions)
+
+    has_deny =
+      Enum.any?(permissions, fn perm ->
+        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
+      end)
+
+    if has_deny do
+      :denied
+    else
+      matching_allows =
+        Enum.filter(permissions, fn perm ->
+          not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
+        end)
+
+      # A scope-less grant applies to every record and dominates the union
+      # (the write-path analogue of get_all_field_groups/4's group-less
+      # collapse, issue #116).
+      if Enum.any?(matching_allows, &is_nil(&1.scope)) do
+        :unrestricted
+      else
+        {:scopes, matching_allows |> Enum.map(& &1.scope) |> Enum.uniq()}
+      end
     end
   end
 

--- a/lib/ash_grant/introspect.ex
+++ b/lib/ash_grant/introspect.ex
@@ -32,7 +32,7 @@ defmodule AshGrant.Introspect do
 
       # Debugging: Can user do this?
       Introspect.can?(Post, :update, user)
-      # => {:allow, %{scope: "own", instance_ids: nil, field_groups: []}}
+      # => {:allow, %{scope: "own", scopes: ["own"], instance_ids: nil, field_groups: []}}
 
       # API: What actions are available?
       Introspect.allowed_actions(Post, user)
@@ -219,7 +219,7 @@ defmodule AshGrant.Introspect do
   ## Examples
 
       iex> AshGrant.Introspect.can_by_identifier("user_1", "post", :read)
-      {:allow, %{scope: "always", instance_ids: nil, field_groups: []}}
+      {:allow, %{scope: "always", scopes: ["always"], instance_ids: nil, field_groups: []}}
 
   """
   @spec can_by_identifier(term(), String.t(), atom(), keyword()) ::
@@ -505,7 +505,7 @@ defmodule AshGrant.Introspect do
   ## Examples
 
       iex> Introspect.can?(Post, :read, %{role: :editor})
-      {:allow, %{scope: "always", instance_ids: nil, field_groups: []}}
+      {:allow, %{scope: "always", scopes: ["always"], instance_ids: nil, field_groups: []}}
 
       iex> Introspect.can?(Post, :destroy, %{role: :viewer})
       {:deny, %{reason: :no_permission}}
@@ -558,7 +558,10 @@ defmodule AshGrant.Introspect do
 
     cond do
       scopes != [] ->
-        {:allow, %{scope: hd(scopes), instance_ids: nil, field_groups: field_groups}}
+        # :scopes carries ALL matching grants' scopes (union, #123);
+        # :scope stays as the first one for backward compatibility.
+        {:allow,
+         %{scope: hd(scopes), scopes: scopes, instance_ids: nil, field_groups: field_groups}}
 
       instance_ids != [] ->
         {:allow, %{scope: nil, instance_ids: instance_ids, field_groups: field_groups}}

--- a/lib/ash_grant/policy_test/assertions.ex
+++ b/lib/ash_grant/policy_test/assertions.ex
@@ -402,26 +402,29 @@ defmodule AshGrant.PolicyTest.Assertions do
   end
 
   defp check_scope_against_record(resource, _action, actor, record, permission_details, arguments) do
-    scope_name = permission_details[:scope]
+    # OR-compose all matching grants' scopes (#123): the record passes when ANY
+    # grant's scope accepts it — mirroring AshGrant.Check's write-path union.
+    # Callers that only supply :scope (singular) keep working via the fallback.
+    scope_names = permission_details[:scopes] || [permission_details[:scope]]
 
-    if scope_name == nil or scope_name == "always" or scope_name == "all" or
-         scope_name == "global" do
-      # No scope restriction or universal scope - record check passes
+    if Enum.any?(scope_names, &scope_passes?(resource, actor, record, &1, arguments)) do
       {:allow, permission_details}
     else
-      # Get the scope filter and evaluate against the record
-      scope_atom = if is_binary(scope_name), do: String.to_atom(scope_name), else: scope_name
-      context = %{actor: actor}
-      filter = AshGrant.Info.resolve_scope_filter(resource, scope_atom, context)
-
-      case evaluate_filter_against_record(filter, record, actor, resource, arguments) do
-        true ->
-          {:allow, permission_details}
-
-        false ->
-          {:deny, %{reason: :scope_mismatch, scope: scope_name, record: record}}
-      end
+      {:deny, %{reason: :scope_mismatch, scopes: scope_names, record: record}}
     end
+  end
+
+  # nil = no scope restriction (e.g. instance permission); "always"/"all"/
+  # "global" are universal scopes — all pass without filter evaluation.
+  defp scope_passes?(_resource, _actor, _record, scope_name, _arguments)
+       when scope_name in [nil, "always", "all", "global"],
+       do: true
+
+  defp scope_passes?(resource, actor, record, scope_name, arguments) do
+    scope_atom = if is_binary(scope_name), do: String.to_atom(scope_name), else: scope_name
+    filter = AshGrant.Info.resolve_scope_filter(resource, scope_atom, %{actor: actor})
+
+    evaluate_filter_against_record(filter, record, actor, resource, arguments)
   end
 
   @doc false

--- a/test/ash_grant/evaluator_property_test.exs
+++ b/test/ash_grant/evaluator_property_test.exs
@@ -381,4 +381,52 @@ defmodule AshGrant.EvaluatorPropertyTest do
       end
     end
   end
+
+  describe "get_write_scopes/4 union semantics (#123)" do
+    property "result is invariant under permutation of the permission list" do
+      check all(
+              resource <- resource_gen(),
+              action <- action_gen(),
+              scopes <- list_of(scope_gen(), max_length: 5),
+              deny_scopes <- list_of(scope_gen(), max_length: 2),
+              include_bare_grant <- boolean()
+            ) do
+        allows = Enum.map(scopes, &"#{resource}:*:#{action}:#{&1}")
+        denies = Enum.map(deny_scopes, &"!#{resource}:*:#{action}:#{&1}")
+        bare = if include_bare_grant, do: ["#{resource}:#{action}"], else: []
+        permissions = allows ++ denies ++ bare
+
+        baseline =
+          normalize_write_scopes(Evaluator.get_write_scopes(permissions, resource, action))
+
+        for permuted <- [
+              Enum.reverse(permissions),
+              Enum.sort(permissions),
+              Enum.shuffle(permissions)
+            ] do
+          assert normalize_write_scopes(Evaluator.get_write_scopes(permuted, resource, action)) ==
+                   baseline
+        end
+      end
+    end
+
+    property "the first-match scope (get_scope) is contained in the union" do
+      check all(
+              resource <- resource_gen(),
+              action <- action_gen(),
+              scopes <- list_of(scope_gen(), min_length: 1, max_length: 5)
+            ) do
+        permissions = Enum.map(scopes, &"#{resource}:*:#{action}:#{&1}")
+
+        first = Evaluator.get_scope(permissions, resource, action)
+        assert first == hd(scopes)
+
+        assert {:scopes, union} = Evaluator.get_write_scopes(permissions, resource, action)
+        assert first in union
+      end
+    end
+  end
+
+  defp normalize_write_scopes({:scopes, scopes}), do: {:scopes, Enum.sort(scopes)}
+  defp normalize_write_scopes(other), do: other
 end

--- a/test/ash_grant/evaluator_test.exs
+++ b/test/ash_grant/evaluator_test.exs
@@ -217,6 +217,82 @@ defmodule AshGrant.EvaluatorTest do
     end
   end
 
+  describe "get_write_scopes/4" do
+    test "unions the scopes of ALL matching allow grants (#123)" do
+      # gs_net regression: a narrow add-on grant must not shadow a blanket grant
+      permissions = [
+        "schedule:*:cancel:online_content",
+        "schedule:*:*:always"
+      ]
+
+      assert {:scopes, scopes} =
+               Evaluator.get_write_scopes(permissions, "schedule", "cancel", :update)
+
+      assert Enum.sort(scopes) == ["always", "online_content"]
+    end
+
+    test "result does not depend on permission order" do
+      permissions = ["schedule:*:cancel:online_content", "schedule:*:*:always"]
+
+      {:scopes, forward} =
+        Evaluator.get_write_scopes(permissions, "schedule", "cancel", :update)
+
+      {:scopes, reversed} =
+        permissions
+        |> Enum.reverse()
+        |> Evaluator.get_write_scopes("schedule", "cancel", :update)
+
+      assert Enum.sort(forward) == Enum.sort(reversed)
+    end
+
+    test "returns :denied when any deny rule matches" do
+      permissions = ["blog:*:*:always", "!blog:*:delete:always"]
+      assert Evaluator.get_write_scopes(permissions, "blog", "delete") == :denied
+    end
+
+    test "deny beats a scope-less grant" do
+      permissions = ["blog:update", "!blog:*:update:always"]
+      assert Evaluator.get_write_scopes(permissions, "blog", "update") == :denied
+    end
+
+    test "returns an empty scope list when nothing matches" do
+      permissions = ["blog:*:read:always"]
+      assert Evaluator.get_write_scopes(permissions, "blog", "update") == {:scopes, []}
+    end
+
+    test "a scope-less grant collapses the union to :unrestricted" do
+      # A grant with no scope (legacy 2-part, or 4-part with empty scope) applies
+      # to every record, so it dominates the union — mirrors the group-less
+      # collapse in get_all_field_groups/4 (#116).
+      for permissions <- [
+            ["blog:update", "blog:*:update:own"],
+            ["blog:*:update:own", "blog:update"],
+            ["blog:*:update:"]
+          ] do
+        assert Evaluator.get_write_scopes(permissions, "blog", "update") == :unrestricted
+      end
+    end
+
+    test "instance permissions do not contribute (RBAC-only, like get_all_scopes)" do
+      permissions = ["doc:doc_123:update:draft"]
+      assert Evaluator.get_write_scopes(permissions, "doc", "update") == {:scopes, []}
+    end
+
+    test "deduplicates scopes across grants" do
+      permissions = ["blog:*:update:own", "blog:*:*:own"]
+      assert Evaluator.get_write_scopes(permissions, "blog", "update") == {:scopes, ["own"]}
+    end
+
+    test "matches prefix patterns by action type" do
+      permissions = ["blog:*:update*:own", "blog:*:*:always"]
+
+      assert {:scopes, scopes} =
+               Evaluator.get_write_scopes(permissions, "blog", "archive_post", :update)
+
+      assert Enum.sort(scopes) == ["always", "own"]
+    end
+  end
+
   describe "find_matching/3" do
     test "finds all matching permissions" do
       permissions = [

--- a/test/ash_grant/policy_test/multi_grant_union_test.exs
+++ b/test/ash_grant/policy_test/multi_grant_union_test.exs
@@ -1,0 +1,95 @@
+defmodule AshGrant.PolicyTest.MultiGrantUnionTest do
+  @moduledoc """
+  The PolicyTest framework must OR-compose multiple grants' scopes (#123),
+  matching the runtime behavior of `AshGrant.Check`.
+
+  Mirrors the incident that surfaced the bug: a director holds a blanket
+  grant (`schedule:*:*:always`) plus a narrow add-on bundle
+  (`schedule:*:cancel:online_content`). The narrow grant must not shadow
+  the blanket one — regardless of permission order.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshGrant.PolicyTest.Assertions
+
+  defmodule Schedule do
+    @moduledoc false
+    use Ash.Resource,
+      domain: nil,
+      validate_domain_inclusion?: false,
+      extensions: [AshGrant]
+
+    ash_grant do
+      resolver(fn actor, _context -> (actor && Map.get(actor, :permissions)) || [] end)
+      resource_name("schedule")
+
+      scope(:always, true)
+      scope(:online_content, expr(type == :online_education))
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:type, :atom, public?: true)
+    end
+
+    actions do
+      defaults([:read])
+
+      update :cancel do
+        accept([])
+      end
+    end
+  end
+
+  defmodule SchedulePolicyTest do
+    @moduledoc false
+    use AshGrant.PolicyTest
+
+    resource(AshGrant.PolicyTest.MultiGrantUnionTest.Schedule)
+
+    actor(:director, %{
+      permissions: ["schedule:*:cancel:online_content", "schedule:*:*:always"]
+    })
+
+    actor(:director_reversed, %{
+      permissions: ["schedule:*:*:always", "schedule:*:cancel:online_content"]
+    })
+
+    actor(:content_manager, %{
+      permissions: ["schedule:*:cancel:online_content"]
+    })
+  end
+
+  describe "multiple grants OR-compose (#123)" do
+    test "blanket grant authorizes records outside the narrow scope (narrow listed first)" do
+      Assertions.do_assert_can(SchedulePolicyTest, :director, :cancel, %{type: :regular_class})
+    end
+
+    test "permission order does not matter" do
+      Assertions.do_assert_can(
+        SchedulePolicyTest,
+        :director_reversed,
+        :cancel,
+        %{type: :regular_class}
+      )
+    end
+
+    test "the narrow grant alone still denies records outside its scope" do
+      Assertions.do_assert_cannot(
+        SchedulePolicyTest,
+        :content_manager,
+        :cancel,
+        %{type: :regular_class}
+      )
+    end
+
+    test "the narrow grant alone allows records inside its scope" do
+      Assertions.do_assert_can(
+        SchedulePolicyTest,
+        :content_manager,
+        :cancel,
+        %{type: :online_education}
+      )
+    end
+  end
+end

--- a/test/ash_grant/write_scope_union_test.exs
+++ b/test/ash_grant/write_scope_union_test.exs
@@ -1,0 +1,179 @@
+defmodule AshGrant.WriteScopeUnionTest do
+  @moduledoc """
+  E2E tests for OR-composed write scopes (#123).
+
+  A write action must be authorized when ANY matching grant's scope passes.
+  Adding a narrow grant on top of a blanket grant must never revoke access —
+  grants are additive; `!` deny is the only subtractive device. This mirrors
+  the read path (`FilterCheck`) and the UI path (`CanPerform`), which already
+  OR-compose all matching grants.
+
+  Uses BulkItem (:always / :own / :team_member / :frozen scopes).
+  """
+  use AshGrant.DataCase, async: true
+
+  alias AshGrant.Test.BulkItem
+
+  # Inline ETS resource for the `write: false` union cases. It lives here (not
+  # in test/support) because the `write:` option emits a compile-time
+  # deprecation warning, and CI compiles test/support with --warnings-as-errors;
+  # .exs files are only loaded by the test runner, where warnings stay warnings.
+  defmodule FrozenItem do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshGrant.WriteScopeUnionTest.FrozenDomain,
+      validate_domain_inclusion?: false,
+      data_layer: Ash.DataLayer.Ets,
+      authorizers: [Ash.Policy.Authorizer],
+      extensions: [AshGrant]
+
+    ets do
+      private?(true)
+    end
+
+    ash_grant do
+      resolver(fn actor, _context -> (actor && Map.get(actor, :permissions)) || [] end)
+      resource_name("frozen_item")
+
+      scope(:always, true)
+      scope(:frozen, [], expr(title == "frozen"), write: false)
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:title, :string, public?: true)
+    end
+
+    policies do
+      policy action_type(:read) do
+        authorize_if(AshGrant.filter_check())
+      end
+
+      policy action_type([:create, :update, :destroy]) do
+        authorize_if(AshGrant.check())
+      end
+    end
+
+    actions do
+      defaults([:read, create: :*, update: :*])
+    end
+  end
+
+  defmodule FrozenDomain do
+    @moduledoc false
+    use Ash.Domain, validate_config_inclusion?: false
+
+    resources do
+      resource(AshGrant.WriteScopeUnionTest.FrozenItem)
+    end
+  end
+
+  defp actor_with_perms(perms, id \\ Ash.UUID.generate()) do
+    %{id: id, permissions: perms}
+  end
+
+  defp create_item!(attrs) do
+    BulkItem
+    |> Ash.Changeset.for_create(:create, attrs, authorize?: false)
+    |> Ash.create!(authorize?: false)
+  end
+
+  defp update_title(item, actor) do
+    item
+    |> Ash.Changeset.for_update(:update, %{title: "Updated"})
+    |> Ash.update(actor: actor)
+  end
+
+  describe "additive grants (#123): a narrow grant must not shadow a blanket grant" do
+    test "update outside the narrow scope succeeds via the blanket grant (narrow listed first)" do
+      actor = actor_with_perms(["item:*:update:own", "item:*:*:always"])
+      item = create_item!(%{title: "Someone else's", author_id: Ash.UUID.generate()})
+
+      assert {:ok, updated} = update_title(item, actor)
+      assert updated.title == "Updated"
+    end
+
+    test "permission order does not change the outcome (blanket listed first)" do
+      actor = actor_with_perms(["item:*:*:always", "item:*:update:own"])
+      item = create_item!(%{title: "Someone else's", author_id: Ash.UUID.generate()})
+
+      assert {:ok, _} = update_title(item, actor)
+    end
+
+    test "destroy outside the narrow scope succeeds via the blanket grant" do
+      actor = actor_with_perms(["item:*:destroy:own", "item:*:*:always"])
+      item = create_item!(%{title: "Someone else's", author_id: Ash.UUID.generate()})
+
+      assert :ok =
+               item
+               |> Ash.Changeset.for_destroy(:destroy)
+               |> Ash.destroy(actor: actor)
+    end
+
+    test "create outside the narrow scope succeeds via the blanket grant" do
+      actor = actor_with_perms(["item:*:create:own", "item:*:*:always"])
+
+      assert {:ok, _} =
+               BulkItem
+               |> Ash.Changeset.for_create(:create, %{
+                 title: "For someone else",
+                 author_id: Ash.UUID.generate()
+               })
+               |> Ash.create(actor: actor)
+    end
+
+    test "union spans evaluation strategies: failing DB-fallback scope + passing in-memory blanket" do
+      # :team_member needs a DB query (exists()); the actor has no membership,
+      # so that grant fails — the :always grant must still authorize.
+      actor = actor_with_perms(["item:*:update:team_member", "item:*:*:always"])
+      item = create_item!(%{title: "No team", author_id: Ash.UUID.generate()})
+
+      assert {:ok, _} = update_title(item, actor)
+    end
+  end
+
+  describe "union does not weaken enforcement" do
+    test "still forbidden when no grant's scope passes" do
+      actor = actor_with_perms(["item:*:update:own", "item:*:read:always"])
+      item = create_item!(%{title: "Not mine", author_id: Ash.UUID.generate()})
+
+      assert {:error, %Ash.Error.Forbidden{}} = update_title(item, actor)
+    end
+
+    test "deny still wins over every allow in the union" do
+      actor_id = Ash.UUID.generate()
+      actor = actor_with_perms(["item:*:*:always", "!item:*:update:always"], actor_id)
+      item = create_item!(%{title: "Mine", author_id: actor_id})
+
+      assert {:error, %Ash.Error.Forbidden{}} = update_title(item, actor)
+    end
+  end
+
+  describe "write: false scopes in a union" do
+    defp create_frozen_item! do
+      FrozenItem
+      |> Ash.Changeset.for_create(:create, %{title: "Anything"}, authorize?: false)
+      |> Ash.create!(authorize?: false)
+    end
+
+    test "write: false no longer hard-blocks when another grant passes (use ! deny for hard blocks)" do
+      actor = actor_with_perms(["frozen_item:*:update:frozen", "frozen_item:*:*:always"])
+      item = create_frozen_item!()
+
+      assert {:ok, _} =
+               item
+               |> Ash.Changeset.for_update(:update, %{title: "Updated"})
+               |> Ash.update(actor: actor)
+    end
+
+    test "write: false alone still forbids" do
+      actor = actor_with_perms(["frozen_item:*:update:frozen", "frozen_item:*:read:always"])
+      item = create_frozen_item!()
+
+      assert {:error, %Ash.Error.Forbidden{}} =
+               item
+               |> Ash.Changeset.for_update(:update, %{title: "Updated"})
+               |> Ash.update(actor: actor)
+    end
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -498,6 +498,25 @@ Evaluation rules:
 2. If no deny matches and at least one allow matches → **allowed**
 3. If **no** rules match → **denied** (deny by default)
 
+### DO: Rely on grants OR-composing — never on one grant shadowing another
+
+When several allow permissions match the same resource and action (multiple
+roles, add-on bundles), their scopes **OR-compose** on every path (read
+filters, write checks, `can_perform`, policy tests): access is granted when
+ANY grant's scope passes. Adding a narrower grant on top of a broader one
+never subtracts access, and permission order never changes the outcome.
+
+```elixir
+permissions = [
+  "schedule:*:cancel:online_content",  # narrow add-on bundle
+  "schedule:*:*:always"                # blanket grant
+]
+# cancel on ANY schedule ✓ — the blanket grant passes; order is irrelevant
+```
+
+To restrict an action, use a `!` deny rule — a scoped allow grant can only
+ever ADD access.
+
 ## PermissionResolver Behaviour
 
 Implement `AshGrant.PermissionResolver` to provide permissions for actors.


### PR DESCRIPTION
Closes #123

## Summary

**The bug.** `AshGrant.Check` (write/generic actions) resolved a single scope via `Evaluator.get_scope/4` — the scope of whichever matching allow permission appeared *first* in the resolver's list. Every other grant was ignored, so an actor holding `["schedule:*:cancel:online_content", "schedule:*:*:always"]` was **forbidden** from canceling a regular class: the additive grant acted as a revocation, and the outcome depended on permission-list order (DB row order → flappy authorization).

One correction to the issue text: there is no `sort_by_specificity/1` in the codebase — resolution was pure list-order first-match, which is worse than described (no "specific beats wildcard" rule ever existed).

**Why it's a library defect, not a modeling problem:**
1. The library contradicted itself: `FilterCheck` (read) and `CanPerform` (UI) already OR-compose all matching grants via `get_all_scopes`, so the UI showed a cancel button the write check then rejected — with zero deny rules involved.
2. Order-dependent authorization is indefensible; nothing user-facing documented first-match.
3. #116 already established the principle for field groups: *adding an allow grant must never subtract access* (`get_all_field_groups/4` group-less collapse). This is the same defect one field over.

**The fix.** New `AshGrant.Evaluator.get_write_scopes/4` returns `:denied` | `:unrestricted` | `{:scopes, [...]}` — the union of ALL matching allow grants' scopes, with deny-wins preserved and scope-less grants (legacy 2-part) collapsing to `:unrestricted` (mirroring #116). Consumers aligned:
- `AshGrant.Check` authorizes when ANY grant's scope passes; each scope keeps its own strategy (in-memory or DB-query fallback). Routing to `scope_through` on no-match/deny is unchanged.
- `Introspect.can?/4` allow-details now carry `scopes:` (all matching scopes) alongside the backward-compatible `scope:` (first).
- `AshGrant.PolicyTest` record assertions (`assert_can/3` / `assert_cannot/3`) evaluate the union, so policy tests agree with runtime.

**Behavior change (strictly broadening).** First-match-pass ⟹ union-pass, so no actor loses access; actors gain back access their read/UI paths already promised. One consequence to call out loudly: **`write: false` is now per-grant, not per-actor** — a `write: false` scope stops that grant from authorizing writes, but the actor's other matching grants still evaluate. Hard blocks belong to `!` deny. (Documented in `check.ex` moduledoc + guides.)

## Test plan (TDD — all written RED first, 17 failures, then GREEN)

- [x] `evaluator_test.exs` — 9 unit tests for `get_write_scopes/4`: union, order-independence, deny-wins, deny beats unrestricted, no-match, scope-less collapse (2-part + empty 4th part), RBAC-only (instance perms excluded), dedup, action-type prefix matching
- [x] `evaluator_property_test.exs` — 2 properties: result invariant under any permutation of the permission list; first-match scope always contained in the union
- [x] `write_scope_union_test.exs` (E2E, DB) — gs_net scenario both permission orders, destroy/create variants, union across strategies (failing `exists()` DB-fallback grant + passing in-memory blanket), no-pass still Forbidden, deny still wins; `write: false` union cases via an inline ETS resource (kept out of `test/support` because the deprecated `write:` option warns at compile time and CI compiles test/support with `--warnings-as-errors`)
- [x] `policy_test/multi_grant_union_test.exs` — PolicyTest framework union via `assert_can`/`assert_cannot` with an inline resource mirroring the incident
- [x] Full suite: 42 doctests, 107 properties, 1128 tests, 0 failures; `MIX_ENV=test mix compile --warnings-as-errors` clean; credo unchanged (11 pre-existing); format clean

## Docs

- `guides/permissions.md` — new "Multiple Matching Grants (OR-Composition)" section
- `usage-rules.md` — new DO rule: rely on OR-composition, restrict with `!` deny
- `guides/debugging-and-introspection.md` — `can?` examples show `scopes:`
- `check.ex` / `evaluator.ex` moduledocs — union flow, `write: false` warning admonition, first-match warning on `get_scope/4`
- README — permissions guide bullet mentions OR-composition
- CHANGELOG intentionally untouched (updated during `/release` per project convention); proposed entry below

<details>
<summary>Proposed CHANGELOG entry (for /release)</summary>

### Fixed

- **Write actions resolved only ONE grant's scope — adding a narrow grant to a role holding a blanket grant revoked the action** (#123). `AshGrant.Check` used `Evaluator.get_scope/4`, which returns the scope of whichever matching allow permission appears *first* in the resolver's list, ignoring every other grant. An actor holding `["schedule:*:cancel:online_content", "schedule:*:*:always"]` was forbidden from canceling a regular class — the additive grant acted as a revocation — and the outcome depended on permission-list order (i.e. DB row order). Write and generic actions now OR-compose **all** matching grants' scopes via the new `AshGrant.Evaluator.get_write_scopes/4` and authorize when **any** scope passes: the union semantics `FilterCheck` (read) and `CanPerform` (UI) have always applied, and the write-path analogue of #116's group-less collapse — adding an allow grant must never subtract access. Deny rules still win over the whole union, a scope-less grant (legacy 2-part format) still short-circuits to unrestricted, and each scope keeps its own evaluation strategy (in-memory or DB-query fallback). The same union now flows through the tooling: `Introspect.can?/4` allow-details carry `scopes:` (all matching grants' scopes) next to the backward-compatible `scope:` (first match), and `AshGrant.PolicyTest` record assertions (`assert_can/3` / `assert_cannot/3`) evaluate the union, so policy tests agree with runtime.

### Changed

- **`write: false` is per-grant, not per-actor** (consequence of #123). A scope with `write: false` prevents grants carrying *that scope* from authorizing a write; the actor's other matching grants are still evaluated. Previously it could hard-block the whole action whenever it happened to be the first matching grant. To hard-block an action regardless of an actor's other grants, use a `!` deny permission.

</details>

> Note for downstream (Alembic fork): this changes write-path authorization outcomes for permission sets where a broader grant coexists with a narrower one — strictly broadening, aligned with the read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)