### PR TITLE
feat: add @read type wildcard and permission diagnostics (#126)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ mix ash_grant.verify path/to/test.yaml --verbose  # Verbose output
 
 - **`AshGrant`** (`lib/ash_grant.ex`) - Main extension module, exports `check/1` and `filter_check/1`
 - **`AshGrant.Dsl`** (`lib/ash_grant/dsl.ex`) - Spark DSL definition for the `ash_grant` block
-- **`AshGrant.Permission`** (`lib/ash_grant/permission.ex`) - Parses and matches permission strings (`resource:instance_id:action:scope`)
+- **`AshGrant.Permission`** (`lib/ash_grant/permission.ex`) - Parses and matches permission strings (`resource:instance_id:action:scope`). Also exposes `diagnostics/1`, which reports deprecated/dead grant syntax for offline auditing (never affects authorization)
 - **`AshGrant.Evaluator`** (`lib/ash_grant/evaluator.ex`) - Implements deny-wins evaluation logic
 
 ### Policy Checks
@@ -102,6 +102,14 @@ mix ash_grant.verify path/to/test.yaml --verbose  # Verbose output
 - Deny rules always override allow rules
 - `instance_key` option: changes which field instance IDs match against (default `:id`)
 - `scope_through` entity: propagates parent instance permissions to child resources via FK
+- `action` = exact name, `*` (any action), or a **type wildcard** matching by Ash action
+  type: `@read` / `@create` / `@update` / `@destroy` / `@action`. A type wildcard never
+  reads the action name. The older `read*` spelling means the same thing but is
+  deprecated (removal at v1.0.0) — it looks like a prefix glob and never was one.
+- Permission strings are **runtime data** from the `PermissionResolver` (roles table,
+  seeds), not DSL — so there is no compile-time site to validate them. Deprecated/dead
+  syntax is reported offline instead, via `AshGrant.Permission.diagnostics/1` and
+  `mix ash_grant.verify`.
 
 ## Key Patterns
 

--- a/guides/checks-and-policies.md
+++ b/guides/checks-and-policies.md
@@ -39,9 +39,8 @@ Generic actions (Ash actions with `type: :action`) use `Ash.ActionInput` instead
 of `Ash.Query` or `Ash.Changeset`. `check/1` handles this correctly, including
 tenant extraction from `action_input` for multi-tenant authorization.
 
-Generic actions must be authorized by **specific action name** in the permission
-string. Type wildcards do not apply because each generic action is individually
-unique:
+Generic actions are best authorized by **specific action name** in the permission
+string, because each generic action is individually unique:
 
 ```elixir
 # Grants access to the specific "ping" action only
@@ -49,7 +48,16 @@ unique:
 
 # Wildcard (*) grants access to all actions including generic ones
 "service_request:*:*:always"
+
+# The @action type wildcard grants EVERY generic action — see warning below
+"service_request:*:@action:always"
 ```
+
+> **Warning:** `@action` is a type wildcard like `@read` or `@update`, so
+> `service_request:*:@action:always` grants **every** generic action on the resource,
+> including ones added later. Since generic actions are unrelated to one another, the
+> grant that permits `:ping` also permits `:process_refund`. Prefer exact action names.
+> See [Permissions](permissions.md) for the full type-wildcard rules.
 
 Since generic actions have no target record, only non-record scopes (like
 `scope :always, true`) will pass scope evaluation.

--- a/guides/permissions.md
+++ b/guides/permissions.md
@@ -13,7 +13,7 @@ AshGrant uses an Apache Shiro-inspired permission string format with deny-wins s
 | `!` | Optional deny prefix | `!blog:*:delete:always` |
 | resource | Resource type or `*` | `blog`, `post`, `*` |
 | instance_id | Resource instance or `*` | `*`, `post_abc123xyz789ab` |
-| action | Action name or wildcard | `read`, `*`, `read*` |
+| action | Action name or wildcard | `read`, `*`, `@read` |
 | scope | Access scope | `all`, `own`, `published`, or empty |
 | field_group | Optional column-level group | `public`, `sensitive`, `confidential` |
 
@@ -22,7 +22,7 @@ When present, only fields in the named group (and its inherited parents) are acc
 
 ## Wildcard Matching Rules
 
-| Component | `*` (all) | `type*` (action type) | Exact match |
+| Component | `*` (all) | `@type` (action type) | Exact match |
 |-----------|-----------|----------------------|-------------|
 | resource | Yes | No | Yes |
 | instance_id | Yes | No | Yes |
@@ -32,8 +32,8 @@ When present, only fields in the named group (and its inherited parents) are acc
 **Examples:**
 
 ```elixir
-"*:*:read:always"       # All resources, read action (exact name match)
-"blog:*:read*:always"   # All :read-type actions on blog (type match)
+"*:*:read:always"       # All resources, action NAMED read (exact name match)
+"blog:*:@read:always"   # All :read-TYPE actions on blog (type match)
 "blog:*:read:always"    # Only the action named "read" on blog (exact match)
 ```
 
@@ -42,38 +42,80 @@ When present, only fields in the named group (and its inherited parents) are acc
 AshGrant has two distinct action matching modes:
 
 - **`read`** (exact) — matches the action **named** `read`, regardless of its action type
-- **`read*`** (type wildcard) — matches any action whose **action type** is `:read`
+- **`@read`** (type wildcard) — matches any action whose **action type** is `:read`,
+  regardless of its name
 
-These are completely separate. `read*` does **not** match by string prefix — it only
-matches by action type.
+These are completely separate. A type wildcard **never reads the action name**: `@read`
+matches a `:read`-type action called `list_published`, and does not match an
+`:update`-type action called `read_and_bump`.
 
 | Permission | Matches | Why |
 |------------|---------|-----|
-| `post:*:read*:always` | `:list`, `:search`, `:get_by_id` | All actions with `type: :read` |
-| `post:*:update*:always` | `:publish`, `:approve`, `:archive` | All actions with `type: :update` |
+| `post:*:@read:always` | `:list`, `:search`, `:get_by_id` | All actions with `type: :read` |
+| `post:*:@update:always` | `:publish`, `:approve`, `:archive` | All actions with `type: :update` |
 | `post:*:read:always` | `:read` only | Exact action name match |
 
-This means a permission like `post:*:read*:always` grants access to **all read-type actions**
+This means a permission like `post:*:@read:always` grants access to **all read-type actions**
 on the resource, including custom ones like `:search` or `:export` if they are defined
-with `type: :read`.
+with `type: :read` — and including read actions **added later**, with no seed change.
+
+Valid types are Ash's action types: `@action`, `@read`, `@create`, `@update`, `@destroy`.
+Anything else never matches — note that deletion is `@destroy`, not `@delete`.
 
 > **Warning:** Be careful in workflows where different read actions should have different
 > access levels. For example, if `:list` shows summaries but `:read` shows full details,
-> using `read*` would grant access to both. Use exact action names instead:
+> using `@read` would grant access to both. Use exact action names instead:
 > `post:*:list:always` and `post:*:read:own`.
+
+#### The deprecated `read*` spelling
+
+Type wildcards were originally spelled `read*`, and that form still works. It is
+**deprecated** and slated for removal in v1.0.0, because the trailing `*` reads like a
+prefix glob and never was one — `read*` does not match `read_all` by name, and matches
+`:read`-type actions with entirely unrelated names.
+
+Migrate `read*` to `@read`. To find grants still using the old spelling, run
+`mix ash_grant.verify`, or check your permission store directly:
+
+```elixir
+MyApp.Role
+|> MyApp.Repo.all()
+|> Enum.flat_map(& &1.permissions)
+|> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
+```
+
+#### Type wildcards never work on instance permissions
+
+Instance matching has no action type available, so a type wildcard on an instance
+permission **never matches anything** — the grant is dead:
+
+```elixir
+"post:post_abc123:@read:"   # Dead — matches nothing, ever
+"post:post_abc123:read:"    # Use an exact action name
+"post:post_abc123:*:"       # ...or the catch-all wildcard
+```
+
+`AshGrant.Permission.diagnostics/1` flags these.
 
 ### Generic Actions
 
-Generic actions (Ash actions with `type: :action`) must be authorized by their
-**specific action name**. Type wildcards do not apply — each generic action is
-individually unique (one might send email, another processes a payment), so
-blanket type-level access is not supported.
+Generic actions (Ash actions with `type: :action`) are best authorized by their
+**specific action name**. Each generic action is individually unique — one might send
+email, another processes a payment — so blanket type-level access is rarely what you
+want.
 
 | Permission | Matches | Why |
 |------------|---------|-----|
 | `service:*:ping:always` | `:ping` only | Exact action name match |
-| `service:*:*:always` | All actions including generic | Universal wildcard |
 | `service:*:check_status:always` | `:check_status` only | Exact action name match |
+| `service:*:*:always` | All actions including generic | Universal wildcard |
+| `service:*:@action:always` | **Every** generic action | Type wildcard — see warning |
+
+> **Warning:** `@action` is a type wildcard like any other, so `service:*:@action:always`
+> grants **every** generic action on the resource — including ones added later. Because
+> generic actions are unrelated to each other, this is almost never what you want: the
+> grant that let someone `:ping` also lets them `:process_refund`. Prefer exact action
+> names for generic actions.
 
 ```elixir
 # Grant access to specific generic actions
@@ -91,7 +133,7 @@ blanket type-level access is not supported.
 "blog:*:update:own"         # Update own blogs only
 "blog:*:*:always"              # All actions on all blogs
 "*:*:read:always"              # Read all resources
-"blog:*:read*:always"          # All read-type actions
+"blog:*:@read:always"          # All :read-TYPE actions
 "!blog:*:delete:always"        # DENY delete on all blogs
 ```
 

--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -47,15 +47,19 @@ defmodule AshGrant.Check do
   instead of `Ash.Query` or `Ash.Changeset`. This check correctly extracts
   tenant from `action_input` for multi-tenant authorization.
 
-  Generic actions must be authorized by their specific action name in the
-  permission string — type wildcards (`action*`) do not apply because generic
-  actions are individually unique:
+  Generic actions are best authorized by their specific action name in the
+  permission string, because generic actions are individually unique:
 
       # Permission grants access to the specific "ping" action
       "service_request:*:ping:always"
 
       # Wildcard (*) grants access to all actions including generic ones
       "service_request:*:*:always"
+
+      # The @action type wildcard grants EVERY generic action on the resource,
+      # including ones added later — the grant that permits :ping also permits
+      # :process_refund. Prefer exact action names.
+      "service_request:*:@action:always"
 
   Since generic actions have no target record, only `scope :always, true` (or
   other non-record scopes) will pass scope evaluation. Record-based scopes

--- a/lib/ash_grant/permission.ex
+++ b/lib/ash_grant/permission.ex
@@ -27,7 +27,7 @@ defmodule AshGrant.Permission do
   | `!` | Deny prefix (optional) | `!` or omitted |
   | resource | Resource type | identifier, `*` |
   | instance_id | Resource instance or `*` | prefixed_id, UUID, `*` |
-  | action | Action name | identifier, `*`, `prefix*` |
+  | action | Action name | identifier, `*`, `read*` (type wildcard) |
   | scope | Access scope | `all`, `own`, custom, or empty |
   | field_group | Column-level group (optional) | `public`, `sensitive`, custom |
 
@@ -122,6 +122,21 @@ defmodule AshGrant.Permission do
           source: String.t() | nil,
           metadata: map() | nil
         }
