### PR TITLE
refactor: clear all 11 credo findings

### DIFF
--- a/lib/ash_grant/calculations/can_perform.ex
+++ b/lib/ash_grant/calculations/can_perform.ex
@@ -166,8 +166,7 @@ defmodule AshGrant.Calculation.CanPerform do
     # Combine all filters with OR (same logic as FilterCheck)
     all_filters =
       ([rbac_filter, instance_filter] ++ parent_filters)
-      |> Enum.reject(&is_nil/1)
-      |> Enum.reject(&(&1 == false))
+      |> Enum.reject(&(is_nil(&1) or &1 == false))
 
     case all_filters do
       [] -> expr(false)
@@ -214,20 +213,24 @@ defmodule AshGrant.Calculation.CanPerform do
         )
 
       if parent_ids != [] do
-        relationship = Ash.Resource.Info.relationship(resource, scope_through.relationship)
-        fk_field = relationship.source_attribute
-        parent_dest_field = relationship.destination_attribute
-        parent_instance_key = AshGrant.Info.instance_key(parent_resource)
-
-        if parent_instance_key == parent_dest_field do
-          [expr(^ref(fk_field) in ^parent_ids)]
-        else
-          [expr(exists(^[scope_through.relationship], ^ref(parent_instance_key) in ^parent_ids))]
-        end
+        [parent_instance_expr(resource, scope_through, parent_resource, parent_ids)]
       else
         []
       end
     end)
+  end
+
+  defp parent_instance_expr(resource, scope_through, parent_resource, parent_ids) do
+    relationship = Ash.Resource.Info.relationship(resource, scope_through.relationship)
+    fk_field = relationship.source_attribute
+    parent_dest_field = relationship.destination_attribute
+    parent_instance_key = AshGrant.Info.instance_key(parent_resource)
+
+    if parent_instance_key == parent_dest_field do
+      expr(^ref(fk_field) in ^parent_ids)
+    else
+      expr(exists(^[scope_through.relationship], ^ref(parent_instance_key) in ^parent_ids))
+    end
   end
 
   defp resolve_parent_resource(resource, scope_through) do

--- a/lib/ash_grant/checks/check.ex
+++ b/lib/ash_grant/checks/check.ex
@@ -351,37 +351,55 @@ defmodule AshGrant.Check do
       record = get_target_record(authorizer)
 
       Enum.any?(scope_throughs, fn scope_through ->
-        # Check action filter
-        action_allowed =
-          scope_through.actions == nil or
-            action_type_atom(action_name, action_type) in scope_through.actions
-
-        if action_allowed do
-          parent_resource = resolve_parent_resource(resource_module, scope_through)
-          parent_resource_name = AshGrant.Info.resource_name(parent_resource)
-
-          parent_ids =
-            AshGrant.Evaluator.get_matching_instance_ids(
-              permissions,
-              parent_resource_name,
-              action_name,
-              action_type
-            )
-
-          if parent_ids != [] and record do
-            relationship =
-              Ash.Resource.Info.relationship(resource_module, scope_through.relationship)
-
-            fk_field = relationship.source_attribute
-            fk_value = to_string(Map.get(record, fk_field))
-            fk_value in parent_ids
-          else
-            false
-          end
-        else
-          false
-        end
+        scope_through_grants_write?(
+          scope_through,
+          resource_module,
+          permissions,
+          action_name,
+          action_type,
+          record
+        )
       end)
