### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-07-06
+
+### Fixed
+
+- **Write actions resolved only ONE grant's scope — adding a narrow grant to a role holding a blanket grant revoked the action** (#123). `AshGrant.Check` used `Evaluator.get_scope/4`, which returns the scope of whichever matching allow permission appears *first* in the resolver's list, ignoring every other grant. An actor holding `["schedule:*:cancel:online_content", "schedule:*:*:always"]` was forbidden from canceling a regular class — the additive grant acted as a revocation — and the outcome depended on permission-list order (i.e. DB row order). Write and generic actions now OR-compose **all** matching grants' scopes via the new `AshGrant.Evaluator.get_write_scopes/4` and authorize when **any** scope passes: the union semantics `FilterCheck` (read) and `CanPerform` (UI) have always applied, and the write-path analogue of #116's group-less collapse — adding an allow grant must never subtract access. Deny rules still win over the whole union, a scope-less grant (legacy 2-part format) still short-circuits to unrestricted, and each scope keeps its own evaluation strategy (in-memory or DB-query fallback). The same union now flows through the tooling: `Introspect.can?/4` allow-details carry `scopes:` (all matching grants' scopes) next to the backward-compatible `scope:` (first match), and `AshGrant.PolicyTest` record assertions (`assert_can/3` / `assert_cannot/3`) evaluate the union, so policy tests agree with runtime.
+
+### Changed
+
+- **`write: false` is per-grant, not per-actor** (consequence of #123). A scope with `write: false` prevents grants carrying *that scope* from authorizing a write; the actor's other matching grants are still evaluated. Previously it could hard-block the whole action whenever it happened to be the first matching grant. To hard-block an action regardless of an actor's other grants, use a `!` deny permission.
+
 ## [0.16.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add `ash_grant` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ash_grant, "~> 0.14"}
+    {:ash_grant, "~> 0.17"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.16.0"
+  @version "0.17.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary

- Bump version to 0.17.0 (`mix.exs`)
- Add CHANGELOG entry for 0.17.0
- README installation snippet now recommends `{:ash_grant, "~> 0.17"}`

### What's new in v0.17.0

**Fixed**
- **Write actions resolved only ONE grant's scope — adding a narrow grant to a role holding a blanket grant revoked the action** (#123, PR #124). Write and generic actions now OR-compose ALL matching grants' scopes via the new `AshGrant.Evaluator.get_write_scopes/4` and authorize when ANY scope passes — matching the union semantics the read path (`FilterCheck`) and UI path (`CanPerform`) always had. Deny-wins preserved; scope-less grants still short-circuit to unrestricted; `Introspect.can?/4` gains a `scopes:` key; PolicyTest `assert_can/3` evaluates the union.

**Changed**
- **`write: false` is per-grant, not per-actor** — it stops that grant from authorizing writes, but the actor's other matching grants still evaluate. Hard blocks belong to `!` deny.

⚠️ Behavior change is strictly access-broadening for permission sets where a broader grant coexists with a narrower one — review if you (knowingly or not) relied on first-match shadowing.

## Post-merge

```
git checkout main && git pull
git tag v0.17.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)