### PR TITLE
fix: signal indeterminate type-wildcard evaluation (#126, layer 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ mix ash_grant.verify path/to/test.yaml --verbose  # Verbose output
 - **`AshGrant.Check`** (`lib/ash_grant/checks/check.ex`) - SimpleCheck for write actions (returns true/false)
 - **`AshGrant.FilterCheck`** (`lib/ash_grant/checks/filter_check.ex`) - FilterCheck for read actions (returns filter expression)
 - **`AshGrant.PermissionValidation`** (`lib/ash_grant/permission_validation.ex`) - Validates resolved permissions and signals invalid deny+field_group combinations per the `field_group_permissions` mode (`:off`/`:warn`/`:strict`); never changes the authorization outcome
+- **`AshGrant.IndeterminateMatch`** (`lib/ash_grant/indeterminate_match.ex`) - Signals when an `Evaluator` entry point returns a value that couldn't actually be determined: a type wildcard evaluated with no `action_type` is silently skipped, so the answer may be wrong (#126, layer 2). Wraps every nil-defaulting entry point (`has_access?`, `get_scope`, `get_all_scopes`, `get_write_scopes`, `get_field_group`, `get_all_field_groups`, `find_matching`, `field_group_grants`). Mode `:off`/`:warn`/`:strict` via `config :ash_grant, indeterminate_type_wildcard:`; never changes the outcome. **Sound by construction**: `guard/6` recomputes the result with the skipped wildcards forced to match and signals only if it differs — so a scope-less/group-less wildcard or a concrete-deny-settled query stays silent (no false positives, which would break `:strict`). `get_matching_instance_ids` is unguarded on purpose (it sees only instance perms, where type wildcards are dead per `diagnostics/1`, not indeterminate)
 - **`AshGrant.FieldFilterCheck`** (`lib/ash_grant/checks/field_filter_check.ex`) - FilterCheck for **per-record** field-group visibility; generated into `field_policies` by `AddFieldPolicies`. Builds a per-row predicate from `Evaluator.field_group_grants/5` (a field is visible on some records, `%Ash.ForbiddenField{}` on others)
 - **`AshGrant.FieldCheck`** (`lib/ash_grant/checks/field_check.ex`) - legacy action-wide SimpleCheck for field groups (superseded by `FieldFilterCheck` in generation; still present)
 
@@ -106,6 +107,11 @@ mix ash_grant.verify path/to/test.yaml --verbose  # Verbose output
   type: `@read` / `@create` / `@update` / `@destroy` / `@action`. A type wildcard never
   reads the action name. The older `read*` spelling means the same thing but is
   deprecated (removal at v1.0.0) — it looks like a prefix glob and never was one.
+  A type wildcard can only be evaluated when an `action_type` is supplied; calling
+  `Evaluator` directly without one silently skips it and may return a wrong answer
+  (`AshGrant.IndeterminateMatch` signals this — see #126, layer 2). Framework checks
+  always pass the type; prefer `Introspect.can?/4` (takes the resource module) in your
+  own code.
 - Permission strings are **runtime data** from the `PermissionResolver` (roles table,
   seeds), not DSL — so there is no compile-time site to validate them. Deprecated/dead
   syntax is reported offline instead, via `AshGrant.Permission.diagnostics/1` and

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,4 +20,11 @@ config :ash_grant,
   ecto_repos: [AshGrant.TestRepo],
   ash_domains: [AshGrant.Test.Domain]
 
+# Several property tests deliberately exercise the nil-action_type + type-wildcard
+# combination to assert that type wildcards never match without a type. That is exactly
+# the condition `AshGrant.IndeterminateMatch` signals, so the library default (`:warn`)
+# would emit hundreds of correct-but-unwanted warnings across the suite. Default it off
+# here; `indeterminate_match_test.exs` sets the mode explicitly per case.
+config :ash_grant, indeterminate_type_wildcard: :off
+
 config :logger, level: :warning

--- a/guides/permissions.md
+++ b/guides/permissions.md
@@ -97,6 +97,52 @@ permission **never matches anything** — the grant is dead:
 
 `AshGrant.Permission.diagnostics/1` flags these.
 
+#### Type wildcards need the action type at check time
+
+The same requirement applies at every check, not just for instance permissions: a type
+wildcard can only be evaluated when the caller supplies the Ash action **type**. Without
+it, the wildcard silently fails to match, and the result can be **wrong** rather than
+merely uninformed.
+
+You almost never hit this, because the framework-generated policy checks
+(`AshGrant.Check`, `AshGrant.FilterCheck`) always pass the action type. It matters only
+when your **own** code calls `AshGrant.Evaluator` directly — a nav gate, a custom
+authorization helper, a script:
+
+```elixir
+# No action_type: "@read" cannot be evaluated, so it is skipped.
+Evaluator.has_access?(["post:*:@read:always"], "post", "read")        # => false (!)
+
+# With the type, the wildcard is evaluated:
+Evaluator.has_access?(["post:*:@read:always"], "post", "read", :read) # => true
+
+# Best: Introspect.can?/4 takes the resource module and resolves the type for you:
+AshGrant.Introspect.can?(MyApp.Blog.Post, :read, actor)               # => {:allow, ...}
+```
+
+That first `false` is indistinguishable from a real denial, which is what makes the bug
+expensive: a grant sits in the database, looks correct, and the feature it gates quietly
+disappears for exactly the actors it targets.
+
+AshGrant detects this and signals it **without changing the outcome**, via
+`AshGrant.IndeterminateMatch`:
+
+| Mode | Behavior |
+|------|----------|
+| `:off` | do nothing |
+| `:warn` | emit a `Logger.warning` (deduplicated per process) — **default** |
+| `:strict` | raise `AshGrant.IndeterminateMatch.IndeterminateMatchError` |
+
+```elixir
+config :ash_grant, indeterminate_type_wildcard: :strict
+```
+
+It reports only calls whose answer could actually be wrong: a skipped **allow** wildcard
+that returned `false`, or a skipped **deny** wildcard that returned `true`. A defensive
+wildcard-plus-literal grant pair still returns the right answer and stays silent — but
+prefer fixing the call to pass the type, since the pair breaks silently if the literal is
+ever removed.
+
 ### Generic Actions
 
 Generic actions (Ash actions with `type: :action`) are best authorized by their

--- a/lib/ash_grant/evaluator.ex
+++ b/lib/ash_grant/evaluator.ex
@@ -18,6 +18,17 @@ defmodule AshGrant.Evaluator do
   This is similar to Apache Shiro's authorization model and provides a secure
   default (deny by default) with the ability to revoke permissions at any level.
 
+  > #### Pass an action type when grants may use type wildcards {: .warning}
+  >
+  > Every entry point here defaults `action_type` to `nil`. A type wildcard
+  > (`"@read"`, or the deprecated `"read*"`) can only be evaluated against an Ash
+  > action type, so with `nil` it is silently skipped — and the result may be
+  > **wrong**, not just uninformed. The examples below use literal action names and
+  > are unaffected, but if your permissions contain type wildcards, pass the type
+  > (`has_access?(perms, "blog", "list", :read)`) or use `AshGrant.Introspect.can?/4`,
+  > which resolves it from the resource module. `AshGrant.IndeterminateMatch` reports
+  > calls that hit this. See #126.
+
   ## Why Deny-Wins?
 
   The deny-wins pattern is useful for:
@@ -130,6 +141,19 @@ defmodule AshGrant.Evaluator do
 
   Implements deny-wins: if any deny rule matches, access is denied.
 
+  ## Pass an `action_type` if any grant may be a type wildcard
+
+  Type wildcards (`"@read"`, or the deprecated `"read*"`) match on the Ash action
+  **type**, so they cannot be evaluated without an `action_type` and are treated as
+  non-matching. Omitting it where such a grant exists therefore produces an answer that
+  is not merely uninformed but potentially **wrong** — `has_access?(["blog:*:@read:always"],
+  "blog", "read")` returns `false`, while the same grant authorizes `:read` actions once a
+  type is supplied.
+
+  `AshGrant.IndeterminateMatch` reports exactly those calls (`:warn` by default, `:strict`
+  to raise). If you have the resource module, prefer `AshGrant.Introspect.can?/4`, which
+  resolves the action type for you.
+
   ## Examples
 
       iex> permissions = ["blog:*:read:always", "blog:*:write:own"]
@@ -140,25 +164,28 @@ defmodule AshGrant.Evaluator do
       iex> AshGrant.Evaluator.has_access?(permissions, "blog", "delete")
       false
 
+  A type wildcard needs the type. Without it the grant cannot be evaluated, and the
+  `false` reflects that — not a real denial:
+
+      iex> permissions = ["blog:*:@read:always"]
+      iex> AshGrant.Evaluator.has_access?(permissions, "blog", "list_published", :read)
+      true
+
   """
   @spec has_access?(permissions(), String.t(), String.t(), atom() | nil) :: boolean()
   def has_access?(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
+    match = &Permission.matches?(&1, resource, action, action_type)
 
-    # Check for deny rules first (deny wins)
-    has_deny =
-      Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
-
-    if has_deny do
-      false
-    else
-      # Check for allow rules
-      Enum.any?(permissions, fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
+    # Body threads its match predicate so IndeterminateMatch can re-run it with type
+    # wildcards forced. Without an action_type they silently fail to match, so the
+    # answer may be fabricated; the guard signals that and never changes it.
+    compute = fn match ->
+      not denied?(permissions, match) and
+        Enum.any?(permissions, &(not Permission.deny?(&1) and match.(&1)))
     end
+
+    AshGrant.IndeterminateMatch.guard(compute, match, permissions, resource, action, action_type)
   end
 
   @doc """
@@ -315,26 +342,27 @@ defmodule AshGrant.Evaluator do
   @spec get_scope(permissions(), String.t(), String.t(), atom() | nil) :: String.t() | nil
   def get_scope(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
+    match = &Permission.matches?(&1, resource, action, action_type)
+    compute = &first_matching_field(permissions, &1, :scope)
 
-    # First check if denied
-    has_deny =
-      Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
+    AshGrant.IndeterminateMatch.guard(compute, match, permissions, resource, action, action_type)
+  end
 
-    if has_deny do
+  # First matching allow permission's `field` (`:scope` or `:field_group`), or nil.
+  # deny-wins: a matching deny short-circuits to nil.
+  defp first_matching_field(permissions, match, field) do
+    if denied?(permissions, match) do
       nil
     else
-      # Find first matching allow permission and return its scope
-      permissions
-      |> Enum.find(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
-      |> case do
+      case Enum.find(permissions, &(not Permission.deny?(&1) and match.(&1))) do
         nil -> nil
-        perm -> perm.scope
+        perm -> Map.fetch!(perm, field)
       end
     end
+  end
+
+  defp denied?(permissions, match) do
+    Enum.any?(permissions, &(Permission.deny?(&1) and match.(&1)))
   end
 
   @doc """
@@ -353,24 +381,21 @@ defmodule AshGrant.Evaluator do
   @spec get_all_scopes(permissions(), String.t(), String.t(), atom() | nil) :: [String.t()]
   def get_all_scopes(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
+    match = &Permission.matches?(&1, resource, action, action_type)
 
-    # Check for deny first
-    has_deny =
-      Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
-
-    if has_deny do
-      []
-    else
-      permissions
-      |> Enum.filter(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
-      |> Enum.map(& &1.scope)
-      |> Enum.reject(&is_nil/1)
-      |> Enum.uniq()
+    compute = fn match ->
+      if denied?(permissions, match) do
+        []
+      else
+        permissions
+        |> Enum.filter(&(not Permission.deny?(&1) and match.(&1)))
+        |> Enum.map(& &1.scope)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+      end
     end
+
+    AshGrant.IndeterminateMatch.guard(compute, match, permissions, resource, action, action_type)
   end
 
   @doc """
@@ -412,23 +437,20 @@ defmodule AshGrant.Evaluator do
           :denied | :unrestricted | {:scopes, [String.t()]}
   def get_write_scopes(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
+    match = &Permission.matches?(&1, resource, action, action_type)
+    compute = &write_scopes(permissions, &1)
 
-    has_deny =
-      Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
+    AshGrant.IndeterminateMatch.guard(compute, match, permissions, resource, action, action_type)
+  end
 
-    if has_deny do
+  defp write_scopes(permissions, match) do
+    if denied?(permissions, match) do
       :denied
     else
-      matching_allows =
-        Enum.filter(permissions, fn perm ->
-          not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-        end)
+      matching_allows = Enum.filter(permissions, &(not Permission.deny?(&1) and match.(&1)))
 
-      # A scope-less grant applies to every record and dominates the union
-      # (the write-path analogue of get_all_field_groups/4's group-less
-      # collapse, issue #116).
+      # A scope-less grant applies to every record and dominates the union (the
+      # write-path analogue of get_all_field_groups/4's group-less collapse, issue #116).
       if Enum.any?(matching_allows, &is_nil(&1.scope)) do
         :unrestricted
       else
@@ -457,24 +479,10 @@ defmodule AshGrant.Evaluator do
   @spec get_field_group(permissions(), String.t(), String.t(), atom() | nil) :: String.t() | nil
   def get_field_group(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
+    match = &Permission.matches?(&1, resource, action, action_type)
+    compute = &first_matching_field(permissions, &1, :field_group)
 
-    has_deny =
-      Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
-
-    if has_deny do
-      nil
-    else
-      permissions
-      |> Enum.find(fn perm ->
-        not Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
-      |> case do
-        nil -> nil
-        perm -> perm.field_group
-      end
-    end
+    AshGrant.IndeterminateMatch.guard(compute, match, permissions, resource, action, action_type)
   end
 
   @doc """
@@ -508,31 +516,26 @@ defmodule AshGrant.Evaluator do
   @spec get_all_field_groups(permissions(), String.t(), String.t(), atom() | nil) :: [String.t()]
   def get_all_field_groups(permissions, resource, action, action_type \\ nil) do
     permissions = normalize_permissions(permissions)
+    match = &Permission.matches?(&1, resource, action, action_type)
+    compute = &all_field_groups(permissions, &1)
 
-    has_deny =
-      Enum.any?(permissions, fn perm ->
-        Permission.deny?(perm) and Permission.matches?(perm, resource, action, action_type)
-      end)
+    AshGrant.IndeterminateMatch.guard(compute, match, permissions, resource, action, action_type)
+  end
 
-    if has_deny do
+  defp all_field_groups(permissions, match) do
+    if denied?(permissions, match) do
       []
     else
-      matching_allows =
-        Enum.filter(permissions, fn perm ->
-          not Permission.deny?(perm) and
-            Permission.matches?(perm, resource, action, action_type)
-        end)
+      matching_allows = Enum.filter(permissions, &(not Permission.deny?(&1) and match.(&1)))
 
-      # A group-less (4-part) allow grant means "all fields are visible" and
-      # dominates the union, so it collapses the result to [] (unrestricted).
-      # Without this, adding a narrower field-group grant on top of a broad
-      # group-less grant would silently subtract access (see issue #116).
+      # A group-less (4-part) allow grant means "all fields are visible" and dominates
+      # the union, so it collapses the result to [] (unrestricted). Without this, adding
+      # a narrower field-group grant on top of a broad group-less grant would silently
+      # subtract access (see issue #116).
       if Enum.any?(matching_allows, &is_nil(&1.field_group)) do
         []
       else
-        matching_allows
-        |> Enum.map(& &1.field_group)
-        |> Enum.uniq()
+        matching_allows |> Enum.map(& &1.field_group) |> Enum.uniq()
       end
     end
   end
@@ -557,15 +560,26 @@ defmodule AshGrant.Evaluator do
           [Permission.t()]
   def field_group_grants(permissions, resource_module, action, required_group, action_type \\ nil) do
     resource_name = AshGrant.Info.resource_name(resource_module)
+    permissions = normalize_permissions(permissions)
+    match = &Permission.matches_action?(&1.action, action, action_type)
 
-    permissions
-    |> normalize_permissions()
-    |> Enum.filter(fn perm ->
-      not Permission.deny?(perm) and
-        Permission.matches_resource?(perm.resource, resource_name) and
-        Permission.matches_action?(perm.action, action, action_type) and
-        grants_field_group?(resource_module, perm.field_group, required_group)
-    end)
+    compute = fn match ->
+      Enum.filter(permissions, fn perm ->
+        not Permission.deny?(perm) and
+          Permission.matches_resource?(perm.resource, resource_name) and
+          match.(perm) and
+          grants_field_group?(resource_module, perm.field_group, required_group)
+      end)
+    end
+
+    AshGrant.IndeterminateMatch.guard(
+      compute,
+      match,
+      permissions,
+      resource_name,
+      action,
+      action_type
+    )
   end
 
   # A group-less (4-part) grant has no field_group — it grants every group.
@@ -608,9 +622,11 @@ defmodule AshGrant.Evaluator do
   """
   @spec find_matching(permissions(), String.t(), String.t(), atom() | nil) :: [Permission.t()]
   def find_matching(permissions, resource, action, action_type \\ nil) do
-    permissions
-    |> normalize_permissions()
-    |> Enum.filter(&Permission.matches?(&1, resource, action, action_type))
+    permissions = normalize_permissions(permissions)
+    match = &Permission.matches?(&1, resource, action, action_type)
+    compute = fn match -> Enum.filter(permissions, match) end
+
+    AshGrant.IndeterminateMatch.guard(compute, match, permissions, resource, action, action_type)
   end
 
   @doc """
@@ -640,6 +656,10 @@ defmodule AshGrant.Evaluator do
   @spec get_matching_instance_ids(permissions(), String.t(), String.t(), atom() | nil) ::
           [String.t()]
   def get_matching_instance_ids(permissions, resource, action, action_type \\ nil) do
+    # No IndeterminateMatch guard: this considers only instance permissions
+    # (instance_id != "*"), and a type wildcard on an instance permission is dead, not
+    # indeterminate — `AshGrant.Permission.diagnostics/1` reports it. RBAC wildcards
+    # (the indeterminate case) never enter here, so a guard would be a no-op.
     permissions = normalize_permissions(permissions)
 
     # Find all instance permissions that match resource and action

--- a/lib/ash_grant/indeterminate_match.ex
+++ b/lib/ash_grant/indeterminate_match.ex
@@ -1,0 +1,221 @@
+defmodule AshGrant.IndeterminateMatch do
+  @moduledoc """
+  Signals authorization answers that could not actually be determined (issue #126).
+
+  A type wildcard (`"@read"`, or the deprecated `"read*"`) matches on the Ash action
+  **type**, so it can only be evaluated when an `action_type` is supplied. Every
+  `AshGrant.Evaluator` entry point defaults `action_type` to `nil`, and with `nil` a
+  type wildcard silently fails to match. The result is a two-layer asymmetry — same
+  actor, same grant, opposite answers:
+
+      actor = %{permissions: ["document:*:@read:always"]}
+
+      # Takes the resource module, so it resolves the action type:
+      AshGrant.Introspect.can?(Document, :read, actor)
+      # => {:allow, ...}
+
+      # Takes a resource string, so it cannot — and answers anyway:
+      AshGrant.Evaluator.has_access?(actor.permissions, "document", "read")
+      # => false
+
+  That `false` is not "does not match", it is "could not tell" wearing "does not
+  match" as a disguise — indistinguishable from a legitimate deny, which is what makes
+  it expensive to debug. In practice it forces defensive `read*` + literal `read` grant
+  pairs, and dropping the literal silently kills the feature it gated.
+
+  This module detects the case and signals it **without changing the outcome**:
+
+    * `:off`    — do nothing
+    * `:warn`   — emit a `Logger.warning` (deduplicated per process)
+    * `:strict` — raise `AshGrant.IndeterminateMatch.IndeterminateMatchError`
+
+  Configure globally (the affected entry points take a resource *string*, so there is
+  no resource module to read a DSL option from):
+
+      config :ash_grant, indeterminate_type_wildcard: :strict
+
+  Default is `:warn`.
+
+  ## How it decides — recompute and compare
+
+  Detection is **sound**: it never flags a call whose answer the skipped wildcards could
+  not have changed, because false positives would make `:strict` unusable. Rather than
+  reason about each function's return shape, `guard/6` recomputes the same result twice:
+
+    * once as the caller did — every type wildcard treated as non-matching;
+    * once with those wildcards **forced to match**.
+
+  If the two results are equal, the wildcards were irrelevant (the answer is the same
+  whichever way they would have resolved) and nothing is signalled — this correctly
+  stays silent for a defensive wildcard-plus-literal pair, a scope-less wildcard that
+  contributes nothing, or a query already settled by a concrete deny. If they differ,
+  the true answer depends on a type the call did not supply, and it is reported.
+
+  Forcing all wildcards at once can, in rare mixed allow/deny cases, mask a difference
+  (a false *negative*); it never invents one (no false *positive*).
+
+  Only RBAC grants (`instance_id == "*"`) are forced. A type wildcard on an instance
+  permission is dead outright — `AshGrant.Permission.diagnostics/1` reports that — so it
+  is treated as non-matching in both passes, never as indeterminate.
+
+  ## Fixing a reported call
+
+  Supply the action type, or use an API that resolves it for you:
+
+      # Resolves the type from the resource module:
+      AshGrant.Introspect.can?(MyApp.Document, :read, actor)
+
+      # Or pass it explicitly:
+      AshGrant.Evaluator.has_access?(perms, "document", "list_published", :read)
+  """
+
+  require Logger
+
+  alias AshGrant.Permission
+
+  defmodule IndeterminateMatchError do
+    @moduledoc """
+    Raised in `:strict` mode when an authorization question could not be answered
+    because a type wildcard was evaluated without an `action_type`.
+    See `AshGrant.IndeterminateMatch`.
+    """
+    defexception [:message]
+  end
+
+  @type mode :: :off | :warn | :strict
+
+  @typedoc """
+  Recomputes an entry point's result using the given per-permission match predicate.
+
+  The predicate replaces every `Permission.matches?/4` (or `matches_action?/3`) call in
+  the function body, so `guard/6` can run the body a second time with wildcards forced.
+  """
+  @type compute :: ((Permission.t() -> boolean()) -> term())
+
+  @default_mode :warn
+
+  @doc """
+  Returns the configured mode (default `:warn`).
+  """
+  @spec mode() :: mode()
+  def mode do
+    Application.get_env(:ash_grant, :indeterminate_type_wildcard, @default_mode)
+  end
+
+  @doc """
+  Runs `compute` with `match_fn`, returning its result and signalling if a forced
+  recompute would differ.
+
+  Never alters the outcome — the normal result is always what comes back. Raises
+  `IndeterminateMatchError` only in `:strict` mode, and only when forcing the skipped
+  type wildcards to match would change the result.
+  """
+  @spec guard(
+          compute(),
+          (Permission.t() -> boolean()),
+          [Permission.t()],
+          String.t(),
+          String.t(),
+          atom() | nil
+        ) ::
+          term()
+  # A supplied action_type means every wildcard was evaluated — nothing to force.
+  def guard(compute, match_fn, _permissions, _resource, _action, action_type)
+      when not is_nil(action_type) do
+    compute.(match_fn)
+  end
+
+  def guard(compute, match_fn, permissions, resource, action, nil) do
+    normal = compute.(match_fn)
+    detect(normal, compute, match_fn, permissions, resource, action, mode())
+  end
+
+  defp detect(normal, _compute, _match_fn, _permissions, _resource, _action, :off), do: normal
+
+  defp detect(normal, compute, match_fn, permissions, resource, action, active_mode) do
+    case wildcards(permissions, resource) do
+      [] ->
+        normal
+
+      offenders ->
+        forced = compute.(forced_match_fn(match_fn, offenders))
+
+        if normal == forced,
+          do: normal,
+          else: report(normal, offenders, resource, action, active_mode)
+    end
+  end
+
+  # The normal predicate, but every skipped RBAC type wildcard is treated as matching.
+  defp forced_match_fn(match_fn, offenders) do
+    forced = MapSet.new(offenders)
+    fn perm -> MapSet.member?(forced, perm) or match_fn.(perm) end
+  end
+
+  # RBAC type-wildcard grants for this resource — the permissions whose match could not
+  # be determined without an action_type. Instance permissions are excluded: a type
+  # wildcard there is dead (see diagnostics/1), not indeterminate.
+  defp wildcards(permissions, resource) do
+    Enum.filter(permissions, fn
+      %Permission{instance_id: "*"} = perm ->
+        Permission.type_wildcard?(perm) and Permission.matches_resource?(perm.resource, resource)
+
+      %Permission{} ->
+        false
+    end)
+  end
+
+  defp report(_normal, offenders, resource, action, :strict) do
+    raise IndeterminateMatchError, message: message(offenders, resource, action)
+  end
+
+  defp report(normal, offenders, resource, action, :warn) do
+    key = {resource, action, offenders |> strings() |> Enum.sort()}
+
+    unless warned?(key) do
+      mark_warned(key)
+      Logger.warning(message(offenders, resource, action))
+    end
+
+    normal
+  end
+
+  defp message(offenders, resource, action) do
+    reasons =
+      []
+      |> maybe_reason(
+        offenders,
+        &(not Permission.deny?(&1)),
+        "a grant that may allow it was skipped"
+      )
+      |> maybe_reason(
+        offenders,
+        &Permission.deny?/1,
+        "a deny rule that may forbid it was skipped"
+      )
+      |> Enum.join("; and ")
+
+    "AshGrant: indeterminate authorization result for #{resource}:#{action}. " <>
+      "The call supplied no action_type, so these type wildcards could not be evaluated " <>
+      "and were treated as non-matching: #{inspect(strings(offenders))}. " <>
+      "#{reasons} — the result may be wrong. Supply an action_type (e.g. " <>
+      "AshGrant.Evaluator.has_access?(perms, #{inspect(resource)}, #{inspect(action)}, " <>
+      ":read)), or use AshGrant.Introspect.can?/4, which resolves the action type from " <>
+      "the resource module. See AshGrant.IndeterminateMatch."
+  end
+
+  defp maybe_reason(reasons, offenders, pred, text) do
+    if Enum.any?(offenders, pred), do: reasons ++ [text], else: reasons
+  end
+
+  defp strings(offenders), do: offenders |> Enum.map(&Permission.to_string/1) |> Enum.uniq()
+
+  # Per-process dedup, mirroring AshGrant.PermissionValidation: repeated checks within
+  # one request log at most once per {resource, action, wildcard-set}. The set lives in
+  # the process dictionary and dies with the request.
+  defp warned?(key), do: MapSet.member?(warned_set(), key)
+
+  defp mark_warned(key), do: Process.put(__MODULE__, MapSet.put(warned_set(), key))
+
+  defp warned_set, do: Process.get(__MODULE__, MapSet.new())
+end

--- a/lib/ash_grant/permission.ex
+++ b/lib/ash_grant/permission.ex
@@ -539,6 +539,32 @@ defmodule AshGrant.Permission do
   end
 
   @doc """
+  Returns true when this permission's action is a type wildcard.
+
+  Type wildcards (`"@read"`, or the deprecated `"read*"`) match on the Ash action
+  **type**, so they can only be evaluated when an `action_type` is supplied. The
+  catch-all `"*"` is not a type wildcard — it matches any action without needing one.
+
+  Callers that may not have an `action_type` use this to tell "this permission did
+  not match" apart from "this permission could not be evaluated". See
+  `AshGrant.IndeterminateMatch`.
+
+  ## Examples
+
+      iex> AshGrant.Permission.type_wildcard?(AshGrant.Permission.parse!("blog:*:@read:always"))
+      true
+      iex> AshGrant.Permission.type_wildcard?(AshGrant.Permission.parse!("blog:*:read*:always"))
+      true
+      iex> AshGrant.Permission.type_wildcard?(AshGrant.Permission.parse!("blog:*:read:always"))
+      false
+      iex> AshGrant.Permission.type_wildcard?(AshGrant.Permission.parse!("blog:*:*:always"))
+      false
+
+  """
+  @spec type_wildcard?(t()) :: boolean()
+  def type_wildcard?(%__MODULE__{action: action}), do: type_wildcard(action) != nil
+
+  @doc """
   Checks if a resource pattern matches a resource name.
 
   Supports wildcard matching with `"*"`.
@@ -563,9 +589,9 @@ defmodule AshGrant.Permission do
 
   Supports the catch-all wildcard `"*"` and exact action names.
 
-  Type wildcards (`"read*"`) never match through this arity. They compare against an
-  Ash action *type*, and no type is available here — use `matches_action?/3` and pass
-  an `action_type` for those.
+  Type wildcards (`"@read"`, or the deprecated `"read*"`) never match through this
+  arity. They compare against an Ash action *type*, and no type is available here — use
+  `matches_action?/3` and pass an `action_type` for those.
 
   ## Examples
 
@@ -576,10 +602,13 @@ defmodule AshGrant.Permission do
       iex> AshGrant.Permission.matches_action?("read", "write")
       false
 
-  `"read*"` is a **type wildcard, not a prefix glob** — it never reads the action name.
-  So it does not match `"read_all"` despite the shared prefix, and without an
-  `action_type` it matches nothing at all, not even `"read"` itself:
+  `"@read"` is a **type wildcard, not a name pattern** — it never reads the action name.
+  Without an `action_type` it matches nothing at all, not even an action named `"read"`.
+  The deprecated `"read*"` spelling behaves identically, and in particular does not
+  match `"read_all"` despite the shared prefix:
 
+      iex> AshGrant.Permission.matches_action?("@read", "read")
+      false
       iex> AshGrant.Permission.matches_action?("read*", "read_all")
       false
       iex> AshGrant.Permission.matches_action?("read*", "read")

--- a/test/ash_grant/indeterminate_match_test.exs
+++ b/test/ash_grant/indeterminate_match_test.exs
@@ -1,0 +1,335 @@
+defmodule AshGrant.IndeterminateMatchTest do
+  @moduledoc """
+  Covers issue #126's second layer: without an `action_type`, a type wildcard silently
+  fails to match, so the returned answer may be fabricated rather than real.
+
+  `async: false` — the mode is read from the application environment.
+  """
+
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias AshGrant.Evaluator
+  alias AshGrant.IndeterminateMatch
+  alias AshGrant.IndeterminateMatch.IndeterminateMatchError
+
+  setup do
+    original = Application.fetch_env(:ash_grant, :indeterminate_type_wildcard)
+
+    on_exit(fn ->
+      case original do
+        {:ok, value} -> Application.put_env(:ash_grant, :indeterminate_type_wildcard, value)
+        :error -> Application.delete_env(:ash_grant, :indeterminate_type_wildcard)
+      end
+    end)
+
+    :ok
+  end
+
+  defp set_mode(mode) do
+    Application.put_env(:ash_grant, :indeterminate_type_wildcard, mode)
+    :ok
+  end
+
+  defp count_signals(log) do
+    log |> String.split("indeterminate authorization result") |> length() |> Kernel.-(1)
+  end
+
+  describe "mode/0" do
+    test "defaults to :warn when unconfigured" do
+      Application.delete_env(:ash_grant, :indeterminate_type_wildcard)
+      assert IndeterminateMatch.mode() == :warn
+    end
+
+    test "reads the configured mode" do
+      set_mode(:strict)
+      assert IndeterminateMatch.mode() == :strict
+    end
+  end
+
+  describe ":warn — signals only when the answer could be wrong" do
+    setup do: set_mode(:warn)
+
+    test "an allow wildcard was skipped and nothing else matched" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:*:read*:always"], "m", "read") == false
+        end)
+
+      assert log =~ "indeterminate authorization result for m:read"
+      assert log =~ "m:*:read*:always"
+      assert log =~ "a grant that may allow it was skipped"
+    end
+
+    test "the @read spelling is flagged identically — renaming does not fix this" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:*:@read:always"], "m", "read") == false
+        end)
+
+      assert log =~ "indeterminate authorization result"
+      assert log =~ "m:*:@read:always"
+    end
+
+    test "a deny wildcard was skipped and access was granted (fail-open direction)" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:*:read:always", "!m:*:read*:sensitive"], "m", "read") ==
+                   true
+        end)
+
+      assert log =~ "a deny rule that may forbid it was skipped"
+      assert log =~ "!m:*:read*:sensitive"
+    end
+
+    test "silent for a defensive wildcard + literal pair — the answer is right either way" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:*:read*:always", "m:*:read:always"], "m", "read") ==
+                   true
+        end)
+
+      refute log =~ "indeterminate"
+    end
+
+    test "silent for a legitimate false with no wildcards involved" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:*:write:always"], "m", "read") == false
+        end)
+
+      refute log =~ "indeterminate"
+    end
+
+    test "silent when an action_type is supplied — everything was evaluable" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:*:read*:always"], "m", "read", :read) == true
+        end)
+
+      refute log =~ "indeterminate"
+    end
+
+    test "silent when the skipped wildcard belongs to another resource" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["other:*:read*:always"], "m", "read") == false
+        end)
+
+      refute log =~ "indeterminate"
+    end
+
+    test "silent for a type wildcard on an instance permission (not the RBAC path)" do
+      # Dead outright, and reported by Permission.diagnostics/1 instead.
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:m_abc123:read*:"], "m", "read") == false
+        end)
+
+      refute log =~ "indeterminate"
+    end
+
+    test "a resource wildcard grant is still relevant" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["*:*:read*:always"], "m", "read") == false
+        end)
+
+      assert log =~ "indeterminate"
+    end
+
+    test "never changes the returned value" do
+      capture_log(fn ->
+        assert Evaluator.has_access?(["m:*:read*:always"], "m", "read") == false
+        assert Evaluator.has_access?(["m:*:read:always", "!m:*:read*:x"], "m", "read") == true
+      end)
+    end
+
+    test "deduplicates repeated identical checks within one process" do
+      log =
+        capture_log(fn ->
+          Enum.each(1..5, fn _ ->
+            Evaluator.has_access?(["m:*:read*:always"], "m", "read")
+          end)
+        end)
+
+      assert count_signals(log) == 1
+    end
+
+    test "distinct questions are reported separately" do
+      log =
+        capture_log(fn ->
+          Evaluator.has_access?(["m:*:read*:always"], "m", "read")
+          Evaluator.has_access?(["m:*:read*:always"], "m", "list")
+        end)
+
+      assert count_signals(log) == 2
+    end
+  end
+
+  describe ":strict — the category error surfaces immediately" do
+    setup do: set_mode(:strict)
+
+    test "raises when the answer is indeterminate" do
+      assert_raise IndeterminateMatchError,
+                   ~r/indeterminate authorization result for m:read/,
+                   fn ->
+                     Evaluator.has_access?(["m:*:read*:always"], "m", "read")
+                   end
+    end
+
+    test "raises on the fail-open deny direction too" do
+      assert_raise IndeterminateMatchError, ~r/deny rule that may forbid it/, fn ->
+        Evaluator.has_access?(["m:*:read:always", "!m:*:read*:sensitive"], "m", "read")
+      end
+    end
+
+    test "does not raise where the answer is sound — :strict is safe to adopt" do
+      assert Evaluator.has_access?(["m:*:read*:always", "m:*:read:always"], "m", "read") == true
+      assert Evaluator.has_access?(["m:*:read*:always"], "m", "read", :read) == true
+      assert Evaluator.has_access?(["m:*:write:always"], "m", "read") == false
+      assert Evaluator.has_access?(["other:*:read*:always"], "m", "read") == false
+    end
+  end
+
+  describe ":off — no detection, no signal" do
+    setup do: set_mode(:off)
+
+    test "stays silent and returns the unchanged result" do
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(["m:*:read*:always"], "m", "read") == false
+        end)
+
+      refute log =~ "indeterminate"
+    end
+  end
+
+  describe "forced-recompute soundness — no false positives" do
+    setup do: set_mode(:strict)
+
+    test "silent when a skipped wildcard contributes nothing (scope-less / group-less)" do
+      # With :read the wildcard would match, but its empty scope / absent field_group
+      # contributes nothing, so the result is identical either way — determinate.
+      assert Evaluator.get_all_scopes(["blog:*:@read:"], "blog", "read") == []
+      assert Evaluator.get_scope(["blog:*:@read:"], "blog", "read") == nil
+
+      assert Evaluator.get_all_field_groups(
+               ["sensitiverecord:*:@read:always"],
+               "sensitiverecord",
+               "read"
+             ) == []
+    end
+
+    test "silent when a concrete deny already fixed the result" do
+      # The concrete deny wins regardless of how the @read wildcard would resolve.
+      assert Evaluator.has_access?(["!m:*:read:x", "m:*:@read:always"], "m", "read") == false
+      assert Evaluator.get_scope(["!m:*:read:x", "m:*:@read:always"], "m", "read") == nil
+    end
+
+    test "silent when a field-group wildcard cannot grant the required group" do
+      # @read matches the action, but "public" does not grant :sensitive, so
+      # field_group_grants excludes it whether or not the type is known.
+      grants =
+        Evaluator.field_group_grants(
+          ["sensitiverecord:*:@read:always:public"],
+          AshGrant.Test.SensitiveRecord,
+          "read",
+          :sensitive
+        )
+
+      assert grants == []
+    end
+  end
+
+  describe "coverage across the guarded entry points" do
+    setup do: set_mode(:strict)
+
+    test "get_all_scopes raises when a skipped wildcard would add a scope" do
+      assert_raise IndeterminateMatchError, fn ->
+        Evaluator.get_all_scopes(["blog:*:@read:own"], "blog", "read")
+      end
+    end
+
+    test "get_scope raises when a skipped wildcard would supply the first scope" do
+      assert_raise IndeterminateMatchError, fn ->
+        Evaluator.get_scope(["blog:*:@read:own"], "blog", "read")
+      end
+    end
+
+    test "get_write_scopes raises when a skipped wildcard would join the union" do
+      assert_raise IndeterminateMatchError, fn ->
+        Evaluator.get_write_scopes(["blog:*:@read:own"], "blog", "read")
+      end
+    end
+
+    test "get_field_group raises when a skipped wildcard would supply the group" do
+      assert_raise IndeterminateMatchError, fn ->
+        Evaluator.get_field_group(
+          ["sensitiverecord:*:@read:always:sensitive"],
+          "sensitiverecord",
+          "read"
+        )
+      end
+    end
+
+    test "get_all_field_groups raises when a skipped grouped wildcard would add a group" do
+      assert_raise IndeterminateMatchError, fn ->
+        Evaluator.get_all_field_groups(
+          ["sensitiverecord:*:@read:always:sensitive"],
+          "sensitiverecord",
+          "read"
+        )
+      end
+    end
+
+    test "find_matching raises when a skipped wildcard would join the list" do
+      assert_raise IndeterminateMatchError, fn ->
+        Evaluator.find_matching(["blog:*:@read:always"], "blog", "read")
+      end
+    end
+
+    test "field_group_grants raises when a skipped wildcard would grant the group" do
+      assert_raise IndeterminateMatchError, fn ->
+        Evaluator.field_group_grants(
+          ["sensitiverecord:*:@read:always:sensitive"],
+          AshGrant.Test.SensitiveRecord,
+          "read",
+          :sensitive
+        )
+      end
+    end
+
+    test "every guarded entry point stays silent once the action type is supplied" do
+      assert Evaluator.get_all_scopes(["blog:*:@read:own"], "blog", "read", :read) == ["own"]
+      assert Evaluator.get_scope(["blog:*:@read:own"], "blog", "read", :read) == "own"
+
+      assert Evaluator.get_write_scopes(["blog:*:@read:own"], "blog", "read", :read) ==
+               {:scopes, ["own"]}
+
+      assert Evaluator.find_matching(["blog:*:@read:always"], "blog", "read", :read) != []
+    end
+  end
+
+  describe "the two-layer asymmetry (issue #126)" do
+    setup do: set_mode(:warn)
+
+    test "can?/4 and has_access?/3 disagree on the same grant; the untyped one now says so" do
+      actor = %{permissions: ["document:*:@read:always"]}
+
+      # Takes the resource module, so it resolves the action type and answers correctly.
+      assert {:allow, _details} = AshGrant.Introspect.can?(AshGrant.Test.Document, :read, actor)
+
+      # Takes a resource string, so it cannot resolve the type. Same actor, same grant,
+      # opposite answer — previously silent, now reported.
+      log =
+        capture_log(fn ->
+          assert Evaluator.has_access?(actor.permissions, "document", "read") == false
+        end)
+
+      assert log =~ "indeterminate authorization result for document:read"
+      assert log =~ "AshGrant.Introspect.can?/4"
+    end
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -97,6 +97,35 @@ MyApp.Role
 |> Enum.flat_map(&AshGrant.Permission.diagnostics/1)
 ```
 
+### DON'T: Check a type wildcard without supplying the action type
+
+A type wildcard can only be evaluated against an Ash action **type**. If you call a
+matcher that has no action type, the wildcard silently fails to match — and the answer
+you get back may be **wrong**, not merely uninformed. This is the trap behind
+"my grant is in the database but the feature is gone for the people it targets."
+
+```elixir
+# DON'T — no action_type, so "@read" cannot be evaluated. Returns false even though
+# this actor should be allowed. The false is fabricated, indistinguishable from a deny.
+Evaluator.has_access?(["blog:*:@read:always"], "blog", "read")        # => false (!)
+
+# DO — pass the action type; now the type wildcard is evaluated.
+Evaluator.has_access?(["blog:*:@read:always"], "blog", "read", :read) # => true
+
+# DO — better, hand a resource MODULE to Introspect, which resolves the type for you.
+AshGrant.Introspect.can?(MyApp.Blog.Post, :read, actor)               # => {:allow, ...}
+```
+
+The framework-generated checks (`AshGrant.Check`, `FilterCheck`) always pass the type,
+so this only bites **direct** calls to `AshGrant.Evaluator` from your own code. When it
+happens, `AshGrant.IndeterminateMatch` reports it (`Logger.warning` by default; set
+`config :ash_grant, indeterminate_type_wildcard: :strict` to raise instead). It never
+changes the returned value — it only tells you the value cannot be trusted.
+
+> A defensive `"@read"` + literal `"read"` pair (or `"read*"` + `"read"`) does still
+> work, because the literal matches regardless of type. But prefer fixing the call to
+> pass the type: the pair silently breaks the moment someone removes the literal.
+
 ### Field-level permissions (5-part format)
 
 ```elixir