+    end
+  end
+
+  defp scope_through_grants_write?(
+         scope_through,
+         resource_module,
+         permissions,
+         action_name,
+         action_type,
+         record
+       ) do
+    # Check action filter
+    action_allowed =
+      scope_through.actions == nil or
+        action_type_atom(action_name, action_type) in scope_through.actions
+
+    if action_allowed do
+      parent_resource = resolve_parent_resource(resource_module, scope_through)
+      parent_resource_name = AshGrant.Info.resource_name(parent_resource)
+
+      parent_ids =
+        AshGrant.Evaluator.get_matching_instance_ids(
+          permissions,
+          parent_resource_name,
+          action_name,
+          action_type
+        )
+
+      if parent_ids != [] and record do
+        relationship =
+          Ash.Resource.Info.relationship(resource_module, scope_through.relationship)
+
+        fk_field = relationship.source_attribute
+        fk_value = to_string(Map.get(record, fk_field))
+        fk_value in parent_ids
+      else
+        false
+      end
+    else
+      false
     end
   end
 

--- a/lib/ash_grant/checks/filter_check.ex
+++ b/lib/ash_grant/checks/filter_check.ex
@@ -282,28 +282,45 @@ defmodule AshGrant.FilterCheck do
     if has_global_access do
       true
     else
-      # Collect all OR-able filter components
-      rbac_filter =
-        if scopes != [] do
-          build_combined_filter(scopes, scope_resolver, context)
-        end
+      combine_filter_components(
+        scopes,
+        instance_ids,
+        instance_key,
+        parent_filters,
+        scope_resolver,
+        context
+      )
+    end
+  end
 
-      instance_filter =
-        if instance_ids != [] do
-          build_instance_filter(instance_ids, instance_key)
-        end
-
-      # Combine all filters with OR
-      all_filters =
-        ([rbac_filter, instance_filter] ++ parent_filters)
-        |> Enum.reject(&is_nil/1)
-        |> Enum.reject(&(&1 == false))
-
-      case all_filters do
-        [] -> false
-        [single] -> single
-        [first | rest] -> Enum.reduce(rest, first, &Ash.Expr.expr(^&2 or ^&1))
+  defp combine_filter_components(
+         scopes,
+         instance_ids,
+         instance_key,
+         parent_filters,
+         scope_resolver,
+         context
+       ) do
+    # Collect all OR-able filter components
+    rbac_filter =
+      if scopes != [] do
+        build_combined_filter(scopes, scope_resolver, context)
       end
+
+    instance_filter =
+      if instance_ids != [] do
+        build_instance_filter(instance_ids, instance_key)
+      end
+
+    # Combine all filters with OR
+    all_filters =
+      ([rbac_filter, instance_filter] ++ parent_filters)
+      |> Enum.reject(&(is_nil(&1) or &1 == false))
+
+    case all_filters do
+      [] -> false
+      [single] -> single
+      [first | rest] -> Enum.reduce(rest, first, &Ash.Expr.expr(^&2 or ^&1))
     end
   end
 
@@ -335,26 +352,28 @@ defmodule AshGrant.FilterCheck do
         )
 
       if parent_ids != [] do
-        relationship = Ash.Resource.Info.relationship(resource_module, scope_through.relationship)
-        fk_field = relationship.source_attribute
-        parent_dest_field = relationship.destination_attribute
-        parent_instance_key = AshGrant.Info.instance_key(parent_resource)
-
-        if parent_instance_key == parent_dest_field do
-          # Simple case: parent's instance_key matches the FK destination (usually :id)
-          [Ash.Expr.expr(^ref(fk_field) in ^parent_ids)]
-        else
-          # Complex case: parent's instance_key differs from PK, need a join
-          [
-            Ash.Expr.expr(
-              exists(^[scope_through.relationship], ^ref(parent_instance_key) in ^parent_ids)
-            )
-          ]
-        end
+        [parent_instance_expr(resource_module, scope_through, parent_resource, parent_ids)]
       else
         []
       end
     end)