+
+  @typedoc """
+  A syntax problem found by `diagnostics/1`.
+
+  `suggestion` is a corrected permission string when one can be inferred, otherwise `nil`.
+  """
+  @type diagnostic :: %{
+          code: :deprecated_type_wildcard | :dead_instance_type_wildcard | :unknown_action_type,
+          permission: String.t(),
+          message: String.t(),
+          suggestion: String.t() | nil
+        }
+
+  # Ash's action types, per `Ash.Resource.Actions.action_type/0`.
+  @valid_action_types ~w(action read create update destroy)
 
   @derive Jason.Encoder
   defstruct [
@@ -318,15 +333,24 @@ defmodule AshGrant.Permission do
 
   Does not consider scope - that's handled by the ScopeResolver.
 
+  This arity passes no `action_type`, so **type wildcards (`"read*"`) never match
+  here** — see `matches?/4` to use them.
+
   ## Examples
 
       iex> perm = AshGrant.Permission.parse!("blog:*:read:always")
       iex> AshGrant.Permission.matches?(perm, "blog", "read")
       true
 
+  A type wildcard needs an action type, and this arity has none — so it matches
+  nothing, regardless of the action name. This is `false` because no type was
+  supplied, *not* because `"read_published"` failed a name comparison:
+
       iex> perm = AshGrant.Permission.parse!("blog:*:read*:always")
       iex> AshGrant.Permission.matches?(perm, "blog", "read_published")
       false
+
+  The bare `"*"` wildcard is a separate rule and is unaffected by `action_type`:
 
       iex> perm = AshGrant.Permission.parse!("blog:*:*:always")
       iex> AshGrant.Permission.matches?(perm, "blog", "delete")
@@ -339,9 +363,10 @@ defmodule AshGrant.Permission do
   @doc """
   Checks if a permission matches a resource, action, and optional Ash action type.
 
-  When `action_type` is provided, prefix patterns like `"read*"` will also match
-  actions whose Ash type equals the prefix (e.g., a `:read`-type action named
-  `list_published` matches `"read*"`).
+  Type wildcards like `"read*"` match on the Ash action *type* alone. A `:read`-type
+  action named `list_published` matches `"read*"` because of its type — never because
+  of its name. When `action_type` is `nil`, type wildcards match nothing; pass a type
+  to use them.
 
   ## Examples
 
@@ -368,6 +393,10 @@ defmodule AshGrant.Permission do
   @doc """
   Checks if a permission matches a specific resource instance.
 
+  Instance matching never has an Ash action type available, so **type wildcards
+  (`"read*"`) can never match an instance permission** — such a grant is dead: it
+  matches nothing, ever. Use `"*"` or an exact action name instead.
+
   ## Examples
 
       iex> perm = AshGrant.Permission.parse!("blog:post_abc123xyz789ab:read:")
@@ -377,6 +406,13 @@ defmodule AshGrant.Permission do
       iex> perm = AshGrant.Permission.parse!("blog:post_abc123xyz789ab:*:")
       iex> AshGrant.Permission.matches_instance?(perm, "post_abc123xyz789ab", "write")
       true
+
+  A type wildcard on an instance permission is always `false` — this grant can never
+  authorize anything:
+
+      iex> perm = AshGrant.Permission.parse!("blog:post_abc123xyz789ab:read*:")
+      iex> AshGrant.Permission.matches_instance?(perm, "post_abc123xyz789ab", "list")
+      false
 
   """
   @spec matches_instance?(t(), String.t(), String.t()) :: boolean()
@@ -411,6 +447,85 @@ defmodule AshGrant.Permission do
   def resource(%__MODULE__{resource: resource}), do: resource
 
   @doc """
+  Reports syntax problems in a permission, for offline auditing.
+
+  Permission strings are runtime data — they live in your roles table, your seeds, or
+  wherever your `AshGrant.PermissionResolver` reads from. AshGrant cannot reach that
+  store, so it exposes this check instead: run it over your own permission data to find
+  grants that need migrating.
+
+      MyApp.Role
+      |> MyApp.Repo.all()
+      |> Enum.flat_map(& &1.permissions)
+      |> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
+
+  `mix ash_grant.verify` runs this automatically over the permissions its policy tests
+  resolve. This never changes authorization behavior: a permission with diagnostics
+  still evaluates exactly as it always did.
+
+  Unparseable strings return `[]` — malformed input is `parse/1`'s business, not this
+  function's.
+
+  ## Diagnostic codes
+
+    * `:deprecated_type_wildcard` — the `"read*"` spelling. Prefer `"@read"`; the
+      trailing-`*` form is slated for removal in v1.0.0.
+    * `:dead_instance_type_wildcard` — a type wildcard on an instance permission.
+      Instance matching has no action type available, so the grant never matches
+      anything. See `matches_instance?/3`.
+    * `:unknown_action_type` — a type wildcard naming something that is not an Ash
+      action type (`:action`, `:read`, `:create`, `:update`, `:destroy`), so it never
+      matches. `"delete*"` is the common case — Ash calls that type `:destroy`.
+
+  ## Examples
+
+  A well-formed grant reports nothing:
+
+      iex> AshGrant.Permission.diagnostics("blog:*:read:always")
+      []
+
+      iex> AshGrant.Permission.diagnostics("blog:*:@read:always")
+      []
+
+  The deprecated spelling suggests its replacement:
+
+      iex> [d] = AshGrant.Permission.diagnostics("blog:*:read*:always")
+      iex> {d.code, d.suggestion}
+      {:deprecated_type_wildcard, "blog:*:@read:always"}
+
+  A type wildcard on an instance permission is dead, in either spelling:
+
+      iex> [d] = AshGrant.Permission.diagnostics("blog:post_abc123:@read:")
+      iex> d.code
+      :dead_instance_type_wildcard
+
+  `delete` is not an Ash action type, so this grant never matches:
+
+      iex> codes = "blog:*:delete*:always" |> AshGrant.Permission.diagnostics() |> Enum.map(& &1.code)
+      iex> Enum.sort(codes)
+      [:deprecated_type_wildcard, :unknown_action_type]
+
+      iex> [_, unknown] = "blog:*:delete*:always" |> AshGrant.Permission.diagnostics() |> Enum.sort_by(& &1.code)
+      iex> unknown.suggestion
+      "blog:*:@destroy:always"
+
+  """
+  @spec diagnostics(t() | String.t()) :: [diagnostic()]
+  def diagnostics(permission_string) when is_binary(permission_string) do
+    case parse(permission_string) do
+      {:ok, perm} -> diagnostics(perm)
+      {:error, _reason} -> []
+    end
+  end
+
+  def diagnostics(%__MODULE__{} = perm) do
+    case type_wildcard(perm.action) do
+      nil -> []
+      {form, type_name} -> type_wildcard_diagnostics(perm, form, type_name)
+    end
+  end
+
+  @doc """
   Checks if a resource pattern matches a resource name.
 
   Supports wildcard matching with `"*"`.
@@ -433,7 +548,11 @@ defmodule AshGrant.Permission do
   @doc """
   Checks if an action pattern matches an action name.
 
-  Supports wildcard matching with `"*"` and prefix matching with `"prefix*"`.
+  Supports the catch-all wildcard `"*"` and exact action names.
+
+  Type wildcards (`"read*"`) never match through this arity. They compare against an
+  Ash action *type*, and no type is available here — use `matches_action?/3` and pass
+  an `action_type` for those.
 
   ## Examples
 
@@ -441,9 +560,16 @@ defmodule AshGrant.Permission do
       true
       iex> AshGrant.Permission.matches_action?("read", "read")
       true
+      iex> AshGrant.Permission.matches_action?("read", "write")
+      false
+
+  `"read*"` is a **type wildcard, not a prefix glob** — it never reads the action name.
+  So it does not match `"read_all"` despite the shared prefix, and without an
+  `action_type` it matches nothing at all, not even `"read"` itself:
+
       iex> AshGrant.Permission.matches_action?("read*", "read_all")
       false
-      iex> AshGrant.Permission.matches_action?("read", "write")
+      iex> AshGrant.Permission.matches_action?("read*", "read")
       false
 
   """
@@ -453,40 +579,159 @@ defmodule AshGrant.Permission do
   @doc """
   Checks if an action pattern matches an action name, with optional Ash action type.
 
-  When `action_type` is provided and the pattern is a type wildcard like `"read*"`,
-  the match succeeds if the action type matches the prefix. This allows `"read*"` to
-  match `:read`-type actions like `list_published` or `by_slug`. Without `action_type`,
-  type wildcards never match — use exact action names instead.
+  ## Type wildcards
+
+  A type wildcard matches on the Ash action *type* and never looks at the action
+  name. Two spellings are equivalent:
+
+    * `"@read"` — **preferred.** Cannot be misread as a glob.
+    * `"read*"` — **deprecated**, removal planned for v1.0.0. The trailing `*` looks
+      like a prefix glob but never was one. Still fully supported; `mix ash_grant.verify`
+      reports grants that use it.
+
+  Because only the type is compared, a `:read`-type action named `list_published`
+  matches `"@read"`, while an `:update`-type action named `read_and_bump` does not.
+  Without an `action_type`, both forms match nothing.
+
+  The catch-all `"*"` is a separate rule: it matches any action and ignores
+  `action_type` entirely.
 
   ## Examples
 
       iex> AshGrant.Permission.matches_action?("*", "anything", :read)
       true
+      iex> AshGrant.Permission.matches_action?("@read", "list_published", :read)
+      true
+      iex> AshGrant.Permission.matches_action?("@read", "list_published", :update)
+      false
+      iex> AshGrant.Permission.matches_action?("read", "read", :read)
+      true
+
+  The deprecated `"read*"` spelling behaves identically:
+
       iex> AshGrant.Permission.matches_action?("read*", "list_published", :read)
       true
-      iex> AshGrant.Permission.matches_action?("read*", "list_published", :update)
+      iex> AshGrant.Permission.matches_action?("update*", "publish", :update)
+      true
+
+  Neither form matches without an `action_type`:
+
+      iex> AshGrant.Permission.matches_action?("@read", "read_all", nil)
       false
       iex> AshGrant.Permission.matches_action?("read*", "read_all", nil)
       false
-      iex> AshGrant.Permission.matches_action?("update*", "publish", :update)
-      true
-      iex> AshGrant.Permission.matches_action?("read", "read", :read)
-      true
 
   """
   @spec matches_action?(String.t(), String.t(), atom() | nil) :: boolean()
   def matches_action?("*", _action, _action_type), do: true
 
+  # Type wildcard, explicit form: "@read"
+  def matches_action?("@" <> type_name, _action, action_type) do
+    matches_type?(type_name, action_type)
+  end
+
   def matches_action?(pattern, action, action_type) do
     if String.ends_with?(pattern, "*") do
-      prefix = String.trim_trailing(pattern, "*")
-      action_type != nil and Atom.to_string(action_type) == prefix
+      # Type wildcard, deprecated form: "read*" — compares the type, never the name
+      pattern
+      |> String.trim_trailing("*")
+      |> matches_type?(action_type)
     else
       pattern == action
     end
   end
 
   # Private functions
+
+  # A type wildcard with no action type to compare against matches nothing.
+  defp matches_type?(_type_name, nil), do: false
+  defp matches_type?(type_name, action_type), do: Atom.to_string(action_type) == type_name
+
+  # Classifies an action pattern as a type wildcard, returning its spelling and the
+  # type it names. `"*"` is the catch-all, not a type wildcard.
+  defp type_wildcard("*"), do: nil
+  defp type_wildcard("@" <> type_name), do: {:explicit, type_name}
+
+  defp type_wildcard(action) do
+    if String.ends_with?(action, "*") do
+      {:deprecated, String.trim_trailing(action, "*")}
+    end
+  end
+
+  defp type_wildcard_diagnostics(perm, form, type_name) do
+    string = __MODULE__.to_string(perm)
+
+    deprecated_diagnostic(perm, form, type_name, string) ++
+      dead_instance_diagnostic(perm, string) ++
+      unknown_type_diagnostic(perm, type_name, string)
+  end
+
+  defp deprecated_diagnostic(_perm, :explicit, _type_name, _string), do: []
+
+  defp deprecated_diagnostic(perm, :deprecated, type_name, string) do
+    # Only suggest the spelling swap when it actually yields a working grant. If the
+    # permission has a deeper problem (dead instance grant, or a type Ash doesn't have),
+    # that diagnostic carries the real fix — suggesting `@#{type_name}` here would point
+    # at a grant that still never matches.
+    suggestion =
+      if type_name in @valid_action_types and not instance_permission?(perm) do
+        __MODULE__.to_string(%{perm | action: "@" <> type_name})
+      end
+
+    [
+      %{
+        code: :deprecated_type_wildcard,
+        permission: string,
+        message:
+          "`#{perm.action}` is a type wildcard, not a prefix glob — it compares the " <>
+            "action type and never reads the action name. The `#{perm.action}` spelling " <>
+            "is slated for removal in v1.0.0." <>
+            if(suggestion, do: " Prefer `@#{type_name}`.", else: ""),
+        suggestion: suggestion
+      }
+    ]
+  end
+
+  defp dead_instance_diagnostic(perm, string) do
+    if instance_permission?(perm) do
+      [
+        %{
+          code: :dead_instance_type_wildcard,
+          permission: string,
+          message:
+            "Type wildcard `#{perm.action}` on an instance permission never matches: " <>
+              "instance matching has no action type to compare against. Use `*` or an " <>
+              "exact action name.",
+          suggestion: nil
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp unknown_type_diagnostic(perm, type_name, string) do
+    if type_name in @valid_action_types do
+      []
+    else
+      corrected = corrected_type(type_name)
+
+      [
+        %{
+          code: :unknown_action_type,
+          permission: string,
+          message:
+            "`#{type_name}` is not an Ash action type " <>
+              "(#{Enum.join(@valid_action_types, ", ")}), so `#{perm.action}` never " <>
+              "matches." <> if(corrected, do: " Did you mean `@#{corrected}`?", else: ""),
+          suggestion: corrected && __MODULE__.to_string(%{perm | action: "@" <> corrected})
+        }
+      ]
+    end
+  end
+
+  defp corrected_type("delete"), do: "destroy"
+  defp corrected_type(_type_name), do: nil
 
   defp parse_deny_prefix("!" <> rest), do: {true, rest}
   defp parse_deny_prefix(str), do: {false, str}

--- a/lib/mix/tasks/ash_grant.verify.ex
+++ b/lib/mix/tasks/ash_grant.verify.ex
@@ -21,6 +21,25 @@ defmodule Mix.Tasks.AshGrant.Verify do
     * `--verbose` - Show detailed output for each test
     * `--format` - Output format: text (default), json
 
+  ## Permission syntax warnings
+
+  After running the tests, this task resolves each policy test actor's permissions and
+  reports deprecated or dead grant syntax — see `AshGrant.Permission.diagnostics/1` for
+  the full list of codes.
+
+  This only sees grants held by the actors your policy tests declare, so a clean run is
+  **not** proof that your permission store is clean. Permission strings live in your own
+  database or seeds, which AshGrant cannot reach; to audit all of them, run
+  `AshGrant.Permission.diagnostics/1` over your own data:
+
+      MyApp.Role
+      |> MyApp.Repo.all()
+      |> Enum.flat_map(& &1.permissions)
+      |> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
+
+  YAML tests carry their permissions inline rather than through policy test modules and
+  are not scanned. Warnings never affect the exit code.
+
   ## Exit Codes
 
     * 0 - All tests passed
@@ -40,9 +59,15 @@ defmodule Mix.Tasks.AshGrant.Verify do
     verbose = Keyword.get(opts, :verbose, false)
     format = Keyword.get(opts, :format, "text")
 
-    results = run_tests(args, verbose)
+    {results, modules} = run_tests(args, verbose)
 
     output_results(results, format, verbose)
+
+    if format != "json" do
+      modules
+      |> collect_diagnostics()
+      |> print_diagnostics()
+    end
 
     if results.failed > 0 do
       System.at_exit(fn _ -> exit({:shutdown, 1}) end)
@@ -57,13 +82,13 @@ defmodule Mix.Tasks.AshGrant.Verify do
 
     if modules == [] do
       Mix.shell().info("No policy test modules found.")
-      %{passed: 0, failed: 0, results: []}
+      {%{passed: 0, failed: 0, results: []}, []}
     else
       if verbose do
         Mix.shell().info("Found #{length(modules)} module(s)")
       end
 
-      AshGrant.PolicyTest.Runner.run_all(modules: modules)
+      {AshGrant.PolicyTest.Runner.run_all(modules: modules), modules}
     end
   end
 
@@ -91,11 +116,13 @@ defmodule Mix.Tasks.AshGrant.Verify do
       {:ok, results} ->
         passed = Enum.count(results, & &1.passed)
         failed = Enum.count(results, &(not &1.passed))
-        %{passed: passed, failed: failed, results: results}
+        # YAML tests carry their permissions inline rather than through policy test
+        # modules, so there are no actors to resolve for the diagnostics pass.
+        {%{passed: passed, failed: failed, results: results}, []}
 
       {:error, reason} ->
         Mix.shell().error("Failed to parse YAML: #{inspect(reason)}")
-        %{passed: 0, failed: 0, results: []}
+        {%{passed: 0, failed: 0, results: []}, []}
     end
   end
 
@@ -106,9 +133,9 @@ defmodule Mix.Tasks.AshGrant.Verify do
 
     if modules == [] do
       Mix.shell().info("No policy test modules found in #{path}")
-      %{passed: 0, failed: 0, results: []}
+      {%{passed: 0, failed: 0, results: []}, []}
     else
-      AshGrant.PolicyTest.Runner.run_all(modules: modules)
+      {AshGrant.PolicyTest.Runner.run_all(modules: modules), modules}
     end
   end
 
@@ -122,9 +149,9 @@ defmodule Mix.Tasks.AshGrant.Verify do
 
     if modules == [] do
       Mix.shell().info("No policy test modules found in #{path}")
-      %{passed: 0, failed: 0, results: []}
+      {%{passed: 0, failed: 0, results: []}, []}
     else
-      AshGrant.PolicyTest.Runner.run_all(modules: modules)
+      {AshGrant.PolicyTest.Runner.run_all(modules: modules), modules}
     end
   end
 
@@ -173,6 +200,63 @@ defmodule Mix.Tasks.AshGrant.Verify do
   defp print_verbose_result(%{passed: false, test_name: name, message: message}) do
     Mix.shell().error("  ✗ #{name}")
     Mix.shell().error("    #{message}")
+  end
+
+  # Resolves each policy test module's actors through the real resolver and reports any
+  # permission syntax problems in the grants that come back. This only sees grants that
+  # the declared test actors happen to hold — it is not an audit of your whole permission
+  # store. To check that, run `AshGrant.Permission.diagnostics/1` over your own data.
+  defp collect_diagnostics(modules) do
+    modules
+    |> Enum.flat_map(&module_diagnostics/1)
+    |> Enum.uniq_by(&{&1.code, &1.permission})
+    |> Enum.sort_by(&{&1.permission, &1.code})
+  end
+
+  defp module_diagnostics(module) do
+    if function_exported?(module, :__policy_test__, 1) do
+      case module.__policy_test__(:resource) do
+        nil -> []
+        resource -> actor_diagnostics(module, resource)
+      end
+    else
+      []
+    end
+  end
+
+  defp actor_diagnostics(module, resource) do
+    module.__policy_test__(:actors)
+    |> Enum.flat_map(fn {_name, attrs} ->
+      resource
+      |> AshGrant.Introspect.permissions_for(attrs)
+      |> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
+    end)
+  rescue
+    # A resolver that cannot handle a bare actor map is the policy tests' problem to
+    # report, not the diagnostics pass's — stay quiet rather than break the run.
+    _ -> []
+  end
+
+  defp print_diagnostics([]), do: :ok
+
+  defp print_diagnostics(diagnostics) do
+    count = length(diagnostics)
+    noun = if count == 1, do: "warning", else: "warnings"
+
+    Mix.shell().info("")
+    Mix.shell().info("#{count} permission syntax #{noun}:")
+
+    Enum.each(diagnostics, fn diagnostic ->
+      Mix.shell().info("")
+      Mix.shell().info("  #{diagnostic.permission}")
+      Mix.shell().info("    #{diagnostic.message}")
+
+      if diagnostic.suggestion do
+        Mix.shell().info("    Replace with: #{diagnostic.suggestion}")
+      end
+    end)
+
+    Mix.shell().info("")
   end
 
   defp print_summary(%{failed: 0, passed: passed}) do

--- a/test/ash_grant/permission_test.exs
+++ b/test/ash_grant/permission_test.exs
@@ -466,4 +466,184 @@ defmodule AshGrant.PermissionTest do
       assert "#{perm}" == "blog:*:read:always"
     end
   end
+
+  describe "matches_action?/3 - @type explicit type wildcards" do
+    test "@read matches :read-type actions regardless of name" do
+      assert Permission.matches_action?("@read", "list_published", :read)
+      assert Permission.matches_action?("@read", "by_slug", :read)
+      assert Permission.matches_action?("@read", "read", :read)
+    end
+
+    test "@read does not match other action types" do
+      refute Permission.matches_action?("@read", "list_published", :update)
+      refute Permission.matches_action?("@read", "read_all", :destroy)
+    end
+
+    test "@read never matches without an action_type" do
+      refute Permission.matches_action?("@read", "read", nil)
+      refute Permission.matches_action?("@read", "read_all", nil)
+    end
+
+    test "@read is exactly equivalent to the deprecated read* spelling" do
+      cases = [{"list_published", :read}, {"read", :read}, {"x", :update}, {"y", nil}]
+
+      for {action, type} <- cases do
+        assert Permission.matches_action?("@read", action, type) ==
+                 Permission.matches_action?("read*", action, type),
+               "@read and read* disagreed on #{action}/#{inspect(type)}"
+      end
+    end
+
+    test "every Ash action type has a working @ form" do
+      assert Permission.matches_action?("@create", "register", :create)
+      assert Permission.matches_action?("@update", "publish", :update)
+      assert Permission.matches_action?("@destroy", "purge", :destroy)
+      assert Permission.matches_action?("@action", "recalculate", :action)
+    end
+
+    test "parses and matches through a full permission string" do
+      perm = Permission.parse!("blog:*:@read:always")
+
+      assert perm.action == "@read"
+      assert Permission.matches?(perm, "blog", "list_published", :read)
+      refute Permission.matches?(perm, "blog", "list_published", :update)
+    end
+
+    test "@ form round-trips through to_string/1" do
+      for s <- ["blog:*:@read:always", "!blog:*:@destroy:always", "blog:*:@update:own:sensitive"] do
+        assert s |> Permission.parse!() |> Permission.to_string() == s
+      end
+    end
+
+    test "@ does not collide with the deny prefix" do
+      perm = Permission.parse!("!blog:*:@read:always")
+
+      assert perm.deny
+      assert perm.action == "@read"
+    end
+  end
+
+  describe "diagnostics/1" do
+    test "clean permissions report nothing" do
+      clean = [
+        "blog:*:read:always",
+        "blog:*:@read:always",
+        "blog:*:*:always",
+        "blog:post_abc:read:",
+        "blog:post_abc:*:",
+        "!blog:*:destroy:always"
+      ]
+
+      for s <- clean do
+        assert Permission.diagnostics(s) == [], "expected #{s} to be clean"
+      end
+    end
+
+    test "deprecated read* is flagged, and its replacement works" do
+      assert [d] = Permission.diagnostics("blog:*:read*:always")
+
+      assert d.code == :deprecated_type_wildcard
+      assert d.permission == "blog:*:read*:always"
+      assert d.suggestion == "blog:*:@read:always"
+      assert Permission.diagnostics(d.suggestion) == []
+    end
+
+    test "suggestion preserves deny prefix and field_group" do
+      assert [d] = Permission.diagnostics("!blog:*:read*:always:sensitive")
+      assert d.suggestion == "!blog:*:@read:always:sensitive"
+    end
+
+    test "type wildcard on an instance permission is flagged as dead" do
+      assert [d] = Permission.diagnostics("blog:post_abc:@read:")
+
+      assert d.code == :dead_instance_type_wildcard
+      assert d.suggestion == nil
+    end
+
+    test "dead instance grant is caught in both spellings" do
+      codes = fn s -> s |> Permission.diagnostics() |> Enum.map(& &1.code) end
+
+      assert :dead_instance_type_wildcard in codes.("blog:post_abc:read*:")
+      assert :dead_instance_type_wildcard in codes.("blog:post_abc:@read:")
+    end
+
+    test "unknown action type is flagged, with @destroy suggested for delete" do
+      assert [d] = Permission.diagnostics("blog:*:@delete:always")
+
+      assert d.code == :unknown_action_type
+      assert d.suggestion == "blog:*:@destroy:always"
+      assert Permission.diagnostics(d.suggestion) == []
+    end
+
+    test "no message recommends a replacement the diagnostics themselves reject" do
+      # `delete*` is deprecated, but `@delete` is not a valid type either. The message
+      # must not tell you to prefer `@delete` while a sibling diagnostic calls it unknown.
+      diagnostics = Permission.diagnostics("blog:*:delete*:always")
+      deprecated = Enum.find(diagnostics, &(&1.code == :deprecated_type_wildcard))
+
+      refute deprecated.message =~ "Prefer"
+      refute deprecated.message =~ "@delete"
+
+      # ...whereas a mechanically fixable one still names its replacement.
+      assert [valid] = Permission.diagnostics("blog:*:read*:always")
+      assert valid.message =~ "Prefer `@read`"
+    end
+
+    test "does not suggest a spelling swap that leaves the grant broken" do
+      # delete* is deprecated AND names a type Ash does not have. Suggesting `@delete`
+      # would point at a grant that still never matches, so the deprecation diagnostic
+      # withholds its suggestion and the unknown-type diagnostic carries the real fix.
+      diagnostics = Permission.diagnostics("blog:*:delete*:always")
+      deprecated = Enum.find(diagnostics, &(&1.code == :deprecated_type_wildcard))
+      unknown = Enum.find(diagnostics, &(&1.code == :unknown_action_type))
+
+      assert deprecated.suggestion == nil
+      assert unknown.suggestion == "blog:*:@destroy:always"
+    end
+
+    test "does not suggest @read for a grant that is dead either way" do
+      diagnostics = Permission.diagnostics("blog:post_abc:read*:")
+      deprecated = Enum.find(diagnostics, &(&1.code == :deprecated_type_wildcard))
+
+      assert deprecated.suggestion == nil
+    end
+
+    test "no suggestion is ever itself flagged" do
+      samples = [
+        "blog:*:read*:always",
+        "blog:*:delete*:always",
+        "blog:post_abc:read*:",
+        "blog:*:@delete:always",
+        "!blog:*:update*:own:sensitive"
+      ]
+
+      for s <- samples, d <- Permission.diagnostics(s), d.suggestion != nil do
+        assert Permission.diagnostics(d.suggestion) == [],
+               "suggestion #{d.suggestion} (from #{s}) is itself flagged"
+      end
+    end
+
+    test "accepts a Permission struct as well as a string" do
+      perm = Permission.parse!("blog:*:read*:always")
+      assert [%{code: :deprecated_type_wildcard}] = Permission.diagnostics(perm)
+    end
+
+    test "unparseable strings report nothing" do
+      assert Permission.diagnostics("garbage") == []
+      assert Permission.diagnostics("") == []
+    end
+
+    test "bare * is not a type wildcard" do
+      assert Permission.diagnostics("blog:*:*:always") == []
+      assert Permission.diagnostics("blog:post_abc:*:") == []
+    end
+
+    test "every diagnostic carries a non-empty message" do
+      samples = ["blog:*:read*:always", "blog:post_abc:@read:", "blog:*:@delete:always"]
+
+      for s <- samples, d <- Permission.diagnostics(s) do
+        assert is_binary(d.message) and d.message != ""
+      end
+    end
+  end
 end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -23,7 +23,7 @@ AshGrant only needs a resolver that returns permission strings for a given actor
 | `!`           | No       | Deny prefix — deny rules always override allows  |
 | `resource`    | Yes      | Resource name or `*` for all                     |
 | `instance_id` | Yes      | `*` for RBAC, specific ID for instance access    |
-| `action`      | Yes      | Action name, `*` for all, or `prefix*` wildcard  |
+| `action`      | Yes      | Action name, `*` for all, or `@read` type wildcard |
 | `scope`       | Yes      | Scope name (e.g., `all`, `own`) or empty string  |
 | `field_group` | No       | 5th part for column-level access control         |
 
@@ -35,7 +35,7 @@ AshGrant only needs a resolver that returns permission strings for a given actor
 "blog:*:update:own"         # Update own blogs only
 "blog:*:*:always"              # All actions on all blogs
 "*:*:read:always"              # Read all resources
-"blog:*:read*:always"          # All read-type actions (read, read_all, etc.)
+"blog:*:@read:always"          # All :read-TYPE actions (list, search, by_slug) — by type, never by name
 "!blog:*:delete:always"        # DENY delete on all blogs
 ```
 
@@ -50,6 +50,52 @@ AshGrant only needs a resolver that returns permission strings for a given actor
 
 Instance permissions with an empty scope (trailing colon) mean unconditional access.
 Instance permissions with a scope name impose an attribute-based condition.
+
+### DON'T: Use `read*` — it is a type wildcard, not a prefix glob
+
+`@read` matches any action whose **Ash action type** is `:read`, regardless of its
+name. The older `read*` spelling means exactly the same thing, but reads like a
+prefix glob and never was one — it does **not** match `read_all` by name, and it
+does match `:read`-type actions with unrelated names like `list_published`.
+
+```elixir
+# DON'T — deprecated spelling; looks like a name glob, isn't one. Removed in v1.0.0.
+"blog:*:read*:always"
+
+# DO — explicit: matches every :read-TYPE action (list, search, by_slug)
+"blog:*:@read:always"
+
+# DO — exact action NAME match, regardless of that action's type
+"blog:*:read:always"
+```
+
+Valid types are Ash's own: `@action`, `@read`, `@create`, `@update`, `@destroy`.
+Anything else silently never matches — deletion is `@destroy`, **not** `@delete`.
+
+### DON'T: Put a type wildcard on an instance permission
+
+Instance matching has no action type available, so a type wildcard on an instance
+permission never matches anything. The grant is dead and fails silently.
+
+```elixir
+# DON'T — matches nothing, ever
+"blog:post_abc123:@read:"
+
+# DO — exact action name, or the catch-all wildcard
+"blog:post_abc123:read:"
+"blog:post_abc123:*:"
+```
+
+Because permission strings live in your database rather than your source, there is
+no compile-time warning for either rule above. Find offending grants with
+`mix ash_grant.verify`, or audit your own store:
+
+```elixir
+MyApp.Role
+|> MyApp.Repo.all()
+|> Enum.flat_map(& &1.permissions)
+|> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
+```
 
 ### Field-level permissions (5-part format)
 


### PR DESCRIPTION
## Summary

Closes the notation problem in #126: `prefix*` is a **type wildcard** (`action_type == prefix`), not a prefix glob over the action name, and `matches_action?/2`'s docstring said the opposite. The `/2` doctest already refuted its own prose, so the test suite stayed green while the documentation misled — as the issue documents, three independent authors hit the same trap downstream.

**No authorization behavior changes.** Every existing permission string evaluates exactly as before.

### The design constraint that shaped this

The issue proposed a **compile-time** deprecation warning, modelled on the `[:*]` → `:all` and scope `write:` deprecations. That playbook does not transfer:

| | `[:*]` → `:all`, `write:` | `prefix*` |
|---|---|---|
| Lives in | DSL options — **source code** | Roles table, seeds — **runtime data** |
| Compiler sees it | Yes | **No** |
| Downstream migration | Edit a file | **Migrate DB rows** |

Verified: `PermissionResolver.resolve/2` returns runtime data, `Evaluator.normalize_permissions/1` calls `parse!/1` per evaluation, and `lib/ash_grant/dsl.ex` has **no** entity accepting a permission string. So there is no compile-time site, and a parse-time `IO.warn` would fire once per grant per request (~90×/request for the app in the issue).

Since AshGrant **cannot reach** the permission store, it exposes the *check* instead of performing it.

### Added

- **`@read` / `@create` / `@update` / `@destroy` / `@action`** — explicit type wildcards, e.g. `"blog:*:@read:always"`. Identical semantics to `read*`, but cannot be misread as a glob. `@` cannot collide with an action name (Elixir action atoms never start with it) and does not clash with the `!` deny prefix.

- **`AshGrant.Permission.diagnostics/1`** — takes a permission string or struct, returns `%{code:, permission:, message:, suggestion:}`. Three codes:
  - `:deprecated_type_wildcard` — the `read*` spelling
  - `:dead_instance_type_wildcard` — a type wildcard on an instance permission
  - `:unknown_action_type` — a type wildcard naming a non-Ash type

  Intended to run over your own store:

  ```elixir
  MyApp.Role
  |> MyApp.Repo.all()
  |> Enum.flat_map(& &1.permissions)
  |> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
  ```

- **`mix ash_grant.verify` reports syntax warnings**, resolving each policy test actor's grants and running `diagnostics/1`. Only covers grants the declared test actors hold — it says so, and a clean run is not proof your store is clean. Warnings never affect the exit code.

### Deprecated

- **`read*`** in favor of `@read`. Removal planned for v1.0.0. Still works, unchanged.

### Fixed (documentation only)

- `matches_action?/2` claimed "prefix matching with `prefix*`" — the root of the downstream damage.
- `matches?/4` said type wildcards "will **also** match" by type; "also" implied name-prefix matching happened too.
- `matches?/3`'s bare `false` doctest now explains that the cause is the absent `action_type`, not a failed name comparison.
- moduledoc format table and `usage-rules.md`, whose examples used only `read`-prefixed names and taught the glob model by example.

### Two silent failures found while fixing, neither previously documented

1. **A type wildcard on an instance permission is dead data.** `matches_instance?/3` passes no action type, so `"blog:post_123:read*:"` matches nothing, ever. Now documented, doctested, and diagnosed.
2. **`delete*` names a type Ash does not have** (it is `:destroy`), so it silently never matches. Same failure class as the filed bug. Diagnosed, suggests `@destroy`.

**Invariant:** no suggestion ever points at a grant that is itself flagged — `delete*` does not suggest `@delete`, and a dead instance grant does not suggest `@read`. Locked by tests (this regressed twice during development: once in the `suggestion` field, once in the message prose).

### Generic actions — three docs stated the opposite of the code

`guides/permissions.md`, `guides/checks-and-policies.md`, and `AshGrant.Check`'s own `@moduledoc` all claimed type wildcards do not apply to generic actions. They do — verified through `Evaluator.has_access?`:

```elixir
E.has_access?(["service:*:@action:always"], "service", "ping", :action)            # => true
E.has_access?(["service:*:@action:always"], "service", "process_refund", :action)  # => true
```

All three now describe the real behavior and warn against it. **Whether to block it is #127** — a fail-closed behavior change does not belong in a notation PR.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — **1150 tests, 52 doctests, 107 properties, 0 failures** (was 1128/44/107)
- [x] `mix credo` — 11 findings, all pre-existing (identical on `main`), none in touched files
- [x] `mix format --check-formatted` — clean
- [x] `@read` exercised end-to-end against the compiled module: parse → match → `to_string` round-trip, `!` deny prefix, 5-part field-group form, all five Ash action types
- [x] `mix ash_grant.verify` run against a fixture holding one grant of each problem class — confirmed the report renders, clean grants stay silent, and the exit code is unaffected
- [x] Every diagnostic suggestion asserted to be itself diagnostic-free
- [x] Pre-existing and unrelated: `mix ash_grant.verify test/support/policy_test_fixtures.ex` reports 4/49 failures on an unmodified `main` checkout too

CHANGELOG deferred to `/release` per project convention.

Refs #126. Spawned #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