### PR DESCRIPTION
## Summary

Layer 2 of [issue #126](https://github.com/jhlee111/ash_grant/issues/126): a type wildcard (`@read`, deprecated `read*`) matches on the Ash action **type**, so an `Evaluator` entry point called without an `action_type` silently skips it and fabricates an answer — a `false` that actually means "could not tell", indistinguishable from a real deny (and in the deny-wildcard direction, a fail-open `true`). v0.18.0 fixed the notation and the docs; this PR fixes the signal gap that causes the incidents.

- **New `AshGrant.IndeterminateMatch`**: recomputes the result with the skipped RBAC type wildcards forced to match and signals only when that changes the answer. Sound by construction — no per-return-type heuristics, no false positives, so `:strict` stays usable. Defensive `@read`+literal pairs, scope-less/group-less wildcards that contribute nothing, and queries already settled by a concrete deny all stay silent.
- Guards every nil-defaulting entry point: `has_access?`, `get_scope`, `get_all_scopes`, `get_write_scopes`, `get_field_group`, `get_all_field_groups`, `find_matching`, `field_group_grants`.
- Mode `:off` / `:warn` (default) / `:strict` via `config :ash_grant, indeterminate_type_wildcard:` — mirrors the `field_group_permissions` precedent. **Never changes the authorization outcome.**
- `get_matching_instance_ids/4` is deliberately unguarded (sees only instance permissions). The pre-existing instance-path inconsistency that surfaced while making that call is filed separately as [issue #131](https://github.com/jhlee111/ash_grant/issues/131).
- Docs now lead type-wildcard sections with `@read` (`permission.ex`, `Evaluator` moduledoc, `usage-rules.md`, `guides/permissions.md`, CLAUDE.md), keeping `read*` as the deprecated-equivalent spelling.

Behavior matrix (outcomes unchanged; **signal** = `:warn` log / `:strict` raise):

| grants, asked `"read"` untyped | result | signal |
|---|---|---|
| `["@read", "read"]` | `true` | silent — determinate, defensive pairs keep working |
| `["@read"]` | `false` | **signals** — skipped allow wildcard, answer could be wrong |
| `["read:always", "!@read:sensitive"]` | `true` | **signals** — skipped deny wildcard (fail-open direction) |
| `["write"]` | `false` | silent — legitimate miss |

## Test plan

- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix test` — 56 doctests, 107 properties, 1180 tests, 0 failures
- [x] New `test/ash_grant/indeterminate_match_test.exs` covering: `:warn` signals only when the answer could be wrong, `:strict` raise, `:off`, forced-recompute soundness (no false positives), coverage across all guarded entry points, and the original two-layer asymmetry repro from the issue
- [x] `mix credo` — findings byte-identical to `main` (pre-existing debt, no new findings from this branch; CI does not gate credo)

Refs [issue #126](https://github.com/jhlee111/ash_grant/issues/126) · follow-up [issue #131](https://github.com/jhlee111/ash_grant/issues/131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
