### PR TITLE
release: v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-07-17
+
+### Added
+
+- **Explicit action-type wildcard: `@read`** (#126). Type wildcards can now be spelled `@read`, `@create`, `@update`, `@destroy`, `@action` — e.g. `"blog:*:@read:always"`. Semantics are identical to the existing `read*` form (match on the Ash action **type**, never on the action name), but the notation can no longer be misread as a prefix glob. Both spellings work; `@` cannot collide with an action name, since Elixir action atoms never start with it.
+
+- **`AshGrant.Permission.diagnostics/1`** (#126) reports deprecated or dead grant syntax for a permission string or struct, returning `%{code:, permission:, message:, suggestion:}` maps. Three codes:
+  - `:deprecated_type_wildcard` — the `read*` spelling; suggests the `@read` equivalent
+  - `:dead_instance_type_wildcard` — a type wildcard on an instance permission. Instance matching has no action type available, so the grant **never matches anything** (`"blog:post_abc:read*:"` is dead). Previously silent and undocumented.
+  - `:unknown_action_type` — a type wildcard naming something that is not an Ash action type. `delete*` is the common case: Ash calls that type `:destroy`, so `"blog:*:delete*:always"` silently never matches. Suggests `@destroy`.
+
+  Permission strings are runtime data that AshGrant cannot reach, so this is exposed as a function to run over your own store:
+
+      MyApp.Role
+      |> MyApp.Repo.all()
+      |> Enum.flat_map(& &1.permissions)
+      |> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
+
+  Authorization behavior is unchanged — a flagged permission still evaluates exactly as it did before.
+
+- **`mix ash_grant.verify` reports permission syntax warnings** (#126) by resolving each policy test actor's grants and running `diagnostics/1` over them. This only covers grants the declared test actors hold, so a clean run is **not** proof that your permission store is clean; YAML tests carry their permissions inline and are not scanned. Warnings never affect the exit code.
+
+### Deprecated
+
+- **The `read*` spelling of type wildcards** (#126), in favor of `@read`. Removal planned for v1.0.0. `read*` still works and its behavior is unchanged. Unlike the `[:*]` → `:all` and scope `write:` deprecations — which were DSL options the compiler could see — permission strings are runtime data from the `PermissionResolver` (your roles table, your seeds), so **there is no compile-time warning** and migrating means updating stored data rather than editing source. Run `mix ash_grant.verify`, or `AshGrant.Permission.diagnostics/1` over your own store, to find grants that need it.
+
+### Fixed
+
+- **`matches_action?/2`'s docstring documented the opposite of what the code does** (#126). It claimed "prefix matching with `prefix*`" while `matches_action?/3`, twenty lines below, correctly documented type matching — and the `/2` doctest already refuted its own prose, so the suite stayed green while the documentation misled. Corrected, along with: `matches?/4` (whose "will **also** match" implied name-prefix matching happened too), `matches?/3` (its `false` is caused by the absent `action_type`, not by a failed name comparison), the moduledoc format table, and `usage-rules.md`, whose examples used only `read`-prefixed action names and so taught the glob model by example.
+
+- **`matches_instance?/3` silently never matches type wildcards, previously undocumented** (#126). Instance matching passes no action type, so a type wildcard on an instance permission is dead. Now documented, doctested, and reported by `diagnostics/1`.
+
+- **Three places claimed type wildcards do not apply to generic actions** (#126) — `guides/permissions.md`, `guides/checks-and-policies.md`, and `AshGrant.Check`'s `@moduledoc`. They do apply: `"service:*:@action:always"` grants **every** generic action on the resource, including ones added later, so the grant that permits `:ping` also permits `:process_refund`. All three now document the real behavior and warn against relying on it; for generic actions, prefer exact action names. Whether to block this is tracked in #127.
+
 ## [0.17.0] - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Permissions resolve to native Ash filters and policy checks, with deny-wins sema
 - **`explain/4`** — trace why authorization succeeded or failed
 - **`Introspect`** — query actor permissions, available actions at runtime
 - **Policy testing** — DSL and YAML-based config tests, no database required
+- **`Permission.diagnostics/1`** — audit your own permission store for deprecated or dead grant syntax; also reported by `mix ash_grant.verify`
 
 AshGrant handles permission evaluation, not role management. Resolve roles to
 permission strings in your resolver.
@@ -32,7 +33,7 @@ Add `ash_grant` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ash_grant, "~> 0.17"}
+    {:ash_grant, "~> 0.18"}
   ]
 end
 ```

--- a/lib/ash_grant.ex
+++ b/lib/ash_grant.ex
@@ -183,7 +183,7 @@ defmodule AshGrant do
       "blog:*:update:own"         # Update own blogs only
       "blog:*:*:always"              # All actions on all blogs
       "*:*:read:always"              # Read all resources
-      "blog:*:read*:always"          # All read-type actions
+      "blog:*:@read:always"          # All :read-TYPE actions (by type, never by name)
       "!blog:*:delete:always"        # DENY delete on all blogs
 
   ### Instance Permissions (specific instance_id)

--- a/lib/ash_grant/permission.ex
+++ b/lib/ash_grant/permission.ex
@@ -54,7 +54,7 @@ defmodule AshGrant.Permission do
       "blog:*:*:always"               # All actions on all blogs
       "*:*:read:always"               # Read all resources
       "*:*:*:always"                  # Full access to everything
-      "blog:*:read*:always"           # All read-type actions
+      "blog:*:@read:always"           # All :read-TYPE actions (by type, never by name)
       "!blog:*:delete:always"         # DENY delete on all blogs
 
   ### Instance Permissions (specific instance_id)
@@ -333,8 +333,8 @@ defmodule AshGrant.Permission do
 
   Does not consider scope - that's handled by the ScopeResolver.
 
-  This arity passes no `action_type`, so **type wildcards (`"read*"`) never match
-  here** — see `matches?/4` to use them.
+  This arity passes no `action_type`, so **type wildcards (`"@read"`, or the deprecated
+  `"read*"`) never match here** — see `matches?/4` to use them.
 
   ## Examples
 
@@ -345,6 +345,12 @@ defmodule AshGrant.Permission do
   A type wildcard needs an action type, and this arity has none — so it matches
   nothing, regardless of the action name. This is `false` because no type was
   supplied, *not* because `"read_published"` failed a name comparison:
+
+      iex> perm = AshGrant.Permission.parse!("blog:*:@read:always")
+      iex> AshGrant.Permission.matches?(perm, "blog", "read_published")
+      false
+
+  The deprecated `"read*"` spelling behaves the same way here:
 
       iex> perm = AshGrant.Permission.parse!("blog:*:read*:always")
       iex> AshGrant.Permission.matches?(perm, "blog", "read_published")
@@ -363,20 +369,27 @@ defmodule AshGrant.Permission do
   @doc """
   Checks if a permission matches a resource, action, and optional Ash action type.
 
-  Type wildcards like `"read*"` match on the Ash action *type* alone. A `:read`-type
-  action named `list_published` matches `"read*"` because of its type — never because
+  Type wildcards like `"@read"` match on the Ash action *type* alone. A `:read`-type
+  action named `list_published` matches `"@read"` because of its type — never because
   of its name. When `action_type` is `nil`, type wildcards match nothing; pass a type
-  to use them.
+  to use them. See `matches_action?/3` for the full rules, including the deprecated
+  `"read*"` spelling.
 
   ## Examples
+
+      iex> perm = AshGrant.Permission.parse!("blog:*:@read:always")
+      iex> AshGrant.Permission.matches?(perm, "blog", "list_published", :read)
+      true
+
+      iex> perm = AshGrant.Permission.parse!("blog:*:@read:always")
+      iex> AshGrant.Permission.matches?(perm, "blog", "list_published", :update)
+      false
+
+  The deprecated `"read*"` spelling is equivalent:
 
       iex> perm = AshGrant.Permission.parse!("blog:*:read*:always")
       iex> AshGrant.Permission.matches?(perm, "blog", "list_published", :read)
       true
-
-      iex> perm = AshGrant.Permission.parse!("blog:*:read*:always")
-      iex> AshGrant.Permission.matches?(perm, "blog", "list_published", :update)
-      false
 
   """
   @spec matches?(t(), String.t(), String.t(), atom() | nil) :: boolean()

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.17.0"
+  @version "0.18.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary

- Bump version to 0.18.0
- Add the v0.18.0 CHANGELOG entry
- Close documentation gaps found by the release doc gate

Releases the work from #128 (closes #126). **No authorization behavior changes** — every existing permission string evaluates exactly as before.

### What's new in v0.18.0

**Added**
- **`@read` / `@create` / `@update` / `@destroy` / `@action`** — explicit action-type wildcards, e.g. `"blog:*:@read:always"`. Identical semantics to `read*`, but the notation can no longer be misread as a prefix glob.
- **`AshGrant.Permission.diagnostics/1`** — reports deprecated or dead grant syntax. Catches three silent failures: the `read*` spelling, type wildcards on instance permissions (which never match anything), and type wildcards naming a non-Ash type (`delete*` — Ash calls it `:destroy`).
- **`mix ash_grant.verify` reports permission syntax warnings** for the grants its policy test actors hold.

**Deprecated**
- **`read*`**, in favor of `@read`. Removal planned for v1.0.0; still works, unchanged. Unlike the `[:*]` → `:all` and scope `write:` deprecations — DSL options the compiler could see — permission strings are runtime data from the `PermissionResolver`, so there is **no compile-time warning** and migrating means updating stored data rather than editing source.

**Fixed (documentation)**
- `matches_action?/2`'s docstring documented the opposite of the code — the root of #126.
- `matches_instance?/3` silently never matches type wildcards; such a grant is dead. Now documented and diagnosed.
- Three places claimed type wildcards do not apply to generic actions. They do — see #127.

### Doc gate findings in this PR

The release doc gate caught gaps #128 missed:

- README pinned `~> 0.17` and never mentioned the new public API.
- `AshGrant`'s and `AshGrant.Permission`'s moduledoc RBAC example lists still presented `read*` as the way to match by type.
- `matches?/3` and `matches?/4` doctests led with the deprecated spelling (they predate `@read` existing).

## Verification

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test` — **1150 tests, 54 doctests, 107 properties, 0 failures**
- [x] `mix credo` — 11 findings, all pre-existing, none in touched files
- [x] `mix format --check-formatted` — clean
- [x] Version consistent: `mix.exs` `@version "0.18.0"`, README `~> 0.18`

## Post-merge

```
git checkout main && git pull
git tag v0.18.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)