### PR TITLE
release: v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2026-07-17
+
+### Added
+
+- **Indeterminate type-wildcard evaluation is now signaled** (#126). A type wildcard matches on the Ash action **type**, so an `Evaluator` entry point called without an `action_type` cannot evaluate it. Previously it silently skipped the wildcard and fabricated an answer — a `false` that means "could not tell", indistinguishable from a real deny, so the same actor and grant got opposite answers from the two APIs (`Introspect.can?(Document, :read, actor)` → allow; `Evaluator.has_access?(perms, "document", "read")` → `false`), which in practice forced defensive `@read` + literal `read` grant pairs. In the deny direction the skip is fail-open: a skipped `!…:@read:…` deny leaves `true` standing. The new `AshGrant.IndeterminateMatch` recomputes the result with the skipped RBAC type wildcards forced to match and signals only if that changes the answer — sound by construction, so defensive wildcard+literal pairs, wildcards that contribute nothing, and queries already settled by a concrete deny stay silent. Severity is configurable, mirroring `field_group_permissions`:
+
+      config :ash_grant, indeterminate_type_wildcard: :warn   # :off | :warn (default) | :strict
+
+  `:warn` logs, `:strict` raises, `:off` disables — and **authorization outcomes never change** in any mode. All eight nil-defaulting entry points are guarded (`has_access?`, `get_scope`, `get_all_scopes`, `get_write_scopes`, `get_field_group`, `get_all_field_groups`, `find_matching`, `field_group_grants`). Framework-generated policies always pass the action type and are unaffected; the signal concerns direct `Evaluator` calls — in application code, prefer `AshGrant.Introspect.can?/4`, which takes the resource module and resolves the type itself. `get_matching_instance_ids/4` is deliberately unguarded; the pre-existing instance-path inconsistency that decision surfaced is tracked in #131.
+
+### Changed
+
+- Type-wildcard documentation and examples now lead with the `@read` spelling (`AshGrant.Permission`, the `AshGrant.Evaluator` moduledoc, `usage-rules.md`, `guides/permissions.md`), with `read*` shown only as the deprecated equivalent.
+
 ## [0.18.0] - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add `ash_grant` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ash_grant, "~> 0.18"}
+    {:ash_grant, "~> 0.19"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AshGrant.MixProject do
   use Mix.Project
 
-  @version "0.18.0"
+  @version "0.19.0"
   @source_url "https://github.com/jhlee111/ash_grant"
 
   def project do


### PR DESCRIPTION
## Summary

- Bump version to 0.19.0
- Update CHANGELOG.md
- Bump README install pin to `~> 0.19`

### What's new in v0.19.0

- **Indeterminate type-wildcard evaluation is now signaled** ([issue #126](https://github.com/jhlee111/ash_grant/issues/126) layer 2, [PR #132](https://github.com/jhlee111/ash_grant/pull/132)). New `AshGrant.IndeterminateMatch` detects when an `Evaluator` entry point called without an `action_type` skipped a type wildcard that could have changed the answer, via forced-recompute — no false positives, so `:strict` is usable. Mode `:off` / `:warn` (default) / `:strict` through `config :ash_grant, indeterminate_type_wildcard:`. Authorization outcomes never change; framework-generated policies are unaffected.
- Type-wildcard docs and examples now lead with `@read`; `read*` remains as the deprecated equivalent.
- The pre-existing instance-path inconsistency surfaced during this work is tracked separately in [issue #131](https://github.com/jhlee111/ash_grant/issues/131).

## Post-merge

```
git checkout main && git pull
git tag v0.19.0
git push --tags
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