+  end
+
+  defp parent_instance_expr(resource_module, scope_through, parent_resource, parent_ids) do
+    relationship = Ash.Resource.Info.relationship(resource_module, scope_through.relationship)
+    fk_field = relationship.source_attribute
+    parent_dest_field = relationship.destination_attribute
+    parent_instance_key = AshGrant.Info.instance_key(parent_resource)
+
+    if parent_instance_key == parent_dest_field do
+      # Simple case: parent's instance_key matches the FK destination (usually :id)
+      Ash.Expr.expr(^ref(fk_field) in ^parent_ids)
+    else
+      # Complex case: parent's instance_key differs from PK, need a join
+      Ash.Expr.expr(
+        exists(^[scope_through.relationship], ^ref(parent_instance_key) in ^parent_ids)
+      )
+    end
   end
 
   defp resolve_parent_resource(resource_module, scope_through) do

--- a/lib/ash_grant/explanation.ex
+++ b/lib/ash_grant/explanation.ex
@@ -306,7 +306,7 @@ defmodule AshGrant.Explanation do
   defp resolve_arguments_section(explanation, color) do
     entries =
       Enum.map_join(explanation.resolve_arguments, "\n", fn entry ->
-        path = entry.from_path |> Enum.map(&inspect/1) |> Enum.join(" → ")
+        path = Enum.map_join(entry.from_path, " → ", &inspect/1)
         scopes = entry.scopes_needing |> Enum.map_join(", ", &inspect/1)
 
         scope_hint =

--- a/lib/ash_grant/introspect.ex
+++ b/lib/ash_grant/introspect.ex
@@ -271,19 +271,23 @@ defmodule AshGrant.Introspect do
   defp load_actor_for(resource, actor_id) do
     case Info.resolver(resource) do
       resolver when is_atom(resolver) and not is_nil(resolver) ->
-        Code.ensure_loaded(resolver)
-
-        if function_exported?(resolver, :load_actor, 1) do
-          case resolver.load_actor(actor_id) do
-            {:ok, actor} -> {:ok, actor}
-            :error -> {:error, :actor_not_found}
-          end
-        else
-          {:error, :actor_loader_not_implemented}
-        end
+        load_actor_via(resolver, actor_id)
 
       _ ->
         {:error, :actor_loader_not_implemented}
+    end
+  end
+
+  defp load_actor_via(resolver, actor_id) do
+    Code.ensure_loaded(resolver)
+
+    if function_exported?(resolver, :load_actor, 1) do
+      case resolver.load_actor(actor_id) do
+        {:ok, actor} -> {:ok, actor}
+        :error -> {:error, :actor_not_found}
+      end
+    else
+      {:error, :actor_loader_not_implemented}
     end
   end
 
@@ -578,17 +582,7 @@ defmodule AshGrant.Introspect do
   defp has_parent_instance_access?(resource, permissions, action_name, action_type) do
     Info.scope_throughs(resource)
     |> Enum.any?(fn scope_through ->
-      parent_resource =
-        case scope_through.resource do
-          nil ->
-            case Ash.Resource.Info.relationship(resource, scope_through.relationship) do
-              nil -> nil
-              rel -> rel.destination
-            end
-
-          explicit ->
-            explicit
-        end
+      parent_resource = scope_through_parent_resource(resource, scope_through)
 
       if parent_resource do
         parent_resource_name = Info.resource_name(parent_resource)
@@ -606,6 +600,19 @@ defmodule AshGrant.Introspect do
         false
       end
     end)
+  end
+
+  defp scope_through_parent_resource(resource, scope_through) do
+    case scope_through.resource do
+      nil ->
+        case Ash.Resource.Info.relationship(resource, scope_through.relationship) do
+          nil -> nil
+          rel -> rel.destination
+        end
+
+      explicit ->
+        explicit
+    end
   end
 
   @doc """

--- a/lib/ash_grant/transformers/add_argument_resolvers.ex
+++ b/lib/ash_grant/transformers/add_argument_resolvers.ex
@@ -46,20 +46,24 @@ defmodule AshGrant.Transformers.AddArgumentResolvers do
         {:ok, dsl_state}
 
       declarations ->
-        resource = Transformer.get_persisted(dsl_state, :module)
-        arg_map = build_arg_map(dsl_state)
-
-        Enum.reduce_while(declarations, {:ok, dsl_state}, fn decl, {:ok, state} ->
-          with :ok <- validate_referenced_by_scope(decl, arg_map, resource),
-               {:ok, leaf_type} <- validate_and_resolve_path(state, decl, resource),
-               {:ok, new_state} <-
-                 install_on_actions(state, decl, leaf_type, arg_map, resource) do
-            {:cont, {:ok, new_state}}
-          else
-            {:error, reason} -> {:halt, {:error, reason}}
-          end
-        end)
+        install_declarations(dsl_state, declarations)
     end
+  end
+
+  defp install_declarations(dsl_state, declarations) do
+    resource = Transformer.get_persisted(dsl_state, :module)
+    arg_map = build_arg_map(dsl_state)
+
+    Enum.reduce_while(declarations, {:ok, dsl_state}, fn decl, {:ok, state} ->
+      with :ok <- validate_referenced_by_scope(decl, arg_map, resource),
+           {:ok, leaf_type} <- validate_and_resolve_path(state, decl, resource),
+           {:ok, new_state} <-
+             install_on_actions(state, decl, leaf_type, arg_map, resource) do
+        {:cont, {:ok, new_state}}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
   end
 
   # Compute %{arg_name => [scope_names]} by walking all scope filters in the
@@ -89,16 +93,16 @@ defmodule AshGrant.Transformers.AddArgumentResolvers do
       _ ->
         parents = scope.inherits || []
 
-        parent_filters =
-          Enum.map(parents, fn parent_name ->
-            find_scope(dsl_state, parent_name)
-            |> case do
-              nil -> true
-              parent -> resolve_scope_in_dsl(dsl_state, parent)
-            end
-          end)
+        parent_filters = Enum.map(parents, &resolve_parent_filter(dsl_state, &1))
 
         combine(parent_filters, base)
+    end
+  end
+
+  defp resolve_parent_filter(dsl_state, parent_name) do
+    case find_scope(dsl_state, parent_name) do
+      nil -> true
+      parent -> resolve_scope_in_dsl(dsl_state, parent)
     end
   end
 


### PR DESCRIPTION
## Summary

`mix credo` exited non-zero on clean main with 11 pre-existing refactoring findings, failing the verification step of the `/pr` workflow for every branch (CI has no credo step, so this was local-only debt — first noticed while shipping [PR #132](https://github.com/jhlee111/ash_grant/pull/132)). This clears all 11; `mix credo` now exits 0.

Pure refactors — no public API, signature, or behavior changes; extracted bodies are verbatim:

- **`Enum.map_join/3`** instead of `Enum.map/2 |> Enum.join/2` (`explanation.ex`)
- **Single-pass `Enum.reject/2`** with a merged predicate instead of two chained rejects (`filter_check.ex`, `can_perform.ex`)
- **Helper extraction** for the seven nesting-depth findings and the one cyclomatic-complexity finding:
  - `check.ex` — `scope_through_grants_write?/6` out of `check_scope_through_write/5`
  - `filter_check.ex` — `combine_filter_components/6` out of `build_filter_with_instances/6`; `parent_instance_expr/4` out of `build_parent_instance_filters/4`
  - `can_perform.ex` — `parent_instance_expr/4` (mirroring FilterCheck, as the module already does)
  - `introspect.ex` — `load_actor_via/2` out of `load_actor_for/2`; `scope_through_parent_resource/2` out of `has_parent_instance_access?/4`
  - `add_argument_resolvers.ex` — `install_declarations/2` out of `transform/1`; `resolve_parent_filter/2` replacing a piped `case`

All new functions are `defp`; nothing user-facing changed, so no README/CHANGELOG/CLAUDE.md updates are needed.

## Test plan

- [x] `mix credo` — exits 0, zero findings (was exit 8 with 11)
- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix test` — 56 doctests, 107 properties, 1180 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
